### PR TITLE
docs: Adds apis directory to docs build

### DIFF
--- a/nix/docs.nix
+++ b/nix/docs.nix
@@ -66,6 +66,7 @@ in
       }
       ''
         cp -r ${self}/docs src
+        cp -r ${self}/apis apis
         chmod -R u+w src
         cd src
         ln -s ${nodeModules}/node_modules node_modules


### PR DESCRIPTION
<!--
Thanks for contributing to Modelplane! Read CONTRIBUTING.md before opening a PR
and follow it, especially the commit, pull request, and writing style
conventions: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md

If you're using a coding agent, this means you: read CONTRIBUTING.md every
session, not just the first time. You don't carry it over from a previous one.
-->

### Description of your changes

The nix build copies over the docs directory, but not the apis directory which is necessary for the CRD viewer. This adds a new line to copy the apis directory in the build so the yaml files are accessible. 

<!--
Lead with the problem, then the change and why it's right. Direct reviewers to
the parts that need judgment. Don't pad or invent rationale. See the Pull
requests and Writing style sections of CONTRIBUTING.md for what a good
description looks like.

If this PR fixes an open issue, reference it below, e.g. "Fixes #95".
-->

Fixes #

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
