### PR TITLE
Serve the docs under the /docs path of modelplane.ai

### DIFF
--- a/docs/themes/geekboot/assets/scss/_crds.scss
+++ b/docs/themes/geekboot/assets/scss/_crds.scss
@@ -284,7 +284,7 @@
   }
 
   .yaml-svg{
-    background-image: url("/img/download.svg");
+    background-image: url("../img/download.svg");
     background-repeat: no-repeat;
     background-position: center;
     border-radius: 4px;
@@ -307,7 +307,7 @@
     .up-button {
       color: var(--body-font-color);
       background-color: #{$aqua-600} !important;
-      background-image: url("/img/arrow-up-white.svg");
+      background-image: url("../img/arrow-up-white.svg");
       background-repeat: no-repeat;
       background-position: center;
       border-radius: 4px;

--- a/docs/themes/geekboot/assets/scss/dark-mode.scss
+++ b/docs/themes/geekboot/assets/scss/dark-mode.scss
@@ -52,11 +52,11 @@
     --result-path: var(--body-background);
 
     // API Page
-    --sort-up: url("/img/sort-up-light.svg");
-    --sort-down: url("/img/sort-down-light.svg");
+    --sort-up: url("../img/sort-up-light.svg");
+    --sort-down: url("../img/sort-down-light.svg");
     --expand-box-background: #{$mp-bg-card};
-    --minus-svg: url("/img/minus-white.svg");
-    --plus-svg: url("/img/plus-150.svg");
+    --minus-svg: url("../img/minus-white.svg");
+    --plus-svg: url("../img/plus-150.svg");
     // Bump description / header text to muted-hi (#b0afcc) for legibility.
     // $mp-muted (#8b8aae) passes WCAG AA but reads as washed-out body text.
     --crd-header-color: #{$mp-muted-hi};

--- a/docs/themes/geekboot/assets/scss/light-mode.scss
+++ b/docs/themes/geekboot/assets/scss/light-mode.scss
@@ -59,11 +59,11 @@
     --result-path: var(--body-background);
 
     // API Page
-    --sort-up: url("/img/sort-up-light.svg");
-    --sort-down: url("/img/sort-down-light.svg");
+    --sort-up: url("../img/sort-up-light.svg");
+    --sort-down: url("../img/sort-down-light.svg");
     --expand-box-background: #{$fog-100};
-    --minus-svg: url("/img/minus-white.svg");
-    --plus-svg: url("/img/plus-black.svg");
+    --minus-svg: url("../img/minus-white.svg");
+    --plus-svg: url("../img/plus-black.svg");
     // fog-600 (#6C7070) passes at 5.0:1 but reads light; fog-700 (#535858) gives 6.6:1
     --crd-header-color: #{$fog-700};
     --crd-row-border: #{$fog-400};

--- a/docs/themes/geekboot/layouts/partials/docs-navbar.html
+++ b/docs/themes/geekboot/layouts/partials/docs-navbar.html
@@ -16,8 +16,8 @@
   </div>
 
   <div class="navbar-brand">
-    <a href="/" aria-label="Modelplane">
-      <img src="/img/modelplane-logo-inverted.svg" alt="Modelplane" height="28" decoding="async" loading="lazy">
+    <a href="{{ "" | relURL }}" aria-label="Modelplane">
+      <img src="{{ "img/modelplane-logo-inverted.svg" | relURL }}" alt="Modelplane" height="28" decoding="async" loading="lazy">
     </a>
   </div>
 
@@ -27,8 +27,8 @@
 
       <div class="offcanvas-header p-0">
         <div class="navbar-brand">
-          <a href="/" aria-label="Modelplane">
-            <img src="/img/modelplane-logo-inverted.svg" alt="Modelplane" height="28" decoding="async" loading="lazy">
+          <a href="{{ "" | relURL }}" aria-label="Modelplane">
+            <img src="{{ "img/modelplane-logo-inverted.svg" | relURL }}" alt="Modelplane" height="28" decoding="async" loading="lazy">
           </a>
         </div>
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close" data-bs-target="#offcanvas"></button>

--- a/docs/themes/geekboot/layouts/partials/favicons.html
+++ b/docs/themes/geekboot/layouts/partials/favicons.html
@@ -1,9 +1,9 @@
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-<link rel="manifest" href="/site.webmanifest">
-<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#f87c44">
+<link rel="apple-touch-icon" sizes="180x180" href="{{ "apple-touch-icon.png" | relURL }}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ "favicon-32x32.png" | relURL }}">
+<link rel="icon" type="image/png" sizes="192x192" href="{{ "android-chrome-192x192.png" | relURL }}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ "favicon-16x16.png" | relURL }}">
+<link rel="manifest" href="{{ "site.webmanifest" | relURL }}">
+<link rel="mask-icon" href="{{ "safari-pinned-tab.svg" | relURL }}" color="#f87c44">
 <meta name="apple-mobile-web-app-title" content="Crossplane Docs">
 <meta name="application-name" content="Crossplane Docs">
 <meta name="msapplication-TileColor" content="#333f5b">

--- a/docs/themes/geekboot/layouts/partials/footer.html
+++ b/docs/themes/geekboot/layouts/partials/footer.html
@@ -3,8 +3,8 @@
   <div class="container">
     <div class="d-flex align-items-center justify-content-between flex-wrap gap-4">
       <div class="d-flex align-items-center gap-3">
-        <a href="/" aria-label="Modelplane">
-          <img src="/img/modelplane-logo-inverted.svg" alt="Modelplane" height="24" loading="lazy">
+        <a href="{{ "" | relURL }}" aria-label="Modelplane">
+          <img src="{{ "img/modelplane-logo-inverted.svg" | relURL }}" alt="Modelplane" height="24" loading="lazy">
         </a>
         <span class="footer-link" style="font-size:13px;">Modelplane Documentation</span>
       </div>

--- a/docs/themes/geekboot/layouts/partials/meta-common.html
+++ b/docs/themes/geekboot/layouts/partials/meta-common.html
@@ -4,10 +4,10 @@
 <meta name="color-scheme" content="light dark">
 <meta name="docsearch:language" content="en" />
 {{ hugo.Generator }}
-<link rel="preload" href="/fonts/Avenir-Roman.woff2" as="font" type="font/woff2"
+<link rel="preload" href="{{ "fonts/Avenir-Roman.woff2" | relURL }}" as="font" type="font/woff2"
 crossorigin>
-<meta property="og:image"           content="/img/crossplane-logo-og.webp" />
-<meta property="twitter:card"       content="/img/crossplane-logo-og.webp" />
+<meta property="og:image"           content="{{ "img/crossplane-logo-og.webp" | absURL }}" />
+<meta property="twitter:card"       content="{{ "img/crossplane-logo-og.webp" | absURL }}" />
 <meta property="og:image:width"     content="600" />
 <meta property="og:image:height"    content="199" />
 <meta property="og:image:alt"       content="Crossplane name and popsicle logo" />

--- a/docs/themes/geekboot/layouts/partials/scripts.html
+++ b/docs/themes/geekboot/layouts/partials/scripts.html
@@ -1,4 +1,4 @@
-{{ $js := resources.Get (index (index .Site.Data.assets "main.js") "src" | relURL) }}
+{{ $js := resources.Get (index (index .Site.Data.assets "main.js") "src") }}
 <script src="{{ $js.Permalink }}" data-no-instant></script>
 {{- $jsmap := resources.Get (printf "%s.map" (index (index .Site.Data.assets "main.js") "src")) -}}
 {{- $jsmap.Publish -}}

--- a/nix/docs.nix
+++ b/nix/docs.nix
@@ -49,6 +49,13 @@ in
   #   HUGO_ENABLEGITINFO=false   no .git in the sandbox; git metadata is
   #                              cosmetic (last-modified dates).
   #   HUGO_ENVIRONMENT=production   selects the PostCSS+PurgeCSS CSS pipeline.
+  #   HUGO_BASEURL=…/docs/   the site is served under the /docs path of
+  #                              modelplane.ai (the marketing site proxies
+  #                              /docs/* here), so every Permalink, canonical
+  #                              tag, asset, and sitemap URL must carry the
+  #                              /docs prefix. Only the production artifact is
+  #                              served there; `hugo server` (docs-serve) keeps
+  #                              the baseURL = "/" from hugo.toml for local dev.
   #
   # PostCSS resolves plugins from node_modules via NODE_PATH, and Hugo finds
   # the postcss CLI through the node_modules/.bin on PATH.
@@ -62,6 +69,7 @@ in
         env = {
           HUGO_ENABLEGITINFO = "false";
           HUGO_ENVIRONMENT = "production";
+          HUGO_BASEURL = "https://modelplane.ai/docs/";
         };
       }
       ''


### PR DESCRIPTION
### Description of your changes

The Hugo docs are moving from the `docs.modelplane.ai` subdomain to a `/docs` subpath on the marketing domain so that backlinks and ranking signals reinforce `modelplane.ai` rather than being split across a subdomain. The marketing site (a separate Next.js project) will proxy `/docs/*` to this Hugo deployment; that rewrite is a companion PR on the `website` repo.

The geekboot theme assumed it was served from a domain root. The logo links and image, the favicons, the font preload, and the icon background images in SCSS were all hardcoded as root-absolute paths (`/img/...`, `/fonts/...`), so under a `/docs` prefix each of them resolves against the apex and 404s. This makes the site portable to the subpath.

The production `baseURL` is set to `https://modelplane.ai/docs/` via `HUGO_BASEURL` in the Nix build (`nix/docs.nix`), so Permalinks, canonical tags, the sitemap, and Hugo-managed assets all carry the prefix. Only the built artifact is served there; `hugo server` (`docs-serve`) still reads `baseURL = "/"` from `hugo.toml`, so local dev is unchanged. Hardcoded template paths become `relURL` (same-origin assets) or `absURL` (the social image, which must be absolute for scrapers). The SCSS icon `url()`s change from `/img/...` to `../img/...`; relative to the compiled CSS at `/scss/docs.css` that resolves to `/img/` at the root and `/docs/img/` under the subpath, correct in both layouts.

The reviewer's attention is worth directing at one non-obvious fix: a stray `relURL` on the `resources.Get` argument in `scripts.html`. `resources.Get` takes a filesystem path, not a URL, and under the `/docs` baseURL the `relURL` turned it into `/docs/js/...`, returning nil and breaking the build. The adjacent `.map` line already passed the raw `src`, which is the intended pattern.

I verified a production-baseURL build locally (`HUGO_BASEURL=https://modelplane.ai/docs/`): the build succeeds and the emitted canonical tags, favicons, font, logo, CSS, JS bundle, and the compiled CSS `url()`s all carry the `/docs/` prefix.

The OG/social metadata still references Crossplane assets and handles (`crossplane-logo-og.webp`, `@crossplane_io`, "Crossplane Docs" titles). Rebranding that is out of scope here and needs a Modelplane OG image; it should be a separate change.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~ Nix isn't available in my environment, so I couldn't run it locally; CI's `check` job ran it and is green, and I verified the production-`baseURL` Hugo build locally.
- [ ] ~Added or updated tests covering any composition function changes.~ No composition function changes — this is a docs-theme-only change.
- [x] Signed off every commit with `git commit -s`.