### PR TITLE
Publish realized node count for non-autoscaled cluster sources

### DIFF
--- a/apis/inferenceclusters/definition.yaml
+++ b/apis/inferenceclusters/definition.yaml
@@ -257,8 +257,11 @@ spec:
                     nodes:
                       type: integer
                       description: >-
-                        Number of nodes in this pool. Derived from
-                        maxNodeCount (if autoscaling) or nodeCount.
+                        Node headroom the scheduler may place replicas against.
+                        On sources Modelplane provisions with a cluster
+                        autoscaler (GKE) this is maxNodeCount, since the pool
+                        grows on demand. On sources with no autoscaler we
+                        control (EKS, Existing) it is the realized nodeCount.
                     devices:
                       type: array
                       description: >-

--- a/functions/compose-inference-cluster/function/fn.py
+++ b/functions/compose-inference-cluster/function/fn.py
@@ -254,7 +254,9 @@ class Composer:
             if not backend_exists:
                 response.normal(self.rsp, "GKE cluster ready, composing backend")
 
-        self.write_status(self.gpu_pools())
+        # The GKE node pools we compose autoscale via GKE's managed cluster
+        # autoscaler, so maxNodeCount is reachable headroom.
+        self.write_status(self.gpu_pools(autoscaled=True))
         self.derive_conditions(cluster_ready=gke_ready)
 
     def compose_eks(self, eks):
@@ -292,7 +294,10 @@ class Composer:
             if not backend_exists:
                 response.normal(self.rsp, "EKS cluster ready, composing backend")
 
-        self.write_status(self.gpu_pools())
+        # The EKS nodegroup carries a scalingConfig, but we install no cluster
+        # autoscaler on EKS, so it never grows past its realized size (#166).
+        # Publish the realized nodeCount, not maxNodeCount.
+        self.write_status(self.gpu_pools(autoscaled=False))
         self.derive_conditions(cluster_ready=eks_ready)
 
     def compose_existing(self, existing):
@@ -315,7 +320,10 @@ class Composer:
             )
         self.compose_serving_stack(backend_secrets)
 
-        self.write_status(self.gpu_pools())
+        # A user-supplied cluster may or may not run an autoscaler, and we don't
+        # control it either way, so we can't promise maxNodeCount will be there.
+        # Publish the realized nodeCount.
+        self.write_status(self.gpu_pools(autoscaled=False))
         self.derive_conditions(cluster_ready=True)
 
     def compose_serving_stack(self, backend_secrets: list[ssv1alpha1.Secret]):
@@ -689,13 +697,21 @@ class Composer:
 
         return None
 
-    def gpu_pools(self):
+    def gpu_pools(self, autoscaled):
         """Derive status.gpuPools from each node pool's class.
 
         The class declares the node's devices (DRA-style); the pool declares how
         many nodes. We copy the class's devices verbatim so
         ModelDeployment.nodeSelector can match against them, and record the node
         count for the scheduler's available-node gate.
+
+        ``autoscaled`` says whether this cluster has a working autoscaler that
+        Modelplane wired up — the caller knows, because it's the same compose
+        path that does (or doesn't) provision one. When it does, we publish each
+        pool's maxNodeCount as the headroom the scheduler may grow into. When it
+        doesn't, maxNodeCount never materializes, so we publish the realized
+        nodeCount — otherwise the scheduler places replicas onto nodes that will
+        never exist and they hang Pending.
         """
         gpu_pools = []
         for pool in self.xr.spec.nodePools or []:
@@ -711,7 +727,7 @@ class Composer:
             gpu_pools.append(
                 {
                     "name": pool.name,
-                    "nodes": pool.maxNodeCount or pool.nodeCount,
+                    "nodes": (pool.maxNodeCount or pool.nodeCount) if autoscaled else pool.nodeCount,
                     "devices": devices,
                 }
             )

--- a/functions/compose-inference-cluster/tests/test_fn.py
+++ b/functions/compose-inference-cluster/tests/test_fn.py
@@ -256,7 +256,7 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                                 "gpuPools": [
                                     {
                                         "name": "l4-pool",
-                                        "nodes": 4,
+                                        "nodes": 2,
                                         "devices": [
                                             {
                                                 "name": "gpu",
@@ -517,7 +517,7 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                                 "gpuPools": [
                                     {
                                         "name": "l4-pool",
-                                        "nodes": 4,
+                                        "nodes": 2,
                                         "devices": [
                                             {
                                                 "name": "gpu",
@@ -675,7 +675,7 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                                 "gpuPools": [
                                     {
                                         "name": "l4-pool",
-                                        "nodes": 4,
+                                        "nodes": 2,
                                         "devices": [
                                             {
                                                 "name": "gpu",


### PR DESCRIPTION
## Problem

The fleet scheduler treats `InferenceCluster.status.gpuPools[].nodes` as the
node headroom it may place `ModelReplica`s against. `compose-inference-cluster`
derived that count as `pool.maxNodeCount or pool.nodeCount` for **every** cluster
source.

On EKS (issue #166) that overcounts. We compose the EKS managed nodegroup with a
`scalingConfig` (`min`/`max`/`desired`), but **we don't install a cluster
autoscaler on EKS**, so the nodegroup never scales past its realized size. The
scheduler, trusting `maxNodeCount`, places replicas onto nodes that will never
exist — and the pods hang `Pending` forever. `Existing` clusters have the same
problem: we don't control whatever (if any) autoscaler the user wired up.

GKE doesn't hit this only because its autoscaler is built into the managed
control plane, so `maxNodeCount` really does materialize on demand.

## Fix

Whether a pool autoscales isn't a property of the source *name* — it's a fact
about whether **we wired up a working autoscaler**. So each compose path now
declares it, right next to where it does (or doesn't) provision one:

- `compose_gke` → `gpu_pools(autoscaled=True)` (GKE's managed autoscaler)
- `compose_eks` → `gpu_pools(autoscaled=False)` (no autoscaler installed — #166)
- `compose_existing` → `gpu_pools(autoscaled=False)` (not ours to control)

`gpu_pools` then publishes `maxNodeCount` as headroom when autoscaled, and the
realized `nodeCount` otherwise. When EKS grows a cluster autoscaler, the flag
flips in the same method that wires it — not in a table decoupled from it.

Plus the XRD field doc and the EKS/Existing test expectations.

## Alternatives considered

1. **`_AUTOSCALED_SOURCES = frozenset({GKE})` constant.** Smallest change, correct
   today, but encodes "which sources autoscale" as a global decoupled from the
   code that actually does it. Someone has to remember to update it when EKS gets
   an autoscaler. Rejected in favour of the per-compose-path flag above (this was
   the first cut of this PR).
2. **Explicit per-pool field** — `NodePool.autoscaling` input or a mirrored
   `status.gpuPools[].autoscaling` bool, so `nodes` semantics stop being inferred
   at all. Also handles a fixed-size GKE pool and future mixed clusters. Bigger
   API surface; deferred unless you want it.
3. **Publish realized count from observed provider status** — read the actual
   current node count off the observed GKECluster/EKSCluster/nodepool MR instead
   of inferring it. Most truthful for "can this schedule *now*", but loses the
   "will this fit if we scale up" semantics GKE placement relies on, and lags on
   eventual consistency.
4. **Split the field into `nodes` (realized) + `maxNodes` (headroom)** and let the
   scheduler choose per its policy. Most correct, largest blast radius (scheduler
   change too).

## Open question

What's the intended contract of `status.gpuPools[].nodes` — **realized capacity**
or **headroom the pool can grow to**? It currently conflates both:

- If it's *headroom*, the honest signal is "does this pool have an autoscaler we
  control" — which is what this PR encodes (and alt 3 makes explicit in the API).
- If the scheduler really wants *realized* capacity, alt 4/5 is the deeper fix and
  GKE placement should lean on a separate headroom field.

This PR takes the headroom reading to unblock #166; happy to land alt 3 here if
we'd rather make it a first-class field.

## Test plan

- [x] `compose-inference-cluster` unit tests pass (`python -m unittest tests.test_fn`)
- [x] EKS + Existing cases now assert realized `nodeCount`; GKE cases keep `maxNodeCount`
- [x] `ruff check` / `ruff format --check` clean
- [x] `nix flake check` (CI)