### PR TITLE
Make docs PR previews standalone and reviewable

### DIFF
--- a/docs/vercel-build.sh
+++ b/docs/vercel-build.sh
@@ -44,7 +44,19 @@ export PATH="/nix/var/nix/profiles/default/bin:$PATH"
 
 # Build the site. result is a symlink into the read-only store; dereference it
 # into a plain, writable directory Vercel can serve.
-nix build .#docs --print-build-logs
+#
+# Production keeps the canonical https://modelplane.ai/docs/ baseURL baked into
+# nix/docs.nix: a pure, cached build identical to what CI verifies. PR previews
+# are served standalone at the deployment's own root (not under /docs), so we
+# rebuild with the preview URL as the baseURL, making links and assets resolve
+# against the preview itself instead of production. --impure lets the
+# derivation read HUGO_BASEURL from the environment (getEnv is "" in pure eval).
+if [ "${VERCEL_ENV:-}" = "production" ]; then
+	nix build .#docs --print-build-logs
+else
+	export HUGO_BASEURL="https://${VERCEL_URL}/"
+	nix build .#docs --impure --print-build-logs
+fi
 rm -rf public
 cp -rL --no-preserve=mode result public
 rm -f result

--- a/nix/docs.nix
+++ b/nix/docs.nix
@@ -56,6 +56,14 @@ in
   #                              /docs prefix. Only the production artifact is
   #                              served there; `hugo server` (docs-serve) keeps
   #                              the baseURL = "/" from hugo.toml for local dev.
+  #                              Vercel PR previews override HUGO_BASEURL with
+  #                              the preview's own URL so the deployment is
+  #                              self-contained and reviewable (it is served at
+  #                              the deployment root, not under /docs). Pure
+  #                              flake eval returns "" for getEnv, so CI and
+  #                              production builds keep the canonical URL and
+  #                              stay reproducible/cached; previews pass
+  #                              --impure (see docs/vercel-build.sh).
   #
   # PostCSS resolves plugins from node_modules via NODE_PATH, and Hugo finds
   # the postcss CLI through the node_modules/.bin on PATH.
@@ -69,7 +77,11 @@ in
         env = {
           HUGO_ENABLEGITINFO = "false";
           HUGO_ENVIRONMENT = "production";
-          HUGO_BASEURL = "https://modelplane.ai/docs/";
+          HUGO_BASEURL =
+            let
+              envBaseURL = builtins.getEnv "HUGO_BASEURL";
+            in
+            if envBaseURL != "" then envBaseURL else "https://modelplane.ai/docs/";
         };
       }
       ''


### PR DESCRIPTION
### Description of your changes

We build the docs site from this repo as the `modelplane-docs` Vercel project and serve it under `/docs` on modelplane.ai (the website proxies `/docs/*` here). PR preview builds were not considered: the docs derivation in `nix/docs.nix` hardcoded `HUGO_BASEURL=https://modelplane.ai/docs/`, so every deployment, including previews, baked in the production `/docs` URL.

That made preview deployments unreviewable on their own. Internal links and CSS/JS asset URLs pointed at `https://modelplane.ai/docs/...` (production) rather than the preview, and standalone docs deployments serve at their root, so the `/docs` prefix (which only exists because of the website proxy) was wrong too.

The fix makes the baseURL depend on the deploy context:

- `nix/docs.nix` reads `HUGO_BASEURL` from the environment, defaulting to the production URL. Pure flake eval returns `""` for `getEnv`, so `nix build .#docs` (what CI verifies and production runs) is unchanged and stays reproducible and cached.
- `docs/vercel-build.sh` branches on `VERCEL_ENV`. Production builds the pure `.#docs`; previews build `--impure` with `HUGO_BASEURL=https://$VERCEL_URL/` so links and assets resolve against the preview itself, served at root.

Preview deployments on `*.vercel.app` are `noindex` by default, so the per-preview baseURL has no SEO impact.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~ (no composition function changes)
- [x] Signed off every commit with `git commit -s`.