### PR TITLE
Latch ModelCache readiness so the hydration Job can be cleaned promptly

### DIFF
--- a/functions/compose-model-cache/function/fn.py
+++ b/functions/compose-model-cache/function/fn.py
@@ -50,6 +50,21 @@ REMOTE_NS = "default"
 HYDRATION_IMAGE = "python:3.11-slim"
 HYDRATION_MOUNT = "/mnt/artifact"
 
+# ttlSecondsAfterFinished governs how long the completed Job (and its
+# PVC-pinning pod) lingers before its TTL controller cascade-deletes both. Keep
+# it short so a just-deleted cache's PVC isn't pinned for long - but above
+# provider-kubernetes' observe interval, so the function still catches the Job's
+# success (to latch Ready and drop the Job) before the TTL fires.
+_JOB_TTL_SECONDS = 180
+
+# Every management policy except Delete. Once a cluster is Ready the Job is
+# dropped from the composition; without Delete, dropping orphans the external Job
+# instead of deleting it, so its own TTL controller cascade-cleans the completed
+# pod that pins the PVC - whereas Crossplane's delete would orphan that pod. (No
+# "all but Delete" shorthand exists, and deletionPolicy: Orphan is ignored once
+# managementPolicies is on.) Re-adding the Job after a flap is a cheap skip.
+_JOB_MANAGEMENT = ["Observe", "Create", "Update", "LateInitialize"]
+
 # Per-source default RWX storage class, mirroring the InferenceCluster XRD
 # defaults (GKE/Existing -> Filestore-backed modelplane-rwx; EKS -> EFS-backed
 # modelplane-rwx-efs). Used only when a cluster omits its cache block entirely:
@@ -142,9 +157,13 @@ class Composer:
         if not self.resolve_inputs():
             return
         matched = self.match_clusters()
-        for cluster in matched:
-            self.compose_cluster_resources(cluster)
+        # Derive each cluster's phase first (from observed state), then compose:
+        # a hydrated cluster's Job is composed Observe-only so Crossplane doesn't
+        # recreate it after the TTL controller cleans it.
         per_cluster_phase = [(c.metadata.name, self.derive_cluster_phase(c.metadata.name)) for c in matched]
+        phase_by_name = dict(per_cluster_phase)
+        for cluster in matched:
+            self.compose_cluster_resources(cluster, phase_by_name[cluster.metadata.name])
         self.mark_ready_resources(per_cluster_phase)
         self.write_status(matched, per_cluster_phase)
         self.derive_conditions(matched, per_cluster_phase)
@@ -184,20 +203,26 @@ class Composer:
         """Clusters that have finished provisioning (providerConfigRef set)."""
         return [c for c in self.clusters if c.status and c.status.providerConfigRef and c.status.providerConfigRef.name]
 
-    def compose_cluster_resources(self, cluster: icv1alpha1.InferenceCluster) -> None:
-        """Always emit the PVC + Job for a matched cluster (never gate on
-        readiness — omitting an Object tells Crossplane to delete it, which
-        would re-trigger hydration on every dependency flap)."""
+    def compose_cluster_resources(self, cluster: icv1alpha1.InferenceCluster, phase: str) -> None:
+        """Compose the PVC always, and the hydration Job until the cluster is Ready.
+
+        Once Ready the Job is dropped: with _JOB_MANAGEMENT (no Delete) that
+        orphans the external Job rather than deleting it, so its own TTL
+        controller cascade-cleans the Job and the completed pod pinning the PVC -
+        instead of Crossplane orphaning the pod. Readiness is latched in the XR
+        status, so dropping the Job doesn't regress it, and a flap that re-adds
+        it is a cheap idempotent skip."""
         pc = cluster.status.providerConfigRef.name
         name = cluster.metadata.name
         resource.update(
             self.rsp.desired.resources[self._pvc_key(name)],
             self._wrap_remote(pc, self._pvc_manifest(cluster), _PVC_READY_CEL),
         )
-        resource.update(
-            self.rsp.desired.resources[self._job_key(name)],
-            self._wrap_remote(pc, self._job_manifest(), _JOB_READY_CEL),
-        )
+        if phase != PHASE_READY:
+            resource.update(
+                self.rsp.desired.resources[self._job_key(name)],
+                self._wrap_remote(pc, self._job_manifest(), _JOB_READY_CEL, management_policies=_JOB_MANAGEMENT),
+            )
 
     def _pvc_manifest(self, cluster: icv1alpha1.InferenceCluster) -> dict:
         hf = self.xr.spec.huggingFace
@@ -213,17 +238,24 @@ class Composer:
             },
         }
 
-    def _wrap_remote(self, provider_config: str, manifest: dict, cel_query: str) -> k8sobjv1alpha1.Object:
-        return k8sobjv1alpha1.Object(
-            spec=k8sobjv1alpha1.Spec(
-                providerConfigRef=k8sobjv1alpha1.ProviderConfigRef(
-                    kind="ClusterProviderConfig",
-                    name=provider_config,
-                ),
-                readiness=k8sobjv1alpha1.Readiness(policy="DeriveFromCelQuery", celQuery=cel_query),
-                forProvider=k8sobjv1alpha1.ForProvider(manifest=manifest),
+    def _wrap_remote(
+        self,
+        provider_config: str,
+        manifest: dict,
+        cel_query: str,
+        management_policies: list[str] | None = None,
+    ) -> k8sobjv1alpha1.Object:
+        spec = k8sobjv1alpha1.Spec(
+            providerConfigRef=k8sobjv1alpha1.ProviderConfigRef(
+                kind="ClusterProviderConfig",
+                name=provider_config,
             ),
+            readiness=k8sobjv1alpha1.Readiness(policy="DeriveFromCelQuery", celQuery=cel_query),
+            forProvider=k8sobjv1alpha1.ForProvider(manifest=manifest),
         )
+        if management_policies is not None:
+            spec.managementPolicies = management_policies
+        return k8sobjv1alpha1.Object(spec=spec)
 
     # --- naming (must stay in sync with backends/base.cache_pvc_name) ---
     # Both sides share resource.child_name("modelcache", namespace, name).
@@ -252,7 +284,7 @@ class Composer:
             "metadata": {"name": self._job_name(), "namespace": REMOTE_NS, "labels": self._labels()},
             "spec": {
                 "backoffLimit": 3,
-                "ttlSecondsAfterFinished": 3600,
+                "ttlSecondsAfterFinished": _JOB_TTL_SECONDS,
                 "template": {
                     "metadata": {"labels": self._labels()},
                     "spec": {
@@ -282,11 +314,29 @@ class Composer:
         job_status = self._observed_status(self._job_key(cluster_name))
         if any(c.get("type") == "Failed" and c.get("status") == "True" for c in job_status.get("conditions", [])):
             return PHASE_FAILED
-        if int(job_status.get("succeeded", 0) or 0) >= 1 and pvc_bound:
+        # Latch Ready: a hydrated cluster stays Ready even once the Job (and its
+        # completed, PVC-pinning pod) has been cleaned and no longer reports its
+        # Complete condition. Reading the prior phase from the observed XR status
+        # keeps readiness stable across that cleanup. Ready still requires the PVC
+        # to be Bound, so if the PVC is lost the cache drops back to Pending
+        # rather than reporting a stale Ready.
+        job_complete = any(
+            c.get("type") == "Complete" and c.get("status") == "True" for c in job_status.get("conditions", [])
+        )
+        hydrated = job_complete or self._was_ready(cluster_name)
+        if pvc_bound and hydrated:
             return PHASE_READY
         if pvc_bound:
             return PHASE_HYDRATING
         return PHASE_PENDING
+
+    def _was_ready(self, cluster_name: str) -> bool:
+        """Whether the previous reconcile already reported this cluster Ready,
+        read from the observed XR status."""
+        status = self.xr.status
+        if not status or not status.clusters:
+            return False
+        return any(c.name == cluster_name and c.phase == PHASE_READY for c in status.clusters)
 
     def _observed_status(self, key: str) -> dict:
         """Remote resource status echoed back under Object.status.atProvider.manifest.status."""
@@ -304,8 +354,13 @@ class Composer:
         PVC/Job's Ready condition (PVC Bound, Job Complete) is reflected onto the
         observed Object. Runs after compose_cluster_resources() so the desired
         entries exist."""
-        for name, _ in per_cluster_phase:
-            for key in (self._pvc_key(name), self._job_key(name)):
+        for name, phase in per_cluster_phase:
+            # The Job is only composed until Ready (then dropped), so don't mark
+            # a key we didn't compose - accessing it would create a phantom entry.
+            keys = [self._pvc_key(name)]
+            if phase != PHASE_READY:
+                keys.append(self._job_key(name))
+            for key in keys:
                 observed = self.req.observed.resources.get(key)
                 if observed and resource.get_condition(observed.resource, "Ready").status == "True":
                     self.rsp.desired.resources[key].ready = fnv1.READY_TRUE

--- a/functions/compose-model-cache/tests/test_fn.py
+++ b/functions/compose-model-cache/tests/test_fn.py
@@ -170,7 +170,7 @@ def _job_object(pc: str, *, command: str = _HYDRATE_CMD, env: list | None = None
                     "metadata": {"name": _JOB_NAME, "namespace": "default", "labels": _LABELS},
                     "spec": {
                         "backoffLimit": 3,
-                        "ttlSecondsAfterFinished": 3600,
+                        "ttlSecondsAfterFinished": 180,
                         "template": {
                             "metadata": {"labels": _LABELS},
                             "spec": {
@@ -192,6 +192,7 @@ def _job_object(pc: str, *, command: str = _HYDRATE_CMD, env: list | None = None
                     },
                 },
             },
+            "managementPolicies": ["Observe", "Create", "Update", "LateInitialize"],
             "providerConfigRef": {"kind": "ClusterProviderConfig", "name": pc},
             "readiness": {
                 "celQuery": 'object.status.conditions.exists(c, c.type == "Complete" && c.status == "True")',
@@ -338,10 +339,9 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
         # not-previously-ready -> ready transition emits the "staged" event. ---
         observed4 = {
             "pvc-cluster-a": _observed_object({"phase": "Bound"}, ready=True),
-            "hydrate-cluster-a": _observed_object({"succeeded": 1}, ready=True),
+            "hydrate-cluster-a": _observed_object({"conditions": [{"type": "Complete", "status": "True"}]}, ready=True),
         }
         pvc_ready = _pvc_object("cluster-a-pc")
-        job_ready = _job_object("cluster-a-pc")
         want4 = fnv1.RunFunctionResponse(
             meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
             desired=fnv1.State(
@@ -357,10 +357,8 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                     ready=fnv1.READY_TRUE,
                 ),
                 resources={
+                    # Job dropped once Ready; only the PVC remains composed.
                     "pvc-cluster-a": fnv1.Resource(resource=resource.dict_to_struct(pvc_ready), ready=fnv1.READY_TRUE),
-                    "hydrate-cluster-a": fnv1.Resource(
-                        resource=resource.dict_to_struct(job_ready), ready=fnv1.READY_TRUE
-                    ),
                 },
             ),
             conditions=[
@@ -447,7 +445,7 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
         # 1/2, ArtifactReady False with reason Partial, XR not ready. ---
         observed7 = {
             "pvc-a": _observed_object({"phase": "Bound"}, ready=True),
-            "hydrate-a": _observed_object({"succeeded": 1}, ready=True),
+            "hydrate-a": _observed_object({"conditions": [{"type": "Complete", "status": "True"}]}, ready=True),
             "pvc-b": _observed_object({"phase": "Bound"}, ready=True),
         }
         want7 = fnv1.RunFunctionResponse(
@@ -467,11 +465,9 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                     ),
                 ),
                 resources={
+                    # Cluster a is Ready, so its Job is dropped; b is still Hydrating.
                     "pvc-a": fnv1.Resource(
                         resource=resource.dict_to_struct(_pvc_object("a-pc")), ready=fnv1.READY_TRUE
-                    ),
-                    "hydrate-a": fnv1.Resource(
-                        resource=resource.dict_to_struct(_job_object("a-pc")), ready=fnv1.READY_TRUE
                     ),
                     "pvc-b": fnv1.Resource(
                         resource=resource.dict_to_struct(_pvc_object("b-pc")), ready=fnv1.READY_TRUE
@@ -486,6 +482,53 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
             context=structpb.Struct(),
         )
         want7.requirements.resources["clusters"].CopyFrom(_CLUSTERS_SELECTOR)
+
+        # --- Case 8: latch. A previously-Ready cluster whose hydration Job was
+        # dropped (and TTL-cleaned), so only the PVC is observed now. The status
+        # latch keeps phase Ready and the Job is not re-composed, PVC marked
+        # ready, summary 1/1, XR ready. Already-ready, so no transition event. ---
+        xr_ready = _cache_xr()
+        xr_ready.status = v1alpha1.Status(
+            summary=v1alpha1.Summary(ready="1/1"),
+            clusters=[v1alpha1.Cluster(name="cluster-a", phase="Ready")],
+            conditions=[
+                v1alpha1.Condition(
+                    type="Ready",
+                    status="True",
+                    reason="Available",
+                    lastTransitionTime="2026-06-08T00:00:00Z",
+                ),
+            ],
+        )
+        observed8 = {"pvc-cluster-a": _observed_object({"phase": "Bound"}, ready=True)}
+        want8 = fnv1.RunFunctionResponse(
+            meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
+            desired=fnv1.State(
+                composite=fnv1.Resource(
+                    resource=resource.dict_to_struct(
+                        {
+                            "status": {
+                                "summary": {"ready": "1/1"},
+                                "clusters": [{"name": "cluster-a", "phase": "Ready"}],
+                            },
+                        },
+                    ),
+                    ready=fnv1.READY_TRUE,
+                ),
+                resources={
+                    # Latched Ready with the Job already dropped: only the PVC.
+                    "pvc-cluster-a": fnv1.Resource(
+                        resource=resource.dict_to_struct(_pvc_object("cluster-a-pc")), ready=fnv1.READY_TRUE
+                    ),
+                },
+            ),
+            conditions=[
+                fnv1.Condition(type="ClustersMatched", status=fnv1.STATUS_CONDITION_TRUE, reason="Matched"),
+                fnv1.Condition(type="ArtifactReady", status=fnv1.STATUS_CONDITION_TRUE, reason="Staged"),
+            ],
+            context=structpb.Struct(),
+        )
+        want8.requirements.resources["clusters"].CopyFrom(_CLUSTERS_SELECTOR)
 
         cases = [
             Case(
@@ -522,6 +565,11 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                 name="one of two clusters ready reports partial",
                 req=_req(_cache_xr(), [_cluster_dict("a", "a-pc"), _cluster_dict("b", "b-pc")], observed7),
                 want=want7,
+            ),
+            Case(
+                name="hydrated cluster stays Ready after its Job is TTL-cleaned",
+                req=_req(xr_ready, [_cluster_dict("cluster-a", "cluster-a-pc")], observed8),
+                want=want8,
             ),
         ]
 


### PR DESCRIPTION
Fixes #140.

Deleting a ModelCache left its PVC stuck `Terminating`. The completed hydration Job pod still referenced the PVC, and `pvc-protection` won't release it while a pod references it. provider-kubernetes deletes the Job with the `batch/v1` default (orphan) propagation, so the pod is orphaned rather than cleaned and pins the PVC indefinitely.

The fix latches readiness and hands the Job's cleanup to its own TTL controller. A cluster's `Ready` phase is recorded in the XR status, so the cache stays `Ready` once hydration has succeeded even after the Job is gone. Once `Ready`, the Job is dropped from the composition — safe because hydration is idempotent (a marker file short-circuits a re-run, so a flap that re-adds the Job is a cheap skip, not a re-download). The Job carries every management policy except `Delete`, so dropping it **orphans** the external Job rather than deleting it: its own TTL controller then deletes it *with* its pods (a real cascade), instead of Crossplane orphaning the pod. The TTL drops to 180s so the PVC isn't pinned for long.

Worst case — deleting a cache within the TTL of hydration finishing — the PVC sits `Terminating` until the Job's TTL fires, then deletes cleanly: bounded by the TTL rather than the previous permanent hang.

A follow-up worth noting: the TTL has to sit above provider-kubernetes' observe interval so we catch the Job's success before it's cleaned. Enabling provider-kubernetes `--enable-watches` (a `DeploymentRuntimeConfig`, same shape we already use for provider-helm) + `watch: true` would make observation event-driven and let the TTL shrink further. Left out here on purpose: `watch` is alpha/not-for-production and `--enable-watches` is cross-cutting, so it's a deliberate call, not a one-function bugfix.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
