### PR TITLE
Fix the GAIE inferencepool install in the serving stack

### DIFF
--- a/functions/compose-serving-stack/function/fn.py
+++ b/functions/compose-serving-stack/function/fn.py
@@ -57,7 +57,7 @@ _AI_GATEWAY_CONTROLLER_PORT = 1063
 # Gateway API Inference Extension (GAIE) constants. Provides the InferencePool
 # CRD that disaggregated replicas front their decode endpoints with.
 _GAIE_CHART = "inferencepool"
-_GAIE_REPO = "oci://ghcr.io/kubernetes-sigs/gateway-api-inference-extension/charts"
+_GAIE_REPO = "oci://registry.k8s.io/gateway-api-inference-extension/charts"
 _GAIE_VERSION = "v1.0.1"
 _GAIE_NAMESPACE = "gateway-api-inference-extension"
 

--- a/functions/compose-serving-stack/function/fn.py
+++ b/functions/compose-serving-stack/function/fn.py
@@ -13,7 +13,10 @@ Usage resources protect ProviderConfigs from premature deletion during
 teardown, ensuring Helm releases can uninstall before losing connectivity.
 """
 
+import pathlib
+
 import grpc
+import yaml
 from crossplane.function import logging, resource, response
 from crossplane.function.proto.v1 import run_function_pb2 as fnv1
 from crossplane.function.proto.v1 import run_function_pb2_grpc as grpcv1
@@ -54,12 +57,21 @@ _AI_GATEWAY_VERSION = "v0.7.0"
 _AI_GATEWAY_CONTROLLER_FQDN = f"ai-gateway-controller.{_AI_GATEWAY_NAMESPACE}.svc.cluster.local"
 _AI_GATEWAY_CONTROLLER_PORT = 1063
 
-# Gateway API Inference Extension (GAIE) constants. Provides the InferencePool
-# CRD that disaggregated replicas front their decode endpoints with.
-_GAIE_CHART = "inferencepool"
-_GAIE_REPO = "oci://registry.k8s.io/gateway-api-inference-extension/charts"
-_GAIE_VERSION = "v1.0.1"
-_GAIE_NAMESPACE = "gateway-api-inference-extension"
+
+# Gateway API Inference Extension (GAIE) CRDs, providing the InferencePool that
+# disaggregated replicas front their decode endpoints with. Vendored from the
+# upstream release's manifests.yaml.
+_HERE = pathlib.Path(__file__).parent
+_GAIE_CRDS = [
+    doc
+    for doc in yaml.safe_load_all((_HERE / "gaie_crds.yaml").read_text())
+    if doc and doc.get("kind") == "CustomResourceDefinition"
+]
+
+
+def _gaie_crd_key(doc: dict) -> str:
+    """Stable composed-resource key for a GAIE CRD."""
+    return f"gaie-crd-{doc['metadata']['name']}"
 
 
 def _helm_release(
@@ -539,29 +551,21 @@ class Composer:
         )
 
     def compose_gaie_crds(self):
-        """Compose the Gateway API Inference Extension (GAIE) CRDs. Gated on the
-        same ProviderConfigs as Envoy Gateway.
-
-        Installs the InferencePool CRD that disaggregated replicas front their
-        decode endpoints with. The codebase has no remote-manifest pattern for
-        provider-kubernetes Objects, so the CRDs come from the upstream Helm
-        chart published by kubernetes-sigs - equivalent to applying that
-        release's manifests.yaml.
+        """Compose the Gateway API Inference Extension (GAIE) CRDs as
+        provider-kubernetes Objects on the remote cluster. Gated on the same
+        ProviderConfigs as Envoy Gateway.
         """
         pc_observed = self.provider_configs_observed()
-        if not (pc_observed or "gaie-crds" in self.req.observed.resources):
-            return
-
-        resource.update(
-            self.rsp.desired.resources["gaie-crds"],
-            _helm_release(
-                chart=_GAIE_CHART,
-                repo=_GAIE_REPO,
-                version=_GAIE_VERSION,
-                namespace=_GAIE_NAMESPACE,
-                provider_config=_pc_name(self.xr),
-            ),
-        )
+        for doc in _GAIE_CRDS:
+            key = _gaie_crd_key(doc)
+            if not (pc_observed or key in self.req.observed.resources):
+                continue
+            resource.update(
+                self.rsp.desired.resources[key],
+                _k8s_object(_pc_name(self.xr), doc),
+            )
+            if resource.get_condition(self.req.observed.resources.get(key), "Ready").status == "True":
+                self.rsp.desired.resources[key].ready = fnv1.READY_TRUE
 
     def compose_prometheus(self):
         """Compose the kube-prometheus-stack. Gated on ProviderConfigs being

--- a/functions/compose-serving-stack/function/fn.py
+++ b/functions/compose-serving-stack/function/fn.py
@@ -759,6 +759,8 @@ class Composer:
         condition_ready = [
             "cert-manager",
             "envoy-gateway",
+            "ai-gateway-crds",
+            "ai-gateway",
             "prometheus",
             "leader-worker-set",
             "node-feature-discovery",

--- a/functions/compose-serving-stack/function/gaie_crds.yaml
+++ b/functions/compose-serving-stack/function/gaie_crds.yaml
@@ -1,0 +1,1007 @@
+# Gateway API Inference Extension (GAIE) CRDs, vendored from the v1.0.1 release:
+# https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.0.1/manifests.yaml
+#
+# When re-vendoring (bump the release in the URL above), strip each CRD's
+# top-level status and metadata.creationTimestamp. The upstream manifests carry
+# these server-owned fields; left in, the provider-kubernetes Object that applies
+# a CRD re-applies every reconcile (observed never matches desired), flooding
+# watch events and tripping the composite's watch circuit breaker.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    inference.networking.k8s.io/bundle-version: v1.0.1
+  name: inferenceobjectives.inference.networking.x-k8s.io
+spec:
+  group: inference.networking.x-k8s.io
+  names:
+    kind: InferenceObjective
+    listKind: InferenceObjectiveList
+    plural: inferenceobjectives
+    singular: inferenceobjective
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.poolRef.name
+      name: Inference Pool
+      type: string
+    - jsonPath: .spec.priority
+      name: Priority
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: InferenceObjective is the Schema for the InferenceObjectives
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'InferenceObjectiveSpec represents the desired state of a
+              specific model use case. This resource is
+
+              managed by the "Inference Workload Owner" persona.
+
+
+              The Inference Workload Owner persona is someone that trains, verifies,
+              and
+
+              leverages a large language model from a model frontend, drives the lifecycle
+
+              and rollout of new versions of those models, and defines the specific
+
+              performance and latency goals for the model. These workloads are
+
+              expected to operate within an InferencePool sharing compute capacity
+              with other
+
+              InferenceObjectives, defined by the Inference Platform Admin.'
+            properties:
+              poolRef:
+                description: PoolRef is a reference to the inference pool, the pool
+                  must exist in the same namespace.
+                properties:
+                  group:
+                    default: inference.networking.k8s.io
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    default: InferencePool
+                    description: Kind is kind of the referent. For example "InferencePool".
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              priority:
+                description: 'Priority defines how important it is to serve the request
+                  compared to other requests in the same pool.
+
+                  Priority is an integer value that defines the priority of the request.
+
+                  The higher the value, the more critical the request is; negative
+                  values _are_ allowed.
+
+                  No default value is set for this field, allowing for future additions
+                  of new fields that may ''one of'' with this field.
+
+                  However, implementations that consume this field (such as the Endpoint
+                  Picker) will treat an unset value as ''0''.
+
+                  Priority is used in flow control, primarily in the event of resource
+                  scarcity(requests need to be queued).
+
+                  All requests will be queued, and flow control will _always_ allow
+                  requests of higher priority to be served first.
+
+                  Fairness is only enforced and tracked between requests of the same
+                  priority.
+
+
+                  Example: requests with Priority 10 will always be served before
+
+                  requests with Priority of 0 (the value used if Priority is unset
+                  or no InfereneceObjective is specified).
+
+                  Similarly requests with a Priority of -10 will always be served
+                  after requests with Priority of 0.'
+                type: integer
+            required:
+            - poolRef
+            type: object
+          status:
+            description: InferenceObjectiveStatus defines the observed state of InferenceObjective
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: '1970-01-01T00:00:00Z'
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Ready
+                description: 'Conditions track the state of the InferenceObjective.
+
+
+                  Known condition types are:
+
+
+                  * "Accepted"'
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: 'lastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+
+                        This should be when the underlying condition changed.  If
+                        that is not known, then using the time when the API field
+                        changed is acceptable.'
+                      format: date-time
+                      type: string
+                    message:
+                      description: 'message is a human readable message indicating
+                        details about the transition.
+
+                        This may be an empty string.'
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: 'observedGeneration represents the .metadata.generation
+                        that the condition was set based upon.
+
+                        For instance, if .metadata.generation is currently 12, but
+                        the .status.conditions[x].observedGeneration is 9, the condition
+                        is out of date
+
+                        with respect to the current state of the instance.'
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: 'reason contains a programmatic identifier indicating
+                        the reason for the condition''s last transition.
+
+                        Producers of specific condition types may define expected
+                        values and meanings for this field,
+
+                        and whether the values are considered a guaranteed API.
+
+                        The value should be a CamelCase string.
+
+                        This field may not be empty.'
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - 'True'
+                      - 'False'
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1173
+    inference.networking.k8s.io/bundle-version: v1.0.1
+  name: inferencepools.inference.networking.k8s.io
+spec:
+  group: inference.networking.k8s.io
+  names:
+    kind: InferencePool
+    listKind: InferencePoolList
+    plural: inferencepools
+    shortNames:
+    - infpool
+    singular: inferencepool
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'InferencePool is the Schema for the InferencePools API.
+
+          '
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of the InferencePool.
+            properties:
+              endpointPickerRef:
+                description: 'EndpointPickerRef is a reference to the Endpoint Picker
+                  extension and its
+
+                  associated configuration.'
+                properties:
+                  failureMode:
+                    default: FailClose
+                    description: 'FailureMode configures how the parent handles the
+                      case when the Endpoint Picker extension
+
+                      is non-responsive. When unspecified, defaults to "FailClose".'
+                    enum:
+                    - FailOpen
+                    - FailClose
+                    type: string
+                  group:
+                    default: ''
+                    description: 'Group is the group of the referent API object. When
+                      unspecified, the default value
+
+                      is "", representing the Core API group.'
+                    maxLength: 253
+                    minLength: 0
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    default: Service
+                    description: 'Kind is the Kubernetes resource kind of the referent.
+
+
+                      Required if the referent is ambiguous, e.g. service with multiple
+                      ports.
+
+
+                      Defaults to "Service" when not specified.
+
+
+                      ExternalName services can refer to CNAME DNS records that may
+                      live
+
+                      outside of the cluster and as such are difficult to reason about
+                      in
+
+                      terms of conformance. They also may not be safe to forward to
+                      (see
+
+                      CVE-2021-25740 for more information). Implementations MUST NOT
+
+                      support ExternalName Services.'
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent API object.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  port:
+                    description: 'Port is the port of the Endpoint Picker extension
+                      service.
+
+
+                      Port is required when the referent is a Kubernetes Service.
+                      In this
+
+                      case, the port number is the service port number, not the target
+                      port.
+
+                      For other resources, destination port might be derived from
+                      the referent
+
+                      resource or this field.'
+                    properties:
+                      number:
+                        description: 'Number defines the port number to access the
+                          selected model server Pods.
+
+                          The number must be in the range 1 to 65535.'
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                    required:
+                    - number
+                    type: object
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: port is required when kind is 'Service' or unspecified
+                    (defaults to 'Service')
+                  rule: self.kind != 'Service' || has(self.port)
+              selector:
+                description: 'Selector determines which Pods are members of this inference
+                  pool.
+
+                  It matches Pods by their labels only within the same namespace;
+                  cross-namespace
+
+                  selection is not supported.
+
+
+                  The structure of this LabelSelector is intentionally simple to be
+                  compatible
+
+                  with Kubernetes Service selectors, as some implementations may translate
+
+                  this configuration into a Service resource.'
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      description: 'LabelValue is the value of a label. This is used
+                        for validation
+
+                        of maps. This matches the Kubernetes label validation rules:
+
+                        * must be 63 characters or less (can be empty),
+
+                        * unless empty, must begin and end with an alphanumeric character
+                        ([a-z0-9A-Z]),
+
+                        * could contain dashes (-), underscores (_), dots (.), and
+                        alphanumerics between.
+
+
+                        Valid values include:
+
+
+                        * MyValue
+
+                        * my.name
+
+                        * 123-my-value'
+                      maxLength: 63
+                      minLength: 0
+                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                      type: string
+                    description: 'MatchLabels contains a set of required {key,value}
+                      pairs.
+
+                      An object must match every label in this map to be selected.
+
+                      The matching logic is an AND operation on all entries.'
+                    type: object
+                required:
+                - matchLabels
+                type: object
+              targetPorts:
+                description: 'TargetPorts defines a list of ports that are exposed
+                  by this InferencePool.
+
+                  Currently, the list may only include a single port definition.'
+                items:
+                  description: Port defines the network port that will be exposed
+                    by this InferencePool.
+                  properties:
+                    number:
+                      description: 'Number defines the port number to access the selected
+                        model server Pods.
+
+                        The number must be in the range 1 to 65535.'
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  required:
+                  - number
+                  type: object
+                maxItems: 1
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - endpointPickerRef
+            - selector
+            - targetPorts
+            type: object
+          status:
+            description: Status defines the observed state of the InferencePool.
+            properties:
+              parents:
+                description: 'Parents is a list of parent resources, typically Gateways,
+                  that are associated with
+
+                  the InferencePool, and the status of the InferencePool with respect
+                  to each parent.
+
+
+                  A controller that manages the InferencePool, must add an entry for
+                  each parent it manages
+
+                  and remove the parent entry when the controller no longer considers
+                  the InferencePool to
+
+                  be associated with that parent.
+
+
+                  A maximum of 32 parents will be represented in this list. When the
+                  list is empty,
+
+                  it indicates that the InferencePool is not associated with any parents.'
+                items:
+                  description: ParentStatus defines the observed state of InferencePool
+                    from a Parent, i.e. Gateway.
+                  properties:
+                    conditions:
+                      description: 'Conditions is a list of status conditions that
+                        provide information about the observed
+
+                        state of the InferencePool. This field is required to be set
+                        by the controller that
+
+                        manages the InferencePool.
+
+
+                        Supported condition types are:
+
+
+                        * "Accepted"
+
+                        * "ResolvedRefs"'
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    parentRef:
+                      description: 'ParentRef is used to identify the parent resource
+                        that this status
+
+                        is associated with. It is used to match the InferencePool
+                        with the parent
+
+                        resource, such as a Gateway.'
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: 'Group is the group of the referent API object.
+                            When unspecified, the referent is assumed
+
+                            to be in the "gateway.networking.k8s.io" API group.'
+                          maxLength: 253
+                          minLength: 0
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: 'Kind is the kind of the referent API object.
+                            When unspecified, the referent is assumed
+
+                            to be a "Gateway" kind.'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent API object.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: 'Namespace is the namespace of the referenced
+                            object. When unspecified, the local
+
+                            namespace is inferred.
+
+
+                            Note that when a namespace different than the local namespace
+                            is specified,
+
+                            a ReferenceGrant object is required in the referent namespace
+                            to allow that
+
+                            namespace''s owner to accept the reference. See the ReferenceGrant
+
+                            documentation for details: https://gateway-api.sigs.k8s.io/api-types/referencegrant/'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: unapproved, experimental-only
+    inference.networking.k8s.io/bundle-version: v1.0.1
+  name: inferencepools.inference.networking.x-k8s.io
+spec:
+  group: inference.networking.x-k8s.io
+  names:
+    kind: InferencePool
+    listKind: InferencePoolList
+    plural: inferencepools
+    shortNames:
+    - xinfpool
+    singular: inferencepool
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: InferencePool is the Schema for the InferencePools API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: InferencePoolSpec defines the desired state of InferencePool
+            properties:
+              extensionRef:
+                description: Extension configures an endpoint picker as an extension
+                  service.
+                properties:
+                  failureMode:
+                    default: FailClose
+                    description: 'Configures how the gateway handles the case when
+                      the extension is not responsive.
+
+                      Defaults to failClose.'
+                    enum:
+                    - FailOpen
+                    - FailClose
+                    type: string
+                  group:
+                    default: ''
+                    description: 'Group is the group of the referent.
+
+                      The default value is "", representing the Core API group.'
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    default: Service
+                    description: 'Kind is the Kubernetes resource kind of the referent.
+
+
+                      Defaults to "Service" when not specified.
+
+
+                      ExternalName services can refer to CNAME DNS records that may
+                      live
+
+                      outside of the cluster and as such are difficult to reason about
+                      in
+
+                      terms of conformance. They also may not be safe to forward to
+                      (see
+
+                      CVE-2021-25740 for more information). Implementations MUST NOT
+
+                      support ExternalName Services.'
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  portNumber:
+                    description: 'The port number on the service running the extension.
+                      When unspecified,
+
+                      implementations SHOULD infer a default value of 9002 when the
+                      Kind is
+
+                      Service.'
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                required:
+                - name
+                type: object
+              selector:
+                additionalProperties:
+                  description: 'LabelValue is the value of a label. This is used for
+                    validation
+
+                    of maps. This matches the Kubernetes label validation rules:
+
+                    * must be 63 characters or less (can be empty),
+
+                    * unless empty, must begin and end with an alphanumeric character
+                    ([a-z0-9A-Z]),
+
+                    * could contain dashes (-), underscores (_), dots (.), and alphanumerics
+                    between.
+
+
+                    Valid values include:
+
+
+                    * MyValue
+
+                    * my.name
+
+                    * 123-my-value'
+                  maxLength: 63
+                  minLength: 0
+                  pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                  type: string
+                description: 'Selector defines a map of labels to watch model server
+                  Pods
+
+                  that should be included in the InferencePool.
+
+                  In some cases, implementations may translate this field to a Service
+                  selector, so this matches the simple
+
+                  map used for Service selectors instead of the full Kubernetes LabelSelector
+                  type.
+
+                  If specified, it will be applied to match the model server pods
+                  in the same namespace as the InferencePool.
+
+                  Cross namesoace selector is not supported.'
+                type: object
+              targetPortNumber:
+                description: 'TargetPortNumber defines the port number to access the
+                  selected model server Pods.
+
+                  The number must be in the range 1 to 65535.'
+                format: int32
+                maximum: 65535
+                minimum: 1
+                type: integer
+            required:
+            - extensionRef
+            - selector
+            - targetPortNumber
+            type: object
+          status:
+            default:
+              parent:
+              - conditions:
+                - lastTransitionTime: '1970-01-01T00:00:00Z'
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                parentRef:
+                  kind: Status
+                  name: default
+            description: Status defines the observed state of InferencePool.
+            properties:
+              parent:
+                description: "Parents is a list of parent resources (usually Gateways)\
+                  \ that are\nassociated with the InferencePool, and the status of\
+                  \ the InferencePool with respect to\neach parent.\n\nA maximum of\
+                  \ 32 Gateways will be represented in this list. When the list contains\n\
+                  `kind: Status, name: default`, it indicates that the InferencePool\
+                  \ is not\nassociated with any Gateway and a controller must perform\
+                  \ the following:\n\n - Remove the parent when setting the \"Accepted\"\
+                  \ condition.\n - Add the parent when the controller will no longer\
+                  \ manage the InferencePool\n   and no other parents exist."
+                items:
+                  description: PoolStatus defines the observed state of InferencePool
+                    from a Gateway.
+                  properties:
+                    conditions:
+                      default:
+                      - lastTransitionTime: '1970-01-01T00:00:00Z'
+                        message: Waiting for controller
+                        reason: Pending
+                        status: Unknown
+                        type: Accepted
+                      description: 'Conditions track the state of the InferencePool.
+
+
+                        Known condition types are:
+
+
+                        * "Accepted"
+
+                        * "ResolvedRefs"'
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: 'lastTransitionTime is the last time the
+                              condition transitioned from one status to another.
+
+                              This should be when the underlying condition changed.  If
+                              that is not known, then using the time when the API
+                              field changed is acceptable.'
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message is a human readable message indicating
+                              details about the transition.
+
+                              This may be an empty string.'
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: 'observedGeneration represents the .metadata.generation
+                              that the condition was set based upon.
+
+                              For instance, if .metadata.generation is currently 12,
+                              but the .status.conditions[x].observedGeneration is
+                              9, the condition is out of date
+
+                              with respect to the current state of the instance.'
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: 'reason contains a programmatic identifier
+                              indicating the reason for the condition''s last transition.
+
+                              Producers of specific condition types may define expected
+                              values and meanings for this field,
+
+                              and whether the values are considered a guaranteed API.
+
+                              The value should be a CamelCase string.
+
+                              This field may not be empty.'
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - 'True'
+                            - 'False'
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    parentRef:
+                      description: GatewayRef indicates the gateway that observed
+                        state of InferencePool.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: Group is the group of the referent.
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: Kind is kind of the referent. For example "Gateway".
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: 'Namespace is the namespace of the referent.  If
+                            not present,
+
+                            the namespace of the referent is assumed to be the same
+                            as
+
+                            the namespace of the referring object.'
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/functions/compose-serving-stack/tests/test_fn.py
+++ b/functions/compose-serving-stack/tests/test_fn.py
@@ -279,7 +279,7 @@ _GAIE_CRDS = {
         "forProvider": {
             "chart": {
                 "name": "inferencepool",
-                "repository": "oci://ghcr.io/kubernetes-sigs/gateway-api-inference-extension/charts",
+                "repository": "oci://registry.k8s.io/gateway-api-inference-extension/charts",
                 "version": "v1.0.1",
             },
             "namespace": "gateway-api-inference-extension",

--- a/functions/compose-serving-stack/tests/test_fn.py
+++ b/functions/compose-serving-stack/tests/test_fn.py
@@ -696,17 +696,18 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                 ),
             ),
         )
-        req.observed.resources["cert-manager"].CopyFrom(
-            fnv1.Resource(
-                resource=resource.dict_to_struct(
-                    {
-                        "apiVersion": "helm.m.crossplane.io/v1beta1",
-                        "kind": "Release",
-                        "status": {"conditions": [{"type": "Ready", "status": "True"}]},
-                    }
+        for r in ("cert-manager", "ai-gateway-crds", "ai-gateway"):
+            req.observed.resources[r].CopyFrom(
+                fnv1.Resource(
+                    resource=resource.dict_to_struct(
+                        {
+                            "apiVersion": "helm.m.crossplane.io/v1beta1",
+                            "kind": "Release",
+                            "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+                        }
+                    ),
                 ),
-            ),
-        )
+            )
         req.observed.resources["gateway"].CopyFrom(
             fnv1.Resource(
                 resource=resource.dict_to_struct(
@@ -743,9 +744,11 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                     ),
                     "ai-gateway-crds": fnv1.Resource(
                         resource=resource.dict_to_struct(_AI_GATEWAY_CRDS),
+                        ready=fnv1.READY_TRUE,
                     ),
                     "ai-gateway": fnv1.Resource(
                         resource=resource.dict_to_struct(_AI_GATEWAY),
+                        ready=fnv1.READY_TRUE,
                     ),
                     **_gaie_crd_desired(ready=True),
                     "gateway": fnv1.Resource(

--- a/functions/compose-serving-stack/tests/test_fn.py
+++ b/functions/compose-serving-stack/tests/test_fn.py
@@ -272,24 +272,38 @@ _AI_GATEWAY = {
     },
 }
 
-_GAIE_CRDS = {
-    "apiVersion": "helm.m.crossplane.io/v1beta1",
-    "kind": "Release",
-    "spec": {
-        "forProvider": {
-            "chart": {
-                "name": "inferencepool",
-                "repository": "oci://registry.k8s.io/gateway-api-inference-extension/charts",
-                "version": "v1.0.1",
-            },
-            "namespace": "gateway-api-inference-extension",
-        },
-        "providerConfigRef": {
-            "kind": "ProviderConfig",
-            "name": _PC_NAME,
-        },
-    },
-}
+
+def _gaie_crd_desired(ready: bool) -> dict:
+    """The GAIE CRDs composed as provider-kubernetes Objects on the remote
+    cluster, built from the same vendored bundle and helper the function
+    composes so the test stays in sync. When ready is True each Object is marked
+    READY_TRUE, matching a pass where the Objects are observed Ready."""
+    out = {}
+    for doc in fn._GAIE_CRDS:
+        key = fn._gaie_crd_key(doc)
+        res = fnv1.Resource()
+        resource.update(res, fn._k8s_object(_PC_NAME, doc))
+        if ready:
+            res.ready = fnv1.READY_TRUE
+        out[key] = res
+    return out
+
+
+def _gaie_crd_observed() -> dict:
+    """Observed GAIE CRD Objects, each reporting Ready=True."""
+    out = {}
+    for doc in fn._GAIE_CRDS:
+        out[fn._gaie_crd_key(doc)] = fnv1.Resource(
+            resource=resource.dict_to_struct(
+                {
+                    "apiVersion": "kubernetes.m.crossplane.io/v1alpha1",
+                    "kind": "Object",
+                    "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+                }
+            )
+        )
+    return out
+
 
 _GATEWAY = {
     "apiVersion": "kubernetes.m.crossplane.io/v1alpha1",
@@ -607,9 +621,7 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                     "ai-gateway": fnv1.Resource(
                         resource=resource.dict_to_struct(_AI_GATEWAY),
                     ),
-                    "gaie-crds": fnv1.Resource(
-                        resource=resource.dict_to_struct(_GAIE_CRDS),
-                    ),
+                    **_gaie_crd_desired(ready=False),
                     "gateway": fnv1.Resource(
                         resource=resource.dict_to_struct(_GATEWAY),
                     ),
@@ -710,6 +722,8 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                 ),
             ),
         )
+        for key, observed in _gaie_crd_observed().items():
+            req.observed.resources[key].CopyFrom(observed)
 
         want = fnv1.RunFunctionResponse(
             meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
@@ -733,9 +747,7 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                     "ai-gateway": fnv1.Resource(
                         resource=resource.dict_to_struct(_AI_GATEWAY),
                     ),
-                    "gaie-crds": fnv1.Resource(
-                        resource=resource.dict_to_struct(_GAIE_CRDS),
-                    ),
+                    **_gaie_crd_desired(ready=True),
                     "gateway": fnv1.Resource(
                         resource=resource.dict_to_struct(_GATEWAY),
                     ),


### PR DESCRIPTION
Fixes #157.
Fixes #158.

The serving stack's Gateway API Inference Extension (GAIE) install, added in #142, can't complete, so a freshly provisioned InferenceCluster never reaches `Ready` and no model can be scheduled onto it. Three problems, found while bringing up an EKS-backed cluster end to end.

First, the `inferencepool` chart was pulled from `oci://ghcr.io/kubernetes-sigs/gateway-api-inference-extension/charts`, which denies anonymous pulls — its token endpoint returns 403. provider-helm can't fetch the chart, so the Release never installs. GAIE publishes the chart for public consumption on `registry.k8s.io`, which serves it anonymously, so this points the repo there.

Second, with the registry corrected, the install still fails: the `inferencepool` chart ships no CRDs. It renders a running InferencePool instance plus its endpoint picker and requires `inferencePool.modelServers.matchLabels`, which the serving stack doesn't set, so the render errors out. The CRDs the serving stack actually wants live in the upstream release's `manifests.yaml`. This vendors them into the function and applies them as provider-kubernetes Objects on the remote cluster, the same way `compose-inference-gateway` installs the Gateway API CRDs that the Traefik chart likewise doesn't ship. The upstream manifests are a live-cluster export carrying a top-level `status` and `metadata.creationTimestamp`; those are stripped from the vendored copy (with a header note for re-vendoring) so the Object doesn't re-apply every reconcile and trip the composite's watch circuit breaker.

Third, the `ai-gateway-crds` and `ai-gateway` releases were composed but never marked ready — they weren't in `mark_readiness`'s list. So even with every release and object healthy on the cluster, the ServingStack's readiness aggregation waited on them forever and the InferenceCluster never reached `Ready`. This adds them to the list.

The first two unmask each other in sequence (the registry fix reveals the chart-content problem); the third was hidden behind both. Each maps to its own commit.

Validated end to end on an EKS-backed InferenceCluster: with all three fixes the GAIE CRDs install and settle, the serving stack converges, and the InferenceCluster reaches `Ready=True`.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.

