### PR TITLE
API: Add ModelCache for multi-node support with backend override

### DIFF
--- a/apis/inferenceclusters/definition.yaml
+++ b/apis/inferenceclusters/definition.yaml
@@ -81,6 +81,20 @@ spec:
                             default: private_key
                             minLength: 1
                             maxLength: 253
+                      cache:
+                        type: object
+                        description: >-
+                          ModelCache configuration for this cluster.
+                        properties:
+                          storageClassName:
+                            type: string
+                            default: modelplane-rwx
+                            description: >-
+                              Name of the RWX StorageClass for ModelCache
+                              PVCs. The admin creates the StorageClass on
+                              the workload cluster (must support
+                              ReadWriteMany dynamic provisioning).
+                            minLength: 1
                   gke:
                     type: object
                     description: >-
@@ -98,6 +112,22 @@ spec:
                       kubernetesVersion:
                         type: string
                         default: "1.35"
+                      cache:
+                        type: object
+                        description: >-
+                          ModelCache configuration for this cluster.
+                        properties:
+                          storageClassName:
+                            type: string
+                            default: modelplane-rwx
+                            description: >-
+                              Name of the RWX StorageClass for ModelCache
+                              PVCs. At the default value, Modelplane
+                              provisions Filestore Enterprise via the
+                              Filestore CSI addon and composes the
+                              StorageClass; set this to a different name to
+                              use one the admin has already created.
+                            minLength: 1
               nodePools:
                 type: array
                 description: >-

--- a/apis/modelcaches/definition.yaml
+++ b/apis/modelcaches/definition.yaml
@@ -1,0 +1,110 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: modelcaches.modelplane.ai
+spec:
+  group: modelplane.ai
+  names:
+    categories: [crossplane, modelplane]
+    kind: ModelCache
+    plural: modelcaches
+    shortNames: [mc]
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    additionalPrinterColumns:
+    - name: SOURCE
+      type: string
+      jsonPath: .spec.source.huggingFace.repo
+    - name: READY
+      type: string
+      jsonPath: .status.summary.ready
+    schema:
+      openAPIV3Schema:
+        type: object
+        required: [spec]
+        properties:
+          spec:
+            type: object
+            required: [source]
+            properties:
+              source:
+                type: object
+                description: >-
+                  Where to fetch the artifact from. A discriminated
+                  union; exactly one source must be set.
+                properties:
+                  huggingFace:
+                    type: object
+                    required: [repo, sizeGiB]
+                    properties:
+                      repo:
+                        type: string
+                        description: HuggingFace repository ID.
+                        minLength: 1
+                      revision:
+                        type: string
+                        description: >-
+                          Branch, tag, or commit SHA. Defaults to
+                          the repo's default branch.
+                      authSecret:
+                        type: object
+                        description: >-
+                          Optional Secret holding an HF token for
+                          gated or private repos. Resolved on the
+                          workload cluster at hydration time.
+                        required: [name]
+                        properties:
+                          name:
+                            type: string
+                            minLength: 1
+                          key:
+                            type: string
+                            default: HF_TOKEN
+                      sizeGiB:
+                        type: integer
+                        description: >-
+                          Capacity to allocate for the staged artifact
+                          on each matched cluster.
+                        minimum: 1
+                        maximum: 100000
+              clusterSelector:
+                type: object
+                description: >-
+                  Label selector to pick the InferenceClusters that
+                  stage this artifact. If omitted, the cache replicates
+                  to every cluster.
+                properties:
+                  matchLabels:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object
+              summary:
+                type: object
+                description: Per-cluster ready / total counts.
+                properties:
+                  ready:
+                    type: string
+                    description: e.g. "2/3"
+              clusters:
+                type: array
+                description: Per-cluster staging status.
+                items:
+                  type: object
+                  required: [name]
+                  properties:
+                    name:
+                      type: string
+                    phase:
+                      type: string
+                      enum: [Pending, Hydrating, Ready, Failed]
+                    message:
+                      type: string

--- a/apis/modeldeployments/definition.yaml
+++ b/apis/modeldeployments/definition.yaml
@@ -43,6 +43,18 @@ spec:
                   matchLabels:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+              modelCacheRef:
+                type: object
+                required: [name]
+                description: >-
+                  Reference to a ModelCache in the same namespace.
+                  Optional for single-node deployments; required for
+                  multi-node (workers.topology.pipeline > 1).
+                properties:
+                  name:
+                    type: string
+                    description: ModelCache resource name in the same namespace.
+                    minLength: 1
               workers:
                 type: object
                 required: [topology, template]

--- a/apis/modelreplicas/definition.yaml
+++ b/apis/modelreplicas/definition.yaml
@@ -35,6 +35,17 @@ spec:
                 properties:
                   name:
                     type: string
+              modelCacheRef:
+                type: object
+                required: [name]
+                description: >-
+                  Optional reference to a ModelCache mounted into the
+                  engine pod. Inherited verbatim from the parent
+                  ModelDeployment.
+                properties:
+                  name:
+                    type: string
+                    minLength: 1
               workers:
                 type: object
                 required: [topology, template]

--- a/design/design.md
+++ b/design/design.md
@@ -715,3 +715,4 @@ Instead, I'd prefer Modelplane to be opinionated about which orchestrator to
 use, dispatching based on topology and engine requirements. Users describe what
 they want; Modelplane picks the lightest composition path that satisfies it.
 
+

--- a/design/modelcache.md
+++ b/design/modelcache.md
@@ -1,0 +1,130 @@
+# ModelCache
+
+**Status:** Draft
+**Date:** May 2026
+**Author:** Dennis Ramdass
+
+This document proposes `ModelCache`, a resource for staging model weights on
+workload-cluster storage. It builds on the base design in [design.md](./design.md).
+
+## Summary
+
+A ModelCache stages a model artifact on workload-cluster storage as a
+first-class resource. Modelplane composes a ReadWriteMany PVC on each matched
+cluster and hydrates it from the configured source. ModelDeployments reference
+a cache via `spec.modelCacheRef.name`; the cache's PVC is mounted into every
+worker pod automatically.
+
+```yaml
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelCache
+metadata:
+  name: kimi-k2
+  namespace: ml-team
+spec:
+  source:
+    huggingFace:
+      repo: moonshotai/Kimi-K2-Instruct
+      authSecret:
+        name: hf-token
+      sizeGiB: 1500
+```
+
+The cache is mounted at `/mnt/models` on every consuming pod; the engine
+container's model arg should reference this path. The path is fixed rather
+than configurable to keep Modelplane out of engine-specific arg rewriting —
+different engines take different flags (e.g. `--model=` for vLLM,
+`--model-path=` for SGLang) and users pass whatever their engine expects.
+
+`spec.source` is a discriminated union — each source declares its own fields,
+including capacity when the source uses central storage. `huggingFace` is the
+only source today. Future sources compose differently: `dragonfly` would
+distribute the artifact to per-node local caches via P2P with no shared PVC
+(no `sizeGiB` because no central storage); `s3` would mirror the
+`huggingFace` model with a different fetch protocol; `oci` would pull a
+bundled OCI artifact into the PVC, which is where NVIDIA NIM-style
+prepackaged engine+weights bundles fit.
+
+## Multi-node
+
+Multi-node deployments require a `modelCacheRef`. Every pod in the
+LeaderWorkerSet gang must load the same model weights, and concurrent fetches
+don't coordinate safely. The failure modes are mostly invisible: simultaneous
+writes to overlapping paths tear files; pods that land on different upstream
+revisions if the source updates mid-pull serve mismatched weights to a single
+TP/PP topology; partial downloads can leave a pod serving incorrect weights
+with no surface error; concurrent egress hits HuggingFace rate limits
+non-deterministically. Modelplane rejects multi-node deployments without a
+cache reference. Single-node deployments may reference a cache as a
+cold-start optimization; without one the engine fetches the model ephemerally
+at startup.
+
+## Storage backends
+
+The cache's PVC backend is picked per cluster. For Modelplane-provisioned
+clusters (`cluster.source: GKE` today), Modelplane provisions a Filestore
+Enterprise instance with multishare on first ModelCache creation, composes a
+StorageClass named `modelplane-rwx` against it, and marks that StorageClass
+as the cluster's default — RWX is the right default for an inference cluster.
+Subsequent caches share the same Filestore instance. For existing clusters
+(`cluster.source: Existing`), the admin creates an RWX StorageClass on the
+workload cluster; Modelplane uses the convention name `modelplane-rwx` unless
+overridden, and doesn't touch the cluster's default class annotation.
+
+Platform teams can override the backend on either source type by setting
+`cluster.<source>.cache.storageClassName` to a StorageClass already created
+on the workload cluster. Any backend supporting RWX dynamic provisioning
+works (WekaIO, NetApp Trident, FSx for NetApp, etc.). The ML team's
+ModelCache and ModelDeployment specs are unchanged regardless of backend.
+
+## Alternatives considered
+
+### CacheClass (cache storage recipe)
+
+I considered a `CacheClass` resource parallel to `InferenceClass` — a
+platform-team-defined named recipe for storage tier, capacity, backup policy,
+and so on. ModelDeployments or ModelCaches would reference one by name.
+
+Storage decisions today reduce to one knob: "does the platform team want a
+non-default backend on this cluster?" One optional
+`cluster.<source>.cache.storageClassName` field covers that. A recipe layer
+would split storage configuration across two resources and introduce
+cross-resource references ML teams have to reason about. If real demand for
+multiple tiers per cluster emerges, a recipe abstraction can be added
+additively without breaking the current shape.
+
+### Storage backend enum on InferenceCluster
+
+I considered a `cacheBackend: Filestore | GCSFuse | StorageClass` enum on
+`cluster.gke` (and analogs per provider). It mixed categories — `Filestore`
+is a product name, `StorageClass` is a Kubernetes primitive — and didn't
+generalize cross-provider. Adding EKS would require `EFS | FSx`; AKS would
+require `AzureFiles | NetAppFiles`. The enum exploded per provider and leaked
+cloud terminology into the API.
+
+The chosen shape — `cluster.<source>.cache.storageClassName` as a single
+optional string per provider sub-block — captures the same intent ("use my
+backend, not yours") without enumerating cloud products.
+
+### Cache size envelope on InferenceCluster
+
+I considered a `cacheCapacityGiB` (or similar) field at the cluster level
+for platform teams to declare total cache budget. Storage choice on
+Filestore-style backends correlates with size — bigger tier, more capacity
+envelope, more cost. Putting capacity on the cluster meant the cluster had to
+commit to a size envelope before any ModelCache existed.
+
+Capacity is per-cache, owned by the ML team, and declared inside each source
+that uses central storage (e.g. `ModelCache.spec.source.huggingFace.sizeGiB`).
+Cluster-level cache infrastructure scales to absorb caches as they're
+created (multishare on GKE; admin's allocation elsewhere). Platform teams
+don't have to predict ML team capacity needs upfront.
+
+### Configurable mount path
+
+I considered an optional `ModelCache.spec.mountPath` field defaulted to
+`/mnt/models`, letting users override for unusual cases (multi-cache pods,
+engine-specific paths, org conventions). None of those are v0.1 needs, and
+hardcoding the path mirrors the `engine` container name convention — strong
+opinionation pays predictability dividends. If a real use case emerges,
+adding the field back is additive.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -19,6 +19,7 @@ graph TD
     end
 
     subgraph "ML team"
+        MC[ModelCache<br><i>kimi-k2</i>]
         MD[ModelDeployment<br><i>qwen-demo</i>]
         MS[ModelService<br><i>qwen</i>]
     end
@@ -31,6 +32,7 @@ graph TD
     end
 
     IC1 -- "references" --> ICL
+    MD -- "references" --> MC
     MD -. "creates" .-> MR1
     MD -. "creates" .-> MR2
     MD -. "creates" .-> ME1
@@ -93,8 +95,8 @@ clusters, which Modelplane assumes are solely for its use.
 ## ModelDeployment
 
 A ModelDeployment is the ML team's interface. It carries everything needed to
-deploy a model to the fleet: the worker template, hardware topology, and replica
-count.
+deploy a model to the fleet: the worker template, hardware topology, replica
+count, and an optional [ModelCache](#modelcache) reference for staged weights.
 
 When you create a ModelDeployment, the scheduler:
 
@@ -117,6 +119,41 @@ through as sidecars.
 Replicas are the only scaling axis. Each `ModelReplica` is a complete,
 fixed-topology serving instance. Scaling `spec.replicas` adds or removes whole
 instances. There's no in-cluster pod autoscaling.
+
+## Multi-node Inference
+
+When a model is too large to fit on one node's GPUs, set
+`workers.topology.pipeline` greater than 1. Modelplane composes a
+LeaderWorkerSet gang of pods that serve the model together: pipeline
+parallelism splits the model across nodes, tensor parallelism splits it
+across GPUs within a node.
+
+Multi-node deployments require a [ModelCache](#modelcache) referenced via
+`spec.modelCacheRef.name`.
+
+## ModelCache
+
+A ModelCache stages a model artifact on workload-cluster storage as a
+first-class resource. Modelplane composes a ReadWriteMany PVC on each matched
+cluster and hydrates it from the configured source. ModelDeployments reference
+a cache via `spec.modelCacheRef.name`; the cache's PVC is mounted into every
+worker pod automatically.
+
+Each cache has:
+
+- A **source**: a discriminated union of where to fetch the artifact, with
+  source-specific fields (e.g. `huggingFace.repo` and `huggingFace.sizeGiB`
+  today). Future types (`dragonfly` for P2P distribution, `oci` for NIM-style
+  bundled artifacts) will declare different fields under their own
+  discriminator.
+- An optional **clusterSelector** to scope replication. If omitted, the cache
+  replicates to every InferenceCluster.
+
+The cache mounts at `/mnt/models` on every consuming pod; engine container
+args should reference this path (e.g. `--model=/mnt/models` for vLLM).
+
+ModelCache is required for multi-node deployments and optional for single-node
+cold-start optimization.
 
 ## ModelReplica
 
@@ -153,3 +190,20 @@ Read the service's public address from `status.address`:
 ```bash
 kubectl get ms qwen -n ml-team -o jsonpath='{.status.address}'
 ```
+
+## Custom Cache Backends
+
+Modelplane provisions Filestore Enterprise on `GKE` clusters and expects a
+StorageClass named `modelplane-rwx` on `Existing` clusters (created by the
+admin). When the default doesn't fit — different cost profile, an RWX backend
+the org already runs, etc. — platform teams point Modelplane at a different
+StorageClass via `cluster.<source>.cache.storageClassName`. On GKE the admin
+must first create the StorageClass on the workload cluster (any backend
+supporting ReadWriteMany dynamic provisioning — WekaIO, NetApp Trident, FSx
+for NetApp, and similar). On Existing clusters the field points at whatever
+name the admin chose. The ML team's ModelCache and ModelDeployment specs are
+unchanged regardless.
+
+Backends that don't fit dynamic-PVC provisioning (e.g. Dragonfly's P2P
+distribution to per-node local caches) will be added natively as new types
+under `ModelCache.spec.source` rather than through this override.

--- a/examples/cache/kimi-k2.yaml
+++ b/examples/cache/kimi-k2.yaml
@@ -1,0 +1,57 @@
+# Kimi K2 multi-node deployment with a managed cache.
+#
+# NOTE: this example targets the design in design/design.md. The composition
+# function (compose-model-cache) lands in a follow-up MR; applying this YAML
+# before that ships will fail with "no composition found for kind ModelCache."
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelCache
+metadata:
+  name: kimi-k2
+  namespace: ml-team
+spec:
+  source:
+    huggingFace:
+      repo: moonshotai/Kimi-K2-Instruct
+      # Secret holding an HF token (Kimi K2 is a gated repo). The Secret
+      # must exist on every matched workload cluster.
+      authSecret:
+        name: hf-token
+      # ~1 TB of weights plus headroom. Modelplane sizes the underlying
+      # storage to absorb this (Filestore Enterprise multishare on GKE).
+      sizeGiB: 1500
+---
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelDeployment
+metadata:
+  name: kimi-k2
+  namespace: ml-team
+spec:
+  replicas: 1
+
+  # Optional: restrict to clusters with frontier-class hardware.
+  # clusterSelector:
+  #   matchLabels:
+  #     modelplane.ai/tier: frontier
+
+  # Reference the ModelCache above; Modelplane mounts it at /mnt/models on
+  # every worker pod.
+  modelCacheRef:
+    name: kimi-k2
+
+  workers:
+    # 8 GPUs per pod, 2 pods per worker = multi-node via LeaderWorkerSet.
+    topology:
+      tensor: 8
+      pipeline: 2
+    template:
+      spec:
+        containers:
+        - name: engine
+          image: vllm/vllm-openai:v0.8.5
+          args:
+          # The cache mounts at /mnt/models; engine reads weights from there.
+          - "--model=/mnt/models"
+          - "--tensor-parallel-size=8"
+          - "--pipeline-parallel-size=2"
+          - "--trust-remote-code"
+          - "--max-model-len=65536"


### PR DESCRIPTION
Multi-node serving today has no safe way to share model weights across the pods of a LeaderWorkerSet gang. Concurrent fetches across pods don't coordinate, and the failure modes are mostly invisible: torn files from simultaneous writes, version drift when the source updates mid-pull, partial downloads serving incorrect weights with no surface error, HuggingFace rate-limit storms.

This PR proposes `ModelCache`, a resource that stages a model artifact on a workload-cluster RWX PVC once and mounts it into every consuming pod. Multi-node deployments require a `modelCacheRef`; single-node deployments may reference one as a cold-start optimization. The full proposal — including alternatives considered (`CacheClass`, storage backend enum, cluster-level capacity envelope, configurable mount path) — is in `design/modelcache.md`, intended as the first one-pager addition alongside the base design.

This PR ships the API surface only: XRDs for `ModelCache`, `modelCacheRef` on `ModelDeployment` and `ModelReplica`, `cluster.<source>.cache.storageClassName` on `InferenceCluster`, an end-to-end example, and `docs/concepts.md` updates. Composition functions follow.