### PR TITLE
Emit all docs pages in the sitemap

### DIFF
--- a/docs/themes/geekboot/layouts/_default/sitemap.xml
+++ b/docs/themes/geekboot/layouts/_default/sitemap.xml
@@ -1,14 +1,7 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range where (where .Site.Pages "Section" "latest") ".Params.searchExclude" "ne" "true" }}
-  <url>
-    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
-    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
-  </url>
-  {{ end }}
-  {{/* For KB and Contrib guides */}}
-  {{ range where .Site.Pages "Params.version" "0" }}
+  {{ range where .Site.Pages ".Params.searchExclude" "ne" "true" }}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}


### PR DESCRIPTION
The sitemap template only ranged over a Crossplane-style `latest` section, so it came out empty; range over all non-`searchExclude` pages instead.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~ Nix isn't available in my environment; verified via a local Hugo build that `/docs/sitemap.xml` now lists all four pages with `https://modelplane.ai/docs/...` URLs.
- [ ] ~Added or updated tests covering any composition function changes.~ No composition function changes — docs theme template only.
- [x] Signed off every commit with `git commit -s`.