### PR TITLE
Gate serving-stack Gateway readiness on its LoadBalancer address

### DIFF
--- a/functions/compose-serving-stack/function/fn.py
+++ b/functions/compose-serving-stack/function/fn.py
@@ -33,6 +33,19 @@ from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
 # Label key for composed resources that need deletion ordering via Usages.
 _LABEL_RESOURCE = "modelplane.ai/resource"
 
+# CEL readiness query for the Envoy Gateway Object. The Gateway's LoadBalancer
+# address is assigned asynchronously by the controller after the Object is
+# applied. With the default SuccessfulCreate policy the Object is Ready the
+# instant it's created, so provider-kubernetes' poll-interval hook re-observes
+# it only on the slow (10m) drift poll - leaving status.atProvider.manifest
+# frozen at a pre-address snapshot, and the downstream scheduler with no gateway
+# address, for up to ~10m. Gating readiness on status.addresses keeps the Object
+# un-Ready until the address is observed, which drops the poll to ~30s so the
+# address propagates promptly. `object` is the observed Gateway manifest; the
+# has() guard keeps the query false (not erroring) before the controller first
+# writes status.addresses.
+_GATEWAY_READY_CEL = "has(object.status.addresses) && object.status.addresses.size() > 0"
+
 # Secret types that couple compose-gke-cluster (writer) to this function
 # (reader) via the InferenceCluster status.
 _SECRET_TYPE_KUBECONFIG = "Kubeconfig"
@@ -123,8 +136,18 @@ def _k8s_object(
     manifest: dict,
     metadata: metav1.ObjectMeta | None = None,
     management_policies: list | None = None,
+    *,
+    cel_query: str | None = None,
 ) -> k8sobjv1alpha1.Object:
-    """Build a provider-kubernetes Object wrapping an arbitrary manifest."""
+    """Build a provider-kubernetes Object wrapping an arbitrary manifest.
+
+    Readiness defaults to SuccessfulCreate (the Object is Ready once applied),
+    which suits resources with no meaningful runtime readiness. Pass cel_query
+    for an Object whose readiness must reflect a controller-populated field of
+    the observed manifest - it selects the DeriveFromCelQuery policy with that
+    query (see _GATEWAY_READY_CEL), which also keeps provider-kubernetes
+    re-observing on its fast poll until the query passes.
+    """
     obj = k8sobjv1alpha1.Object(
         # Only set metadata when present. Under exclude_unset serialization,
         # passing metadata=None would emit a null metadata into the composed
@@ -142,6 +165,11 @@ def _k8s_object(
     )
     if management_policies:
         obj.spec.managementPolicies = management_policies
+    if cel_query is not None:
+        obj.spec.readiness = k8sobjv1alpha1.Readiness(
+            policy="DeriveFromCelQuery",
+            celQuery=cel_query,
+        )
     return obj
 
 
@@ -717,6 +745,7 @@ class Composer:
                         },
                     },
                     metadata=metav1.ObjectMeta(labels={_LABEL_RESOURCE: "gateway"}),
+                    cel_query=_GATEWAY_READY_CEL,
                 ),
             )
 

--- a/functions/compose-serving-stack/tests/test_fn.py
+++ b/functions/compose-serving-stack/tests/test_fn.py
@@ -339,6 +339,10 @@ _GATEWAY = {
             "kind": "ProviderConfig",
             "name": _PC_NAME,
         },
+        "readiness": {
+            "policy": "DeriveFromCelQuery",
+            "celQuery": fn._GATEWAY_READY_CEL,
+        },
     },
 }
 
@@ -679,8 +683,89 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
             "-want, +got",
         )
 
+    async def test_gateway_gated_on_address(self) -> None:
+        """The Gateway Object carries the DeriveFromCelQuery readiness, and is
+        only marked ready once provider-kubernetes reports Ready=True (which it
+        derives from the address-gating CEL query). This keeps the Object on the
+        fast re-observe poll until the LoadBalancer address is observed, instead
+        of freezing at a pre-address snapshot on the slow drift poll (#121)."""
+        req = _base_request()
+        req.observed.resources["provider-config-helm"].CopyFrom(
+            fnv1.Resource(
+                resource=resource.dict_to_struct(
+                    {"apiVersion": "helm.m.crossplane.io/v1beta1", "kind": "ProviderConfig"}
+                ),
+            ),
+        )
+        req.observed.resources["provider-config-kubernetes"].CopyFrom(
+            fnv1.Resource(
+                resource=resource.dict_to_struct(
+                    {"apiVersion": "kubernetes.m.crossplane.io/v1alpha1", "kind": "ProviderConfig"}
+                ),
+            ),
+        )
+
+        # Before the address is observed there's no Ready condition: the desired
+        # Gateway Object must not be marked ready, and no address is surfaced.
+        req.observed.resources["gateway"].CopyFrom(
+            fnv1.Resource(
+                resource=resource.dict_to_struct(
+                    {"apiVersion": "kubernetes.m.crossplane.io/v1alpha1", "kind": "Object"}
+                ),
+            ),
+        )
+        got = await self.runner.RunFunction(req, None)
+        self.assertEqual(
+            got.desired.resources["gateway"].ready,
+            fnv1.READY_UNSPECIFIED,
+            "gateway must not be ready before its address is observed",
+        )
+        self.assertEqual(
+            resource.struct_to_dict(got.desired.resources["gateway"].resource)["spec"]["readiness"],
+            {"policy": "DeriveFromCelQuery", "celQuery": fn._GATEWAY_READY_CEL},
+            "gateway Object must gate readiness on its address via CEL",
+        )
+        self.assertNotIn(
+            "gateway",
+            resource.struct_to_dict(got.desired.composite.resource).get("status", {}),
+            "no gateway address should be surfaced before it's observed",
+        )
+
+        # Once provider-kubernetes derives Ready=True from the CEL query (the
+        # address is now in the observed manifest), the Object is marked ready
+        # and the address propagates to the XR status.
+        req.observed.resources["gateway"].CopyFrom(
+            fnv1.Resource(
+                resource=resource.dict_to_struct(
+                    {
+                        "apiVersion": "kubernetes.m.crossplane.io/v1alpha1",
+                        "kind": "Object",
+                        "status": {
+                            "conditions": [{"type": "Ready", "status": "True"}],
+                            "atProvider": {
+                                "manifest": {"status": {"addresses": [{"value": "172.18.255.200"}]}},
+                            },
+                        },
+                    }
+                ),
+            ),
+        )
+        got = await self.runner.RunFunction(req, None)
+        self.assertEqual(
+            got.desired.resources["gateway"].ready,
+            fnv1.READY_TRUE,
+            "gateway must be ready once provider-kubernetes observes the address",
+        )
+        self.assertEqual(
+            resource.struct_to_dict(got.desired.composite.resource)["status"]["gateway"]["address"],
+            "172.18.255.200",
+            "gateway address must surface to the XR status once observed",
+        )
+
     async def test_third_pass(self) -> None:
-        """Steady state: observed readiness propagates and the gateway address is surfaced."""
+        """Steady state: composed releases report Ready, and the gateway address is
+        surfaced from the observed Object's manifest. The observed gateway Object
+        carries no Ready condition here, so the gateway Object itself stays unready."""
         req = _base_request()
         req.observed.resources["provider-config-helm"].CopyFrom(
             fnv1.Resource(
@@ -751,6 +836,9 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                         ready=fnv1.READY_TRUE,
                     ),
                     **_gaie_crd_desired(ready=True),
+                    # The Gateway Object's observed manifest carries the
+                    # address, so write_status surfaces it - but the observed
+                    # Object has no Ready condition here, so it stays unready.
                     "gateway": fnv1.Resource(
                         resource=resource.dict_to_struct(_GATEWAY),
                     ),


### PR DESCRIPTION
### Description of your changes

Fixes #121

On a fresh `InferenceCluster` a `ModelDeployment` never schedules — it sits at `ReplicasScheduled=False / InsufficientCapacity` because the cluster's `status.gateway.address` is never populated, even though the live Envoy `Gateway` on the workload cluster has had its address the whole time.

`compose-serving-stack` wraps the Gateway in a provider-kubernetes `Object` with the default `readiness.policy: SuccessfulCreate`, so it's `Ready` the instant it's applied. provider-kubernetes only re-observes an `Object`'s manifest on its fast (~30s) poll while the Object is *not* `Ready`; a `Ready` Object re-observes only on the slow (~10m) drift poll. The Gateway's address is assigned asynchronously *after* the first observe, so the observed manifest stays frozen at a pre-address snapshot for up to ~10m.

This change gives the Gateway `Object` a `DeriveFromCelQuery` readiness policy gating on the observed `status.addresses`. While the address is absent the `Object` is not `Ready`, so provider-kubernetes keeps re-observing on its ~30s poll and the address propagates promptly. This mirrors the pattern `compose-model-replica` already uses.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
