### PR TITLE
Add InferenceGateway e2e test and fix premature readiness

### DIFF
--- a/functions/compose-inference-gateway/main.py
+++ b/functions/compose-inference-gateway/main.py
@@ -52,7 +52,11 @@ class Composer:
                 "spec": {"credentials": {"source": "InjectedIdentity"}},
             },
         )
-        self.rsp.desired.resources["provider-config-helm"].ready = fnv1.READY_TRUE
+        # Gate READY_TRUE on observation: prevents the XR from briefly reaching
+        # Ready=True on the first reconcile when provider-config-helm is the
+        # only desired resource and Crossplane auto-derives readiness from it.
+        if "provider-config-helm" in self.req.observed.resources:
+            self.rsp.desired.resources["provider-config-helm"].ready = fnv1.READY_TRUE
 
     def compose_metallb(self):
         """Optional MetalLB for kind/bare-metal clusters that don't have a

--- a/tests/e2etest-inferencegateway/main.py
+++ b/tests/e2etest-inferencegateway/main.py
@@ -27,76 +27,86 @@ test = e2etestv1alpha1.E2ETest(
         skipDelete=False,
         initResources=[
             # Shared namespace for Modelplane infrastructure.
-            _fixture(corev1.Namespace(
-                metadata=coremetav1.ObjectMeta(name="modelplane-system"),
-            )),
-
+            _fixture(
+                corev1.Namespace(
+                    metadata=coremetav1.ObjectMeta(name="modelplane-system"),
+                )
+            ),
             # RBAC aggregation so Crossplane can compose Gateway API, MetalLB,
             # and Usage resources.
-            _fixture(rbacv1.ClusterRole(
-                metadata=coremetav1.ObjectMeta(
-                    name="crossplane-compose-modelplane",
-                    labels={"rbac.crossplane.io/aggregate-to-crossplane": "true"},
-                ),
-                rules=[
-                    rbacv1.PolicyRule(apiGroups=[""], resources=["namespaces"], verbs=["*"]),
-                    rbacv1.PolicyRule(
-                        apiGroups=["gateway.networking.k8s.io"],
-                        resources=["gateways", "gatewayclasses", "httproutes"],
-                        verbs=["*"],
+            _fixture(
+                rbacv1.ClusterRole(
+                    metadata=coremetav1.ObjectMeta(
+                        name="crossplane-compose-modelplane",
+                        labels={"rbac.crossplane.io/aggregate-to-crossplane": "true"},
                     ),
-                    rbacv1.PolicyRule(
-                        apiGroups=["gateway.envoyproxy.io"],
-                        resources=["backends"],
-                        verbs=["*"],
-                    ),
-                    rbacv1.PolicyRule(
-                        apiGroups=["metallb.io"],
-                        resources=["ipaddresspools", "l2advertisements"],
-                        verbs=["*"],
-                    ),
-                    rbacv1.PolicyRule(
-                        apiGroups=["protection.crossplane.io"],
-                        resources=["usages"],
-                        verbs=["*"],
-                    ),
-                ],
-            )),
-
+                    rules=[
+                        rbacv1.PolicyRule(
+                            apiGroups=[""], resources=["namespaces"], verbs=["*"]
+                        ),
+                        rbacv1.PolicyRule(
+                            apiGroups=["gateway.networking.k8s.io"],
+                            resources=["gateways", "gatewayclasses", "httproutes"],
+                            verbs=["*"],
+                        ),
+                        rbacv1.PolicyRule(
+                            apiGroups=["gateway.envoyproxy.io"],
+                            resources=["backends"],
+                            verbs=["*"],
+                        ),
+                        rbacv1.PolicyRule(
+                            apiGroups=["metallb.io"],
+                            resources=["ipaddresspools", "l2advertisements"],
+                            verbs=["*"],
+                        ),
+                        rbacv1.PolicyRule(
+                            apiGroups=["protection.crossplane.io"],
+                            resources=["usages"],
+                            verbs=["*"],
+                        ),
+                    ],
+                )
+            ),
             # Grant cluster-admin to all provider SAs in crossplane-system.
             # The DRC/ImageConfig SA-naming pattern has a race condition in
             # up test run --local (package deployment is created before the
             # ImageConfig reconciler can update runtimeConfigRef). Using the
             # Group subject covers any auto-generated SA name.
-            _fixture(rbacv1.ClusterRoleBinding(
-                metadata=coremetav1.ObjectMeta(name="provider-helm-modelplane"),
-                roleRef=rbacv1.RoleRef(
-                    apiGroup="rbac.authorization.k8s.io",
-                    kind="ClusterRole",
-                    name="cluster-admin",
-                ),
-                subjects=[rbacv1.Subject(
-                    kind="Group",
-                    apiGroup="rbac.authorization.k8s.io",
-                    name="system:serviceaccounts:crossplane-system",
-                )],
-            )),
+            _fixture(
+                rbacv1.ClusterRoleBinding(
+                    metadata=coremetav1.ObjectMeta(name="provider-helm-modelplane"),
+                    roleRef=rbacv1.RoleRef(
+                        apiGroup="rbac.authorization.k8s.io",
+                        kind="ClusterRole",
+                        name="cluster-admin",
+                    ),
+                    subjects=[
+                        rbacv1.Subject(
+                            kind="Group",
+                            apiGroup="rbac.authorization.k8s.io",
+                            name="system:serviceaccounts:crossplane-system",
+                        )
+                    ],
+                )
+            ),
         ],
         manifests=[
-            _fixture(igwv1alpha1.InferenceGateway(
-                metadata=metav1.ObjectMeta(name="default"),
-                spec=igwv1alpha1.Spec(
-                    backend="EnvoyGateway",
-                    envoyGateway=igwv1alpha1.EnvoyGateway(
-                        version="v1.3.0",
-                        loadBalancer="MetalLB",
-                        metallb=igwv1alpha1.Metallb(
-                            addressPool="172.18.255.200-172.18.255.250",
+            _fixture(
+                igwv1alpha1.InferenceGateway(
+                    metadata=metav1.ObjectMeta(name="default"),
+                    spec=igwv1alpha1.Spec(
+                        backend="EnvoyGateway",
+                        envoyGateway=igwv1alpha1.EnvoyGateway(
+                            version="v1.3.0",
+                            loadBalancer="MetalLB",
+                            metallb=igwv1alpha1.Metallb(
+                                addressPool="172.18.255.200-172.18.255.250",
+                            ),
                         ),
+                        gateway=igwv1alpha1.Gateway(port=80),
                     ),
-                    gateway=igwv1alpha1.Gateway(port=80),
-                ),
-            )),
+                )
+            ),
         ],
     ),
 )

--- a/tests/e2etest-inferencegateway/main.py
+++ b/tests/e2etest-inferencegateway/main.py
@@ -41,9 +41,7 @@ test = e2etestv1alpha1.E2ETest(
                         labels={"rbac.crossplane.io/aggregate-to-crossplane": "true"},
                     ),
                     rules=[
-                        rbacv1.PolicyRule(
-                            apiGroups=[""], resources=["namespaces"], verbs=["*"]
-                        ),
+                        rbacv1.PolicyRule(apiGroups=[""], resources=["namespaces"], verbs=["*"]),
                         rbacv1.PolicyRule(
                             apiGroups=["gateway.networking.k8s.io"],
                             resources=["gateways", "gatewayclasses", "httproutes"],

--- a/tests/e2etest-inferencegateway/main.py
+++ b/tests/e2etest-inferencegateway/main.py
@@ -1,0 +1,102 @@
+from .model.ai.modelplane.inferencegateway import v1alpha1 as igwv1alpha1
+from .model.io.k8s.api.core import v1 as corev1
+from .model.io.k8s.api.rbac import v1 as rbacv1
+from .model.io.k8s.apimachinery.pkg.apis.core.meta import v1 as coremetav1
+from .model.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
+from .model.io.upbound.dev.meta.e2etest import v1alpha1 as e2etestv1alpha1
+
+
+def _fixture(model) -> dict:
+    data = model.model_dump(exclude_none=True, warnings=False)
+    if hasattr(model, "apiVersion") and model.apiVersion is not None:
+        data["apiVersion"] = model.apiVersion
+    if hasattr(model, "kind") and model.kind is not None:
+        data["kind"] = model.kind
+    return data
+
+
+test = e2etestv1alpha1.E2ETest(
+    metadata=metav1.ObjectMeta(name="e2etest-inferencegateway"),
+    spec=e2etestv1alpha1.Spec(
+        crossplane=e2etestv1alpha1.Crossplane(
+            autoUpgrade=e2etestv1alpha1.AutoUpgrade(channel="Stable"),
+        ),
+        defaultConditions=["Ready"],
+        timeoutSeconds=600,
+        cleanupTimeoutSeconds=300,
+        skipDelete=False,
+        initResources=[
+            # Shared namespace for Modelplane infrastructure.
+            _fixture(corev1.Namespace(
+                metadata=coremetav1.ObjectMeta(name="modelplane-system"),
+            )),
+
+            # RBAC aggregation so Crossplane can compose Gateway API, MetalLB,
+            # and Usage resources.
+            _fixture(rbacv1.ClusterRole(
+                metadata=coremetav1.ObjectMeta(
+                    name="crossplane-compose-modelplane",
+                    labels={"rbac.crossplane.io/aggregate-to-crossplane": "true"},
+                ),
+                rules=[
+                    rbacv1.PolicyRule(apiGroups=[""], resources=["namespaces"], verbs=["*"]),
+                    rbacv1.PolicyRule(
+                        apiGroups=["gateway.networking.k8s.io"],
+                        resources=["gateways", "gatewayclasses", "httproutes"],
+                        verbs=["*"],
+                    ),
+                    rbacv1.PolicyRule(
+                        apiGroups=["gateway.envoyproxy.io"],
+                        resources=["backends"],
+                        verbs=["*"],
+                    ),
+                    rbacv1.PolicyRule(
+                        apiGroups=["metallb.io"],
+                        resources=["ipaddresspools", "l2advertisements"],
+                        verbs=["*"],
+                    ),
+                    rbacv1.PolicyRule(
+                        apiGroups=["protection.crossplane.io"],
+                        resources=["usages"],
+                        verbs=["*"],
+                    ),
+                ],
+            )),
+
+            # Grant cluster-admin to all provider SAs in crossplane-system.
+            # The DRC/ImageConfig SA-naming pattern has a race condition in
+            # up test run --local (package deployment is created before the
+            # ImageConfig reconciler can update runtimeConfigRef). Using the
+            # Group subject covers any auto-generated SA name.
+            _fixture(rbacv1.ClusterRoleBinding(
+                metadata=coremetav1.ObjectMeta(name="provider-helm-modelplane"),
+                roleRef=rbacv1.RoleRef(
+                    apiGroup="rbac.authorization.k8s.io",
+                    kind="ClusterRole",
+                    name="cluster-admin",
+                ),
+                subjects=[rbacv1.Subject(
+                    kind="Group",
+                    apiGroup="rbac.authorization.k8s.io",
+                    name="system:serviceaccounts:crossplane-system",
+                )],
+            )),
+        ],
+        manifests=[
+            _fixture(igwv1alpha1.InferenceGateway(
+                metadata=metav1.ObjectMeta(name="default"),
+                spec=igwv1alpha1.Spec(
+                    backend="EnvoyGateway",
+                    envoyGateway=igwv1alpha1.EnvoyGateway(
+                        version="v1.3.0",
+                        loadBalancer="MetalLB",
+                        metallb=igwv1alpha1.Metallb(
+                            addressPool="172.18.255.200-172.18.255.250",
+                        ),
+                    ),
+                    gateway=igwv1alpha1.Gateway(port=80),
+                ),
+            )),
+        ],
+    ),
+)

--- a/tests/e2etest-inferencegateway/model
+++ b/tests/e2etest-inferencegateway/model
@@ -1,0 +1,1 @@
+../../.up/python/models

--- a/upbound.yaml
+++ b/upbound.yaml
@@ -4,6 +4,9 @@ metadata:
   name: modelplane
 spec:
   apiDependencies:
+  - k8s:
+      version: v1.33.0
+    type: k8s
   - git:
       path: cluster/crds
       ref: release-2.2


### PR DESCRIPTION
Gate provider-config-helm READY_TRUE on the resource being observed so the XR does not briefly reach Ready=True on the first reconcile before any Helm releases have been composed. Add k8s apiDependency to generate Kubernetes Python models used by the new e2etest-inferencegateway test.


```sh
up test run tests/e2etest-inferencegateway --e2e --local
...
    | 00:09:20 | apply | Assert Status Conditions | ASSERT    | DONE  | modelplane.ai/v1alpha1/InferenceGateway @ default
    | 00:09:20 | apply | Assert Status Conditions | TRY       | END   |
    | 00:09:20 | apply | @chainsaw                | CLEANUP   | SKIP  |
=== NAME  chainsaw
    | 00:09:20 | chainsaw | @chainsaw | CLEANUP   | SKIP  |
--- PASS: chainsaw (0.00s)
    --- PASS: chainsaw/apply (32.47s)
PASS
2026/05/05 00:09:20 Tests Summary:
2026/05/05 00:09:20 - Passed: 1
2026/05/05 00:09:20 - Failed: 0
2026/05/05 00:09:20 - Skipped: 0
2026/05/05 00:09:20 Skipping test 01-update.yaml
2026/05/05 00:09:20 Skipping test 02-import.yaml
2026/05/05 00:09:20 Skipping test 03-delete.yaml
Skipping cleanup of managed resources and control plane teardown
🙌
🙌 Tests Summary:
🙌 ------------------
🙌 Total Tests Executed: 1
🙌 Passed tests:         1
🙌 Failed tests:         0
```

Flipping `skipDelete=True` in e2e tests lets you get a quick local modelplane test cluster with a single command.

```
kind export kubeconfig --name modelplane-uptest-e2etest-inferencegateway
...
$ k get configurations
NAME         INSTALLED   HEALTHY   PACKAGE                                                  AGE
modelplane   True        True      xpkg.upbound.io/solutions/modelplane:v0.0.0-1777932404   10m

$ k get inferencegateways.modelplane.ai
NAME      READY   BACKEND        ADDRESS          AGE     SYNCED   READY   COMPOSITION                       AGE
default   True    EnvoyGateway   172.18.255.200   8m22s   True     True    inferencegateways.modelplane.ai   8m22s

crossplane beta trace inferencegateways.modelplane.ai default
NAME                                                          SYNCED   READY   STATUS
InferenceGateway/default                                      True     True    Available
├─ GatewayClass/envoy                                         -        -
├─ Gateway/modelplane (modelplane-system)                     -        -
├─ ProviderConfig/modelplane-in-cluster (modelplane-system)   -        -
├─ Release/default-b07aadb897d6 (modelplane-system)           True     True    Available
├─ Release/default-fa00b673f7a8 (modelplane-system)           True     True    Available
├─ IPAddressPool/modelplane (metallb-system)                  -        -
├─ L2Advertisement/modelplane (metallb-system)                -        -
├─ Usage/default-241755381d31 (modelplane-system)             -        True    Available
├─ Usage/default-4fb72f72b8de (modelplane-system)             -        True    Available
└─ Namespace/metallb-system
```