### PR TITLE
Support the scale subresource on ModelDeployment

### DIFF
--- a/apis/modeldeployments/definition.yaml
+++ b/apis/modeldeployments/definition.yaml
@@ -18,6 +18,17 @@ spec:
     - name: REPLICAS
       type: string
       jsonPath: .status.replicas.ready
+    # Serve a scale subresource so `kubectl scale` and event-driven autoscalers
+    # (e.g. KEDA) can drive spec.replicas, the deployment's single scaling axis.
+    # statusReplicasPath points at the count of scheduled replicas, mirroring how
+    # Deployment and LeaderWorkerSet report status.replicas as the observed total
+    # and keep readiness separate. No labelSelectorPath: replica pods run on
+    # remote workload clusters, not alongside this XR, so metric-based HPA can't
+    # observe them; scaling is by kubectl or external metrics.
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas.total
     schema:
       openAPIV3Schema:
         type: object

--- a/crossplane-project.yaml
+++ b/crossplane-project.yaml
@@ -8,11 +8,10 @@ spec:
   license: Apache-2.0
   description: An open-source AI inference platform built on Crossplane.
   architectures: [amd64, arm64]
-  # compose-model-deployment and compose-model-cache match all resources of a
-  # kind with a bare ResourceSelector, which Crossplane only honours from
-  # v2.2.1 (https://github.com/crossplane/crossplane/pull/7241).
+  # The ModelDeployment XRD configures the scale subresource, which XRDs only
+  # support from v2.3 (https://github.com/crossplane/crossplane/pull/7004).
   crossplane:
-    version: '>=v2.2.1'
+    version: '>=v2.3.0'
   schemas:
     languages: [python]
   functions:

--- a/design/design.md
+++ b/design/design.md
@@ -724,9 +724,11 @@ instances. There's no in-cluster pod autoscaling, no KEDA or similar on workload
 clusters.
 
 The ModelDeployment XRD declares a Kubernetes scale subresource
-(`specReplicasPath: .spec.replicas`, `statusReplicasPath: .status.replicas`).
-Autoscaling is opt-in via a separate KEDA `ScaledObject` (or similar), the same
-pattern as Kubernetes Deployment + HPA.
+(`specReplicasPath: .spec.replicas`, `statusReplicasPath: .status.replicas.total`).
+`status.replicas.total` is the count of scheduled replicas, mirroring how
+Deployment and LeaderWorkerSet report `status.replicas` as the observed total and
+keep readiness in a separate field. Autoscaling is opt-in via `kubectl scale` or a
+separate KEDA `ScaledObject` (or similar).
 
 ## Alternatives considered
 

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1780687580,
-        "narHash": "sha256-03N3bljLb+2UYKwAyFQyJ6h2uNGhRbslNJxE3bOatJg=",
+        "lastModified": 1781565524,
+        "narHash": "sha256-n9G+G1BPQh1dCTSnYB6Jjqq6jlTnBv//xax24h+R84I=",
         "owner": "crossplane",
         "repo": "cli",
-        "rev": "5ed17c904256cc7f9bcc463f286b8eda9b46637c",
+        "rev": "1a0f22906aa52ae01129513e248d3f22cee495ba",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,9 +12,11 @@
     # tracking the latest uv_build releases.
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    # Pinned to crossplane/cli main: it carries the merged-but-unreleased
+    # Pinned to crossplane/cli main for two merged-but-unreleased fixes: the
     # datamodel-code-generator bump (crossplane/cli#24, #64) that fixes Python
-    # model generation for fields named int/bool. Repin to a tag once released.
+    # model generation for fields named int/bool, and crossplane/cli#119, which
+    # stops the scale subresource on an XRD from clobbering the generated model
+    # with the autoscaling Scale type. Repin to a tag once released.
     crossplane-cli.url = "github:crossplane/cli";
 
     # uv2nix reads a uv workspace's uv.lock and generates Nix derivations


### PR DESCRIPTION
Fixes #87

A ModelDeployment scales along one axis: `spec.replicas`. Each replica is a complete serving instance, so scaling means adding or removing whole replicas. Until now nothing exposed that axis through the Kubernetes scale subresource, so `kubectl scale` and event-driven autoscalers had no standard way to drive it. The design called for the subresource, but XRDs couldn't configure one until Crossplane v2.3 ([crossplane/crossplane#7004](https://github.com/crossplane/crossplane/pull/7004)), released recently.

This declares the scale subresource on the ModelDeployment XRD, mapping `spec.replicas` to the scale spec and `status.replicas.total` to the scale status. `total` is the count of scheduled replicas, which the composition function already writes; it mirrors how Deployment and LeaderWorkerSet report `status.replicas` as the observed total while keeping readiness in a separate field. The subresource declares no `labelSelectorPath`: a ModelDeployment's replica pods run on remote workload clusters, not alongside the XR, so a metric-based HorizontalPodAutoscaler can't observe them to scrape metrics. Scaling is by `kubectl scale` or an external-metrics autoscaler like KEDA. The project now requires Crossplane `>=v2.3.0`.

```console
$ kubectl scale modeldeployment/qwen3-8b --replicas=3
modeldeployment.modelplane.ai/qwen3-8b scaled
```

Generating the Python schemas for an XRD with a scale subresource clobbered the ModelDeployment model with the autoscaling `Scale` type, which broke the composition functions that import it. [crossplane/cli#119](https://github.com/crossplane/cli/pull/119) fixes that in the schema generator; the `crossplane-cli` flake input (already pinned to main for an unreleased fix) moves forward to a main commit that includes it.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~ No function changes; the XRD already had the `status.replicas.total` the subresource points at.
- [x] Signed off every commit with `git commit -s`.
