### PR TITLE
Add ModelCache v1alpha1 API

### DIFF
--- a/apis/modelcaches/definition.yaml
+++ b/apis/modelcaches/definition.yaml
@@ -1,0 +1,135 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: modelcaches.modelplane.ai
+spec:
+  group: modelplane.ai
+  names:
+    categories: [crossplane, modelplane]
+    kind: ModelCache
+    plural: modelcaches
+    shortNames: [mc]
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    additionalPrinterColumns:
+    - name: REPO
+      type: string
+      jsonPath: .spec.artifact.source.huggingFace.repo
+    - name: READY
+      type: string
+      jsonPath: .status.summary.ready
+    schema:
+      openAPIV3Schema:
+        type: object
+        required: [spec]
+        properties:
+          spec:
+            type: object
+            required: [artifact, mount]
+            properties:
+              artifact:
+                type: object
+                required: [source]
+                description: >-
+                  What to stage and where to fetch it from.
+                properties:
+                  source:
+                    type: object
+                    description: >-
+                      Where to fetch the artifact from. Exactly one
+                      source must be set.
+                    properties:
+                      huggingFace:
+                        type: object
+                        required: [repo]
+                        properties:
+                          repo:
+                            type: string
+                            description: HuggingFace repository ID.
+                            minLength: 1
+                          revision:
+                            type: string
+                            description: >-
+                              Branch, tag, or commit SHA. Defaults to
+                              the repo's default branch.
+                          tokenSecretRef:
+                            type: object
+                            description: >-
+                              Reference to a Secret holding an HF token
+                              for gated or private repos. Resolved on
+                              the workload cluster at hydration time.
+                            required: [name]
+                            properties:
+                              name:
+                                type: string
+                                minLength: 1
+                              key:
+                                type: string
+                                default: HF_TOKEN
+              mount:
+                type: object
+                required: [path]
+                description: >-
+                  Where the artifact appears inside consuming pods.
+                  Consumers (e.g. ModelDeployment) reading this cache
+                  see the contents at this path.
+                properties:
+                  path:
+                    type: string
+                    description: Absolute filesystem path inside the pod.
+                    pattern: "^/.+"
+              storage:
+                type: object
+                description: >-
+                  How to stage the artifact on each matched cluster.
+                  The storage class is inherited from the target
+                  InferenceCluster's spec.storage.rwxCache; ML teams
+                  do not pick it. Only the size override is exposed.
+                properties:
+                  sizeGiB:
+                    type: integer
+                    minimum: 1
+                    maximum: 10000
+                    description: >-
+                      Optional PVC size override. Defaults to the
+                      target cluster's spec.storage.rwxCache.defaultSizeGiB.
+              clusterSelector:
+                type: object
+                description: >-
+                  Label selector to pick the InferenceClusters that
+                  stage this artifact. If omitted, all clusters match.
+                properties:
+                  matchLabels:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object
+              summary:
+                type: object
+                description: Per-cluster ready / total counts.
+                properties:
+                  ready:
+                    type: string
+                    description: e.g. "2/3"
+              clusters:
+                type: array
+                description: Per-cluster staging status.
+                items:
+                  type: object
+                  required: [name]
+                  properties:
+                    name:
+                      type: string
+                    phase:
+                      type: string
+                      enum: [Pending, Hydrating, Ready, Failed]
+                    message:
+                      type: string

--- a/apis/modeldeployments/definition.yaml
+++ b/apis/modeldeployments/definition.yaml
@@ -43,6 +43,20 @@ spec:
                   matchLabels:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+              modelCacheRef:
+                type: object
+                required: [name]
+                description: >-
+                  Optional reference to a ModelCache. When set, the
+                  cache's PVC is mounted into every worker pod and the
+                  engine reads weights from the cache instead of
+                  fetching from the source at boot. Inherited verbatim
+                  by each composed ModelReplica.
+                properties:
+                  name:
+                    type: string
+                    description: ModelCache resource name in the same namespace.
+                    minLength: 1
               workers:
                 type: object
                 required: [topology, template]

--- a/apis/modelreplicas/definition.yaml
+++ b/apis/modelreplicas/definition.yaml
@@ -35,6 +35,17 @@ spec:
                 properties:
                   name:
                     type: string
+              modelCacheRef:
+                type: object
+                required: [name]
+                description: >-
+                  Optional reference to a ModelCache mounted into the
+                  engine pod. Inherited verbatim from the parent
+                  ModelDeployment.
+                properties:
+                  name:
+                    type: string
+                    minLength: 1
               workers:
                 type: object
                 required: [topology, template]

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -19,6 +19,7 @@ graph TD
     end
 
     subgraph "ML team"
+        MC[ModelCache<br><i>qwen-2-5</i>]
         MD[ModelDeployment<br><i>qwen-demo</i>]
         MS[ModelService<br><i>qwen</i>]
     end
@@ -31,6 +32,9 @@ graph TD
     end
 
     IC1 -- "references" --> ICL
+    MD -- "references" --> MC
+    MC -. "replicates to" .-> IC1
+    MC -. "replicates to" .-> IC2
     MD -. "creates" .-> MR1
     MD -. "creates" .-> MR2
     MD -. "creates" .-> ME1
@@ -112,11 +116,52 @@ The worker template is a curated subset of `PodTemplateSpec`. The container
 named `engine` is the inference engine (e.g. vLLM); additional containers pass
 through as sidecars.
 
+An optional `spec.modelCacheRef` mounts a [ModelCache](#modelcache)'s PVC into
+every worker pod, so the engine reads weights from the staged cache instead of
+fetching from the source at boot.
+
 ### Scaling
 
 Replicas are the only scaling axis. Each `ModelReplica` is a complete,
 fixed-topology serving instance. Scaling `spec.replicas` adds or removes whole
 instances. There's no in-cluster pod autoscaling.
+
+## ModelCache
+
+A ModelCache stages a model artifact on workload-cluster storage as a
+first-class resource, independently of any deployment. It enables
+cross-deployment sharing (one cache referenced by many ModelDeployments),
+independent lifecycle (the cache persists when deployments come and go),
+and proactive pre-staging.
+
+For multi-node deployments without a ModelCache reference, Modelplane
+auto-provisions per-replica storage using the target
+[InferenceCluster](#inferencecluster)'s `spec.storage.rwxCache` config —
+same RWX behavior, no shared lifecycle. ModelCache is the explicit opt-in
+for ML teams who want sharing, lifecycle control, or a size override.
+
+Each cache has:
+
+- An **artifact source**: today, a HuggingFace repo, with an optional
+  `revision` and `tokenSecretRef` for gated models.
+- A **mount path**: where the artifact appears inside consuming pods.
+- An optional **size override**. The storage class is inherited from
+  the target cluster's `rwxCache`; ML teams don't pick it.
+- Optional `clusterSelector` labels to scope replication. If omitted, the
+  cache replicates to every InferenceCluster.
+
+ModelDeployments reference a cache via `spec.modelCacheRef.name`;
+Modelplane mounts the cache's PVC into every worker pod automatically.
+
+These benefits scale with model size. A 1 TB+ frontier-scale model is hours
+of download and significant storage cost; ModelCache pays that cost once
+across every deployment that references it, and the per-cache size override
+avoids forcing the platform team to raise the cluster default for outliers.
+
+<!-- TODO(dennis): auto-mount behavior requires compose-model-replica to
+read modelCacheRef and mount the cache's PVC into every worker pod. Ships
+in the ModelCache impl MR. -->
+
 
 ## ModelReplica
 

--- a/examples/cache/model-cache-qwen.yaml
+++ b/examples/cache/model-cache-qwen.yaml
@@ -1,0 +1,42 @@
+# A ModelCache stages a model artifact on workload-cluster storage as
+# a first-class resource. Create one when you want cross-deployment
+# sharing, independent lifecycle, or a size override. Multi-node
+# deployments without a ModelCache reference get per-replica storage
+# auto-provisioned from the target cluster's spec.storage.rwxCache.
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelCache
+metadata:
+  name: qwen-2-5
+  namespace: ml-team
+spec:
+  artifact:
+    source:
+      huggingFace:
+        repo: Qwen/Qwen2.5-0.5B-Instruct
+        # Optional: pin to a specific commit, branch, or tag. Defaults
+        # to the repo's default branch.
+        # revision: main
+        # Optional: reference a Secret holding an HF token for gated
+        # or private repos. The Secret must exist on every matched
+        # workload cluster.
+        # tokenSecretRef:
+        #   name: hf-token
+        #   key: HF_TOKEN
+
+  # Where the artifact appears inside consuming pods. ModelDeployments
+  # mounting this cache see the model files at this path.
+  mount:
+    path: /mnt/models
+
+  # Optional: size override. The storage class is inherited from each
+  # target cluster's spec.storage.rwxCache; ML teams don't pick it.
+  # Default size also comes from the cluster's
+  # spec.storage.rwxCache.defaultSizeGiB.
+  # storage:
+  #   sizeGiB: 50
+
+  # Optional: scope which InferenceClusters stage this artifact. If
+  # omitted, the cache replicates to every cluster.
+  # clusterSelector:
+  #   matchLabels:
+  #     modelplane.ai/region: us-central

--- a/examples/deployment/model-deployment-cached.yaml
+++ b/examples/deployment/model-deployment-cached.yaml
@@ -1,0 +1,38 @@
+# A ModelDeployment that reads weights from a shared ModelCache instead
+# of fetching them from HuggingFace at startup. Reference a ModelCache
+# in the same namespace via spec.modelCacheRef; Modelplane mounts the
+# cache's PVC into every worker pod automatically.
+#
+# Use a ModelCache when you want cross-deployment sharing, independent
+# cache lifecycle, or a size override. Multi-node deployments without
+# modelCacheRef still get RWX storage automatically from the target
+# cluster's spec.storage.rwxCache; ModelCache is the explicit opt-in.
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelDeployment
+metadata:
+  name: qwen-demo-cached
+  namespace: ml-team
+spec:
+  replicas: 1
+
+  # Reference a ModelCache in the same namespace. Modelplane mounts
+  # the cache's PVC at the cache's spec.mount.path on every worker pod.
+  modelCacheRef:
+    name: qwen-2-5
+
+  workers:
+    topology:
+      tensor: 1
+    template:
+      spec:
+        containers:
+        - name: engine
+          image: vllm/vllm-openai:v0.7.3
+          args:
+          # Point vLLM at the cache's mount path. Must match the
+          # referenced ModelCache's spec.mount.path; there's no
+          # validation today.
+          # TODO(dennis): inject --model=<cache.mount.path> from the
+          # composition function so users don't have to keep these
+          # in sync.
+          - "--model=/mnt/models"


### PR DESCRIPTION
Follow-up to #82. Builds on the cluster-level `spec.storage.rwxCache` shape.

Adds the ML-team-facing opt-in for cross-deployment sharing, independent cache lifecycle, and proactive pre-staging on top of the invisible per-replica caching Modelplane already provides for multi-node deployments.

API surface + docs + examples only. Composition function follows in a separate MR.

## What this adds

- `apis/modelcaches/definition.yaml` — `ModelCache` XRD. Artifact source + mount path + optional size override + cluster selector. Storage class is always inherited from the target cluster's `rwxCache`; ML teams don't pick it.
- `apis/modeldeployments/definition.yaml` — `spec.modelCacheRef` (singular, matching the existing `inferenceClusterRef` pattern).
- `apis/modelreplicas/definition.yaml` — same `spec.modelCacheRef`, inherited from the parent ModelDeployment.
- `docs/concepts.md` — `## ModelCache` section positioned as the optional shared/lifecycled overlay on top of the cluster-level invisible caching; mermaid diagram updated.
- `examples/cache/model-cache-qwen.yaml` — Qwen 0.5B cache example.
- `examples/deployment/model-deployment-cached.yaml` — deployment referencing the cache via `spec.modelCacheRef`.

## How this relates to #82

| Scenario | #82 (this PR's base) | This PR adds |
|---|---|---|
| Multi-node, no cache reference | Auto-provision per-replica PVC from cluster `rwxCache` | (no change) |
| Multi-node + `modelCacheRef` set | n/a | Mount shared cache PVC across replicas; lifecycle decoupled from deployment |
| Single-node + `modelCacheRef` set | n/a | Mount shared cache PVC; cold-start optimization |
| Single-node, no cache reference | Ephemeral fetch in engine container | (no change) |

ML teams who don't care about sharing or pre-staging never see this surface — the cluster default still handles multi-node invisibly.

## What this does NOT change

- `examples/deployment/model-deployment.yaml` (the canonical single-node example) — untouched.
- `docs/getting-started.md` — untouched. ModelCache stays an opt-in feature; the basic flow doesn't use it.
- No composition function logic.