### PR TITLE
Use action-up for CI registry auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,15 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
 
-      # The registry requires Docker-style auth with the robot's access ID
-      # as the username. Public dependency resolution doesn't need auth.
+      # action-up handles robot token auth for both the API and the
+      # registry. docker/login-action is also needed because up project
+      # push uses Docker's credential store for OCI pushes.
+      - name: Login to Upbound
+        uses: upbound/action-up@v1
+        with:
+          api-token: ${{ secrets.UP_ROBOT_TOKEN }}
+          organization: modelplane
+
       - name: Login to registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
The `docker/login-action` step writes to `~/.docker/config.json`, but `up project push` uses its own credential store. The push fails at "Ensuring repository exists" with `Unauthorized` because `up` doesn't see the Docker credentials.

This adds `upbound/action-up@v1` to authenticate `up`'s credential store, matching the pattern used by [configuration-caas](https://github.com/upbound/configuration-caas/blob/main/.github/workflows/ci.yaml). The `docker/login-action` step is kept as a fallback for the OCI push itself.