### PR TITLE
Disable the HTTPRoute request timeout for model traffic

### DIFF
--- a/functions/compose-model-replica/function/backends/base.py
+++ b/functions/compose-model-replica/function/backends/base.py
@@ -136,6 +136,15 @@ ROUTE_KEY = "model-route"
 _WORKLOAD_KEY = "model-serving"
 _CLAIM_KEY = "resource-claim"
 
+# HTTPRoute request timeout for model traffic. "0s" disables it (Gateway API
+# semantics). Without an explicit timeout the gateway applies its own default
+# (Envoy's is 15s), which severs token streaming mid-generation — any response
+# longer than that dies with an incomplete-body error. LLM generation time is
+# unbounded by design (it scales with output length), so we disable the
+# request timeout and rely on the gateway's stream-idle timeout to reap
+# genuinely stuck connections.
+REQUEST_TIMEOUT = "0s"
+
 
 def workload_key(engine) -> str:
     """Response key for an engine's workload (Deployment or LeaderWorkerSet)."""
@@ -258,6 +267,7 @@ def serving_resources(replica: v1alpha1.ModelReplica, provider_config: str) -> d
             "rules": [
                 {
                     "matches": [{"path": {"type": "PathPrefix", "value": f"/{replica.metadata.namespace}/{name}/"}}],
+                    "timeouts": {"request": REQUEST_TIMEOUT},
                     "filters": [
                         {
                             "type": "URLRewrite",

--- a/functions/compose-model-replica/function/routing.py
+++ b/functions/compose-model-replica/function/routing.py
@@ -207,6 +207,7 @@ def _http_route(replica: v1alpha1.ModelReplica, name: str) -> dict:
             "rules": [
                 {
                     "matches": [{"path": {"type": "PathPrefix", "value": f"/{replica.metadata.namespace}/{name}/"}}],
+                    "timeouts": {"request": base.REQUEST_TIMEOUT},
                     "filters": [
                         {
                             "type": "URLRewrite",

--- a/functions/compose-model-replica/tests/test_backends.py
+++ b/functions/compose-model-replica/tests/test_backends.py
@@ -178,6 +178,7 @@ def _route(name):
             "rules": [
                 {
                     "matches": [{"path": {"type": "PathPrefix", "value": f"/ml-team/{name}/"}}],
+                    "timeouts": {"request": "0s"},
                     "filters": [
                         {
                             "type": "URLRewrite",
@@ -765,9 +766,12 @@ class TestDisaggregated(unittest.TestCase):
 
     def test_route_targets_inference_pool(self):
         route = self._apply()[base.ROUTE_KEY].spec.forProvider.manifest
-        ref = route["spec"]["rules"][0]["backendRefs"][0]
+        rule = route["spec"]["rules"][0]
+        ref = rule["backendRefs"][0]
         self.assertEqual(ref["kind"], "InferencePool")
         self.assertEqual(ref["name"], "r-pool")
+        # Disable the request timeout so long token streams aren't severed.
+        self.assertEqual(rule["timeouts"]["request"], "0s")
 
     def test_selects_engines_by_phase_not_name(self):
         """Roles come from each engine's phase, not its name."""

--- a/functions/compose-model-replica/tests/test_fn.py
+++ b/functions/compose-model-replica/tests/test_fn.py
@@ -277,6 +277,7 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                                                                 },
                                                             },
                                                         ],
+                                                        "timeouts": {"request": "0s"},
                                                         "filters": [
                                                             {
                                                                 "type": "URLRewrite",


### PR DESCRIPTION
## Problem

The HTTPRoutes that front a replica's serving pods (both the unified
Service-backed route in `backends/base.py` and the disaggregated
InferencePool-backed route in `routing.py`) set **no request timeout**, so the
gateway falls back to its own default. On the Envoy-based inference gateway that
default is **15s**, which severs token streaming mid-generation. Any response
longer than 15s dies with:

```
RemoteProtocolError: peer closed connection without sending complete message body
```

LLM generation time scales with output length — a 1024-token completion on an L4
runs **~60s** — so under a benchmark every long request errored and **zero
requests completed** on both the unified and disaggregated clusters.

## Diagnosis (live)

A 1024-token completion through the gateway was cut off at **exactly 15.2s**; the
HTTPRoute had no `timeouts` and there was no traffic policy. Patching the live
route with `timeouts.request: "0s"` let the same completion finish (**1014
tokens, finish_reason=stop, ~60s**).

## Fix

Set `timeouts.request: "0s"` (Gateway API semantics: disable) on both composed
routes, via a shared `REQUEST_TIMEOUT` constant. Generation time is unbounded by
design, so a fixed request deadline is the wrong tool — rely on the gateway's
stream-idle timeout to reap genuinely stuck connections.

## Alternatives considered

1. **Disable (`"0s"`, chosen)** — matches how LLM gateways are normally run;
   relies on stream-idle timeout for stuck conns.
2. **Generous fixed timeout (e.g. 600s)** — bounded, but any cap eventually
   severs a long-enough generation; just moves the cliff.
3. **Expose it on the API** (per-deployment timeout field) — more surface than
   warranted; can add later if someone needs a cap.

## Scope note

This fixes the **workload-cluster** routes through the Envoy inference gateway
(the demonstrated failure). `compose-model-service` composes a separate
control-plane HTTPRoute for a Traefik gateway; Traefik doesn't impose Envoy's
15s default, so it's left out of scope here — flag if you want it covered too.

## Test plan

- [x] `compose-model-replica` unit tests pass (36) — unified + disagg routes assert the timeout
- [x] `ruff check` clean
- [x] Verified live: long generation completes through the patched gateway
- [x] `nix flake check` (CI)