### PR TITLE
Use max node count for GPU capacity in autoscaled pools

### DIFF
--- a/apis/inferenceenvironments/definition.yaml
+++ b/apis/inferenceenvironments/definition.yaml
@@ -134,6 +134,13 @@ spec:
                                   type: integer
                                   default: 1
                                   minimum: 1
+                                maxNodeCount:
+                                  type: integer
+                                  description: >-
+                                    Maximum node count for autoscaled pools.
+                                    Used instead of nodeCount when computing
+                                    GPU capacity for scheduling.
+                                  minimum: 1
                                 gpu:
                                   type: object
                                   properties:
@@ -284,6 +291,13 @@ spec:
                                 nodeCount:
                                   type: integer
                                   default: 1
+                                  minimum: 1
+                                maxNodeCount:
+                                  type: integer
+                                  description: >-
+                                    Maximum node count for autoscaled pools.
+                                    Used instead of nodeCount when computing
+                                    GPU capacity for scheduling.
                                   minimum: 1
                                 gpu:
                                   type: object

--- a/functions/compose-inference-env/main.py
+++ b/functions/compose-inference-env/main.py
@@ -359,11 +359,12 @@ class Composer:
         for pool in gke.nodePools:
             if pool.role != "GPU" or not pool.gpu:
                 continue
+            nodes = pool.maxNodeCount or pool.nodeCount
             gpu_pools.append(
                 {
                     "acceleratorType": pool.gpu.acceleratorType,
                     "memory": GPU_VRAM.get(pool.gpu.acceleratorType, "0Gi"),
-                    "count": pool.gpu.acceleratorCount * pool.nodeCount,
+                    "count": pool.gpu.acceleratorCount * nodes,
                 }
             )
         return gpu_pools
@@ -374,11 +375,12 @@ class Composer:
         for pool in existing.nodePools or []:
             if not pool.gpu or not pool.gpu.acceleratorType:
                 continue
+            nodes = pool.maxNodeCount or pool.nodeCount
             gpu_pools.append(
                 {
                     "acceleratorType": pool.gpu.acceleratorType,
                     "memory": GPU_VRAM.get(pool.gpu.acceleratorType, "0Gi"),
-                    "count": pool.gpu.acceleratorCount * pool.nodeCount,
+                    "count": pool.gpu.acceleratorCount * nodes,
                 }
             )
         return gpu_pools

--- a/tests/test-inference-env/main.py
+++ b/tests/test-inference-env/main.py
@@ -89,7 +89,7 @@ test = compositiontest.CompositionTest(
                                 iev1alpha1.GpuPool(
                                     acceleratorType="nvidia-l4",
                                     memory="24Gi",
-                                    count=1,
+                                    count=2,
                                 ),
                             ],
                         ),


### PR DESCRIPTION
Fixes #4

The env function computes GPU capacity as `acceleratorCount * nodeCount`, where `nodeCount` is the initial pool size. For autoscaled pools, the cluster can grow well beyond that — a pool with `nodeCount: 2` and `maxNodeCount: 8` has capacity for 8 nodes worth of GPUs, not 2. The scheduler uses these numbers to decide whether a model fits, so it rejects models that would fit fine once the autoscaler scales up.

`gke_gpu_pools()` and `existing_gpu_pools()` now use `maxNodeCount` instead of `nodeCount` when it's set, falling back to `nodeCount` when it isn't. The XRD for existing (BYO) cluster node pools also gains an optional `maxNodeCount` field so that users who manage their own autoscaling can declare max capacity.