### PR TITLE
Move URLRewrite filter from backendRef to rule level

### DIFF
--- a/functions/compose-model-service/function/fn.py
+++ b/functions/compose-model-service/function/fn.py
@@ -6,10 +6,12 @@ address and parentRef) and the matching ModelEndpoints (for their
 backend names and rewrite paths), then composes a single HTTPRoute on
 the control plane.
 
-The match prefix is `/<service-ns>/<service-name>/`. Each backendRef
-carries its own URLRewrite filter derived from the endpoint's
-spec.rewritePath, so endpoints from different deployments or external
-providers can coexist with different rewrite targets.
+The match prefix is `/<service-ns>/<service-name>/`. Endpoints are
+grouped by rewritePath; each group becomes one HTTPRoute rule with a
+rule-level URLRewrite filter. This is necessary because Gateway API
+only allows RequestHeaderModifier and ResponseHeaderModifier at the
+backendRef level. Endpoints with the same rewritePath share a rule and
+are load-balanced by weight within it.
 """
 
 import grpc
@@ -163,11 +165,15 @@ class Composer:
     def compose_httproute(self):
         """Compose an HTTPRoute that load-balances across matched endpoints.
 
-        Each backendRef carries its own URLRewrite filter so endpoints
-        with different rewritePaths (e.g. composed replicas vs. external
-        SaaS providers) are rewritten correctly per-backend.
+        Endpoints are grouped by rewritePath. Each group becomes one
+        HTTPRoute rule sharing the same PathPrefix match. The URLRewrite
+        filter is attached at the rule level (not per-backendRef) because
+        Gateway API only permits RequestHeaderModifier and
+        ResponseHeaderModifier on individual backendRefs.
         """
-        backend_refs = []
+        # Group ready endpoints by rewritePath. Endpoints without a
+        # rewritePath use None as the key (no rewrite filter).
+        groups: dict[str | None, list[dict]] = {}
         for ep in self.endpoints:
             if not ep.status or not ep.status.routing or not ep.status.routing.backendName:
                 continue
@@ -178,38 +184,41 @@ class Composer:
                 "port": 80,
                 "weight": 1,
             }
-            if ep.spec.rewritePath:
-                ref["filters"] = [
+            key = ep.spec.rewritePath or None
+            groups.setdefault(key, []).append(ref)
+
+        match_prefix = f"/{self.xr.metadata.namespace}/{self.xr.metadata.name}/"
+        match = {"path": {"type": "PathPrefix", "value": match_prefix}}
+
+        rules = []
+        # Emit rules in a deterministic order: sorted rewritePaths first,
+        # then the no-rewrite group (None key) last.
+        for key in sorted(groups, key=lambda k: (k is None, k or "")):
+            rule: dict = {"matches": [match]}
+            if key is not None:
+                rule["filters"] = [
                     {
                         "type": "URLRewrite",
                         "urlRewrite": {
                             "path": {
                                 "type": "ReplacePrefixMatch",
-                                "replacePrefixMatch": ep.spec.rewritePath,
+                                "replacePrefixMatch": key,
                             },
                         },
                     }
                 ]
-            backend_refs.append(ref)
+            rule["backendRefs"] = groups[key]
+            rules.append(rule)
 
-        match_prefix = f"/{self.xr.metadata.namespace}/{self.xr.metadata.name}/"
-
-        rule: dict = {
-            "matches": [
-                {
-                    "path": {
-                        "type": "PathPrefix",
-                        "value": match_prefix,
-                    },
-                }
-            ],
-        }
-        if backend_refs:
-            rule["backendRefs"] = backend_refs
+        # No ready backends — emit a single rule with no backendRefs so
+        # the HTTPRoute still exists (Envoy returns 500 until backends
+        # appear, but the route object is valid).
+        if not rules:
+            rules.append({"matches": [match]})
 
         httproute_spec = {
             "parentRefs": [{"name": _GATEWAY_NAME, "namespace": _NAMESPACE_SYSTEM}],
-            "rules": [rule],
+            "rules": rules,
         }
 
         resource.update(

--- a/functions/compose-model-service/tests/test_fn.py
+++ b/functions/compose-model-service/tests/test_fn.py
@@ -98,6 +98,17 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                                             "matches": [
                                                 {"path": {"type": "PathPrefix", "value": "/ml-team/test-service/"}}
                                             ],
+                                            "filters": [
+                                                {
+                                                    "type": "URLRewrite",
+                                                    "urlRewrite": {
+                                                        "path": {
+                                                            "type": "ReplacePrefixMatch",
+                                                            "replacePrefixMatch": "/default/model/",
+                                                        },
+                                                    },
+                                                }
+                                            ],
                                             "backendRefs": [
                                                 {
                                                     "group": "gateway.envoyproxy.io",
@@ -105,17 +116,6 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                                                     "name": "backend-1",
                                                     "port": 80,
                                                     "weight": 1,
-                                                    "filters": [
-                                                        {
-                                                            "type": "URLRewrite",
-                                                            "urlRewrite": {
-                                                                "path": {
-                                                                    "type": "ReplacePrefixMatch",
-                                                                    "replacePrefixMatch": "/default/model/",
-                                                                },
-                                                            },
-                                                        }
-                                                    ],
                                                 },
                                             ],
                                         }
@@ -266,10 +266,268 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
         sel0_3.match_labels.labels.update({"app": "model"})
         want3.requirements.resources["endpoints-0"].CopyFrom(sel0_3)
 
+        # Case 4: two endpoints with the same rewritePath produce one rule with two backendRefs.
+        req4 = fnv1.RunFunctionRequest(
+            observed=fnv1.State(
+                composite=fnv1.Resource(resource=resource.dict_to_struct(xr)),
+            ),
+        )
+        req4.required_resources["inference-gateway"].items.append(
+            fnv1.Resource(
+                resource=resource.dict_to_struct(
+                    {
+                        "apiVersion": "modelplane.ai/v1alpha1",
+                        "kind": "InferenceGateway",
+                        "metadata": {"name": "default"},
+                        "spec": {"backend": "EnvoyGateway"},
+                        "status": {"address": "34.55.100.10"},
+                    }
+                )
+            )
+        )
+        for name, ip in [("ep-1", "10.0.0.1"), ("ep-2", "10.0.0.2")]:
+            req4.required_resources["endpoints-0"].items.append(
+                fnv1.Resource(
+                    resource=resource.dict_to_struct(
+                        {
+                            "apiVersion": "modelplane.ai/v1alpha1",
+                            "kind": "ModelEndpoint",
+                            "metadata": {"name": name, "namespace": "ml-team"},
+                            "spec": {"url": f"http://{ip}/default/model/v1", "rewritePath": "/default/model/"},
+                            "status": {"routing": {"backendName": f"backend-{name}"}},
+                        }
+                    )
+                )
+            )
+
+        want4 = fnv1.RunFunctionResponse(
+            meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
+            desired=fnv1.State(
+                composite=fnv1.Resource(
+                    resource=resource.dict_to_struct(
+                        {"status": {"address": "http://34.55.100.10/ml-team/test-service"}}
+                    ),
+                ),
+                resources={
+                    "httproute": fnv1.Resource(
+                        resource=resource.dict_to_struct(
+                            {
+                                "apiVersion": "gateway.networking.k8s.io/v1",
+                                "kind": "HTTPRoute",
+                                "metadata": {"namespace": "ml-team"},
+                                "spec": {
+                                    "parentRefs": [{"name": "modelplane", "namespace": "modelplane-system"}],
+                                    "rules": [
+                                        {
+                                            "matches": [
+                                                {"path": {"type": "PathPrefix", "value": "/ml-team/test-service/"}}
+                                            ],
+                                            "filters": [
+                                                {
+                                                    "type": "URLRewrite",
+                                                    "urlRewrite": {
+                                                        "path": {
+                                                            "type": "ReplacePrefixMatch",
+                                                            "replacePrefixMatch": "/default/model/",
+                                                        },
+                                                    },
+                                                }
+                                            ],
+                                            "backendRefs": [
+                                                {
+                                                    "group": "gateway.envoyproxy.io",
+                                                    "kind": "Backend",
+                                                    "name": "backend-ep-1",
+                                                    "port": 80,
+                                                    "weight": 1,
+                                                },
+                                                {
+                                                    "group": "gateway.envoyproxy.io",
+                                                    "kind": "Backend",
+                                                    "name": "backend-ep-2",
+                                                    "port": 80,
+                                                    "weight": 1,
+                                                },
+                                            ],
+                                        }
+                                    ],
+                                },
+                            }
+                        ),
+                    ),
+                },
+            ),
+            conditions=[
+                fnv1.Condition(
+                    type="EndpointsResolved",
+                    status=fnv1.STATUS_CONDITION_TRUE,
+                    reason="Resolved",
+                    message="Matched 2 endpoint(s)",
+                ),
+                fnv1.Condition(
+                    type="RoutingReady",
+                    status=fnv1.STATUS_CONDITION_FALSE,
+                    reason="Configuring",
+                ),
+            ],
+            context=structpb.Struct(),
+        )
+        want4.requirements.resources["inference-gateway"].CopyFrom(
+            fnv1.ResourceSelector(api_version="modelplane.ai/v1alpha1", kind="InferenceGateway", match_name="default")
+        )
+        sel0_4 = fnv1.ResourceSelector(api_version="modelplane.ai/v1alpha1", kind="ModelEndpoint")
+        sel0_4.match_labels.labels.update({"app": "model"})
+        want4.requirements.resources["endpoints-0"].CopyFrom(sel0_4)
+
+        # Case 5: two endpoints with different rewritePaths produce two rules.
+        req5 = fnv1.RunFunctionRequest(
+            observed=fnv1.State(
+                composite=fnv1.Resource(resource=resource.dict_to_struct(xr)),
+            ),
+        )
+        req5.required_resources["inference-gateway"].items.append(
+            fnv1.Resource(
+                resource=resource.dict_to_struct(
+                    {
+                        "apiVersion": "modelplane.ai/v1alpha1",
+                        "kind": "InferenceGateway",
+                        "metadata": {"name": "default"},
+                        "spec": {"backend": "EnvoyGateway"},
+                        "status": {"address": "34.55.100.10"},
+                    }
+                )
+            )
+        )
+        req5.required_resources["endpoints-0"].items.append(
+            fnv1.Resource(
+                resource=resource.dict_to_struct(
+                    {
+                        "apiVersion": "modelplane.ai/v1alpha1",
+                        "kind": "ModelEndpoint",
+                        "metadata": {"name": "ep-a", "namespace": "ml-team"},
+                        "spec": {"url": "http://10.0.0.1/default/model-a/v1", "rewritePath": "/default/model-a/"},
+                        "status": {"routing": {"backendName": "backend-a"}},
+                    }
+                )
+            )
+        )
+        req5.required_resources["endpoints-0"].items.append(
+            fnv1.Resource(
+                resource=resource.dict_to_struct(
+                    {
+                        "apiVersion": "modelplane.ai/v1alpha1",
+                        "kind": "ModelEndpoint",
+                        "metadata": {"name": "ep-b", "namespace": "ml-team"},
+                        "spec": {"url": "http://10.0.0.2/default/model-b/v1", "rewritePath": "/default/model-b/"},
+                        "status": {"routing": {"backendName": "backend-b"}},
+                    }
+                )
+            )
+        )
+
+        want5 = fnv1.RunFunctionResponse(
+            meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
+            desired=fnv1.State(
+                composite=fnv1.Resource(
+                    resource=resource.dict_to_struct(
+                        {"status": {"address": "http://34.55.100.10/ml-team/test-service"}}
+                    ),
+                ),
+                resources={
+                    "httproute": fnv1.Resource(
+                        resource=resource.dict_to_struct(
+                            {
+                                "apiVersion": "gateway.networking.k8s.io/v1",
+                                "kind": "HTTPRoute",
+                                "metadata": {"namespace": "ml-team"},
+                                "spec": {
+                                    "parentRefs": [{"name": "modelplane", "namespace": "modelplane-system"}],
+                                    "rules": [
+                                        {
+                                            "matches": [
+                                                {"path": {"type": "PathPrefix", "value": "/ml-team/test-service/"}}
+                                            ],
+                                            "filters": [
+                                                {
+                                                    "type": "URLRewrite",
+                                                    "urlRewrite": {
+                                                        "path": {
+                                                            "type": "ReplacePrefixMatch",
+                                                            "replacePrefixMatch": "/default/model-a/",
+                                                        },
+                                                    },
+                                                }
+                                            ],
+                                            "backendRefs": [
+                                                {
+                                                    "group": "gateway.envoyproxy.io",
+                                                    "kind": "Backend",
+                                                    "name": "backend-a",
+                                                    "port": 80,
+                                                    "weight": 1,
+                                                },
+                                            ],
+                                        },
+                                        {
+                                            "matches": [
+                                                {"path": {"type": "PathPrefix", "value": "/ml-team/test-service/"}}
+                                            ],
+                                            "filters": [
+                                                {
+                                                    "type": "URLRewrite",
+                                                    "urlRewrite": {
+                                                        "path": {
+                                                            "type": "ReplacePrefixMatch",
+                                                            "replacePrefixMatch": "/default/model-b/",
+                                                        },
+                                                    },
+                                                }
+                                            ],
+                                            "backendRefs": [
+                                                {
+                                                    "group": "gateway.envoyproxy.io",
+                                                    "kind": "Backend",
+                                                    "name": "backend-b",
+                                                    "port": 80,
+                                                    "weight": 1,
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            }
+                        ),
+                    ),
+                },
+            ),
+            conditions=[
+                fnv1.Condition(
+                    type="EndpointsResolved",
+                    status=fnv1.STATUS_CONDITION_TRUE,
+                    reason="Resolved",
+                    message="Matched 2 endpoint(s)",
+                ),
+                fnv1.Condition(
+                    type="RoutingReady",
+                    status=fnv1.STATUS_CONDITION_FALSE,
+                    reason="Configuring",
+                ),
+            ],
+            context=structpb.Struct(),
+        )
+        want5.requirements.resources["inference-gateway"].CopyFrom(
+            fnv1.ResourceSelector(api_version="modelplane.ai/v1alpha1", kind="InferenceGateway", match_name="default")
+        )
+        sel0_5 = fnv1.ResourceSelector(api_version="modelplane.ai/v1alpha1", kind="ModelEndpoint")
+        sel0_5.match_labels.labels.update({"app": "model"})
+        want5.requirements.resources["endpoints-0"].CopyFrom(sel0_5)
+
         cases = [
             Case(name="endpoints with ready backends compose HTTPRoute with backendRefs", req=req1, want=want1),
             Case(name="no endpoints produces warning and EndpointsResolved=False", req=req2, want=want2),
             Case(name="endpoint without backend composes HTTPRoute without backendRefs", req=req3, want=want3),
+            Case(name="same rewritePath produces one rule with two backendRefs", req=req4, want=want4),
+            Case(name="different rewritePaths produce one rule per path", req=req5, want=want5),
         ]
 
         for case in cases:


### PR DESCRIPTION
Fixes #85.

Gateway API only allows RequestHeaderModifier and ResponseHeaderModifier at the backendRef level. Placing URLRewrite filters on individual backendRefs causes Envoy Gateway to reject the HTTPRoute with UnsupportedRefValue, resulting in HTTP 500 for all requests through a ModelService.

This PR groups endpoints by rewritePath and emits one HTTPRoute rule per unique path. Each rule carries the URLRewrite filter at the rule level, where Gateway API permits it. Endpoints sharing a rewritePath land under the same rule and load-balance within it.