### PR TITLE
Build function images without cross-compilation or emulation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,5 @@ jobs:
 
       - name: Build and Push
         run: |
-          nix run .#build-crossplane --print-build-logs
-          nix run .#push-crossplane --print-build-logs
+          nix run .#build --print-build-logs
+          nix run .#push --print-build-logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,17 @@ on:
     branches:
       - main
   pull_request: {}
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Version tag to push the package with, e.g. v0.1.0. Leave empty to
+          push a dev version derived from git metadata. To cut a release, run
+          this workflow against the release tag (e.g. v0.1.0) with this set to
+          the same value.
+        type: string
+        required: false
+        default: ""
 
 # Cancel in-progress runs for the same PR. Runs on main are never cancelled.
 concurrency:
@@ -29,8 +39,13 @@ jobs:
       - name: Check
         run: nix flake check --print-build-logs
 
+  # Pushes the package on every push to main and on any manual run. Both push a
+  # dev version derived from git metadata unless the run supplies a tag input,
+  # which is how releases are cut - see CONTRIBUTING.md.
   push-package:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      || github.event_name == 'workflow_dispatch'
     needs: [check]
     runs-on: ubuntu-24.04
 
@@ -49,7 +64,15 @@ jobs:
           username: ${{ secrets.UP_ROBOT_ID }}
           password: ${{ secrets.UP_ROBOT_TOKEN }}
 
+      # With a tag input (a release) push that exact version; otherwise push a
+      # dev version the push app derives from git metadata.
       - name: Build and Push
         run: |
           nix run .#build --print-build-logs
-          nix run .#push --print-build-logs
+          if [ -n "${TAG}" ]; then
+            nix run .#push --print-build-logs -- --tag "${TAG}"
+          else
+            nix run .#push --print-build-logs
+          fi
+        env:
+          TAG: ${{ inputs.tag }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,26 @@ compare the resulting `RunFunctionResponse` against an expected response via
 Add new cases to the function's existing `test_fn.py`. Run `nix flake check`
 to verify they pass.
 
+### Running locally
+
+`nix run .#dev` builds the project and runs it on a local development control
+plane: a [KIND](https://kind.sigs.k8s.io/) cluster with its own OCI registry,
+created and managed by the Crossplane CLI. It builds the functions, loads the
+packages into the local registry, installs the Configuration, and points
+`kubectl` at the cluster. Iterate by editing a function and rerunning it; tear
+down with `kind delete cluster --name crossplane-modelplane`.
+
+```bash
+nix run .#dev
+```
+
+This needs a running Docker-compatible container runtime (for KIND and the local
+registry). It works on Linux and macOS: the function images are Linux images,
+but they're assembled entirely from data — a Python interpreter and dependency
+wheels fetched prebuilt, plus our own source — so they build on any host with no
+cross-compilation or emulation. The same is true of `nix run .#build-crossplane`,
+which builds the project's packages without running them.
+
 ## Working on the docs site
 
 The documentation site under `docs/` is a [Hugo](https://gohugo.io/) project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ regenerates them, so regenerate them by building after changing an XRD or
 bumping a dependency:
 
 ```bash
-nix run .#build-crossplane
+nix run .#build
 ```
 
 The build deletes and recreates the whole `schemas/python/` tree, so models for
@@ -101,23 +101,23 @@ to verify they pass.
 
 ### Running locally
 
-`nix run .#dev` builds the project and runs it on a local development control
+`nix run .#run` builds the project and runs it on a local development control
 plane: a [KIND](https://kind.sigs.k8s.io/) cluster with its own OCI registry,
 created and managed by the Crossplane CLI. It builds the functions, loads the
 packages into the local registry, installs the Configuration, and points
 `kubectl` at the cluster. Iterate by editing a function and rerunning it; tear
-down with `kind delete cluster --name crossplane-modelplane`.
+down with `nix run .#stop`.
 
 ```bash
-nix run .#dev
+nix run .#run
 ```
 
 This needs a running Docker-compatible container runtime (for KIND and the local
 registry). It works on Linux and macOS: the function images are Linux images,
 but they're assembled entirely from data — a Python interpreter and dependency
 wheels fetched prebuilt, plus our own source — so they build on any host with no
-cross-compilation or emulation. The same is true of `nix run .#build-crossplane`,
-which builds the project's packages without running them.
+cross-compilation or emulation. The same is true of `nix run .#build`, which
+builds the project's packages without running them.
 
 ## Working on the docs site
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -332,6 +332,22 @@ This makes the scheduler skip environments without a `Ready=True` condition. Whe
 The pool-fitting logic moves into a `_best_pool_fit` helper to keep `schedule()` under the branch-count lint threshold. A new `test-model-deployment-not-ready-env` case covers the skip behavior.
 ```
 
+## Releasing
+
+Releases are cut from a release branch and published by the `CI` workflow. To
+release a new minor version, e.g. `v0.1.0`:
+
+1. From the GitHub UI, create a `release-0.1` branch from `main`.
+2. Create a GitHub release targeting that branch, and let the release create the
+   tag `v0.1.0`.
+3. Run the `CI` workflow (Actions → CI → Run workflow) against the `v0.1.0` tag,
+   setting the `tag` input to `v0.1.0`.
+
+The `tag` input makes the workflow push the package with that exact version
+rather than the dev version it derives from git metadata on ordinary runs.
+Patch releases (e.g. `v0.1.1`) reuse the existing `release-0.1` branch: cut the
+release from it and run the workflow against the new tag.
+
 ## Reporting issues
 
 Open an issue with the bug report or feature request template. The Writing style

--- a/flake.nix
+++ b/flake.nix
@@ -174,6 +174,10 @@
           };
           docs-serve = apps.docsServe { };
           docs-generate = apps.docsGenerate { };
+          dev = apps.dev {
+            inherit crossplane functionsPkg;
+            dockerCredentialUp = pkgs.upbound;
+          };
         }
       );
 
@@ -213,7 +217,8 @@
               echo ""
               echo "  nix flake check               nix run .#fix"
               echo "  nix run .#build-crossplane    nix run .#push-crossplane"
-              echo "  nix run .#docs-serve          nix run .#docs-generate"
+              echo "  nix run .#dev                 nix run .#docs-serve"
+              echo "  nix run .#docs-generate"
               echo ""
             '';
           };

--- a/flake.nix
+++ b/flake.nix
@@ -164,20 +164,21 @@
         in
         {
           fix = apps.fix { };
-          build-crossplane = apps.buildCrossplane {
+          build = apps.build {
             inherit crossplane functionsPkg;
             dockerCredentialUp = pkgs.upbound;
           };
-          push-crossplane = apps.pushCrossplane {
+          push = apps.push {
             inherit crossplane version;
             dockerCredentialUp = pkgs.upbound;
           };
-          docs-serve = apps.docsServe { };
-          docs-generate = apps.docsGenerate { };
-          dev = apps.dev {
+          run = apps.run {
             inherit crossplane functionsPkg;
             dockerCredentialUp = pkgs.upbound;
           };
+          stop = apps.stop { inherit crossplane; };
+          docs-serve = apps.docsServe { };
+          docs-generate = apps.docsGenerate { };
         }
       );
 
@@ -216,9 +217,9 @@
               echo "Modelplane development shell"
               echo ""
               echo "  nix flake check               nix run .#fix"
-              echo "  nix run .#build-crossplane    nix run .#push-crossplane"
-              echo "  nix run .#dev                 nix run .#docs-serve"
-              echo "  nix run .#docs-generate"
+              echo "  nix run .#build               nix run .#push"
+              echo "  nix run .#run                 nix run .#stop"
+              echo "  nix run .#docs-serve          nix run .#docs-generate"
               echo ""
             '';
           };

--- a/flake.nix
+++ b/flake.nix
@@ -79,14 +79,6 @@
         "aarch64-darwin"
       ];
 
-      # Function images contain Linux Python interpreters. They can only be
-      # built on Linux hosts. macOS users can still use apps, checks, and the
-      # dev shell.
-      linuxSystems = [
-        "x86_64-linux"
-        "aarch64-linux"
-      ];
-
       # Semantic version for packages. Uses buildVersion if set by CI,
       # otherwise generates a dev version from git metadata.
       version =
@@ -133,32 +125,33 @@
 
       # Build the docs site with nix build .#docs.
       #
-      # Function runtime images contain Linux Python interpreters, so they only
-      # build on Linux: build individual images with nix build .#<function>-<arch>,
+      # Function runtime images are Linux images, but they're assembled purely
+      # from data (a cached interpreter, prebuilt wheels, and our source), so
+      # they build on any host - including macOS - with no cross-compilation or
+      # emulation. Build individual images with nix build .#<function>-<arch>,
       # or all of them with nix build .#functions.
       packages = forAllSystems (
-        { pkgs, system, ... }:
+        { pkgs, ... }:
         let
           docs = import ./nix/docs.nix { inherit pkgs self; };
+          functions = import ./nix/functions.nix {
+            inherit
+              pkgs
+              self
+              functionNames
+              pyproject-nix
+              uv2nix
+              pyproject-build-systems
+              ;
+          };
         in
         {
           docs = docs.site;
         }
-        // nixpkgs.lib.optionalAttrs (builtins.elem system linuxSystems) (
-          let
-            functions = import ./nix/functions.nix {
-              inherit
-                pkgs
-                self
-                functionNames
-                pyproject-nix
-                uv2nix
-                pyproject-build-systems
-                ;
-            };
-          in
-          functions.images // { functions = functions.all; }
-        )
+        // functions.images
+        // {
+          functions = functions.all;
+        }
       );
 
       apps = forAllSystems (

--- a/nix.sh
+++ b/nix.sh
@@ -91,6 +91,19 @@ max-jobs = auto
 
 # Sandbox builds to prevent access to undeclared dependencies. Requires --privileged.
 sandbox = true
+
+# The nixos/nix image ships build-users-group = nixbld but has no such group,
+# which breaks any local build (nix tries to drop to a build user that doesn't
+# exist). We run nix as root in single-user mode, so clear it to build
+# in-process. Builds that fetch from the cache don't hit this; ones that build
+# derivations locally - like crossplane project build - do.
+build-users-group =
+
+# Function images are built for both Linux architectures. The build references
+# the non-host arch's interpreter and wheels - all prebuilt data, no foreign
+# code runs (see nix/functions.nix) - but those derivations carry the foreign
+# system, so Nix needs both Linux platforms enabled to realise them.
+extra-platforms = x86_64-linux aarch64-linux
 "
 
 # Only allocate a TTY if stdout is a terminal. TTY mode corrupts binary output

--- a/nix.sh
+++ b/nix.sh
@@ -4,7 +4,7 @@
 # Usage: ./nix.sh <command>
 #
 # Run './nix.sh flake show' for available apps and packages, or see flake.nix.
-# Examples: ./nix.sh flake check, ./nix.sh run .#build-crossplane, ./nix.sh develop
+# Examples: ./nix.sh flake check, ./nix.sh run .#build, ./nix.sh develop
 #
 # The first run downloads dependencies into /nix/store (cached in a Docker
 # volume). Subsequent runs reuse the cache. To reset: docker volume rm modelplane-nix

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -68,7 +68,7 @@
   #
   # docker-credential-up remains available for resolving any dependencies that
   # require registry authentication.
-  buildCrossplane =
+  build =
     {
       crossplane,
       dockerCredentialUp,
@@ -79,7 +79,7 @@
       meta.description = "Build the Crossplane project and regenerate schemas";
       program = pkgs.lib.getExe (
         pkgs.writeShellApplication {
-          name = "modelplane-build-crossplane";
+          name = "modelplane-build";
           runtimeInputs = [
             crossplane
             dockerCredentialUp
@@ -102,7 +102,7 @@
   # with its own OCI registry, managed by `crossplane project run`). This is
   # the fast local iteration loop: no real registry push - the CLI sideloads
   # packages into the local registry itself.
-  dev =
+  run =
     {
       crossplane,
       dockerCredentialUp,
@@ -113,7 +113,7 @@
       meta.description = "Build and run the project in a local dev control plane";
       program = pkgs.lib.getExe (
         pkgs.writeShellApplication {
-          name = "modelplane-dev";
+          name = "modelplane-run";
           runtimeInputs = [
             crossplane
             dockerCredentialUp
@@ -135,8 +135,8 @@
     };
 
   # Push the Crossplane project to a registry. Uses a dev version tag unless
-  # --tag is passed, e.g.: nix run .#push-crossplane -- --tag v0.1.0
-  pushCrossplane =
+  # --tag is passed, e.g.: nix run .#push -- --tag v0.1.0
+  push =
     {
       crossplane,
       dockerCredentialUp,
@@ -147,7 +147,7 @@
       meta.description = "Push the Crossplane project to a registry";
       program = pkgs.lib.getExe (
         pkgs.writeShellApplication {
-          name = "modelplane-push-crossplane";
+          name = "modelplane-push";
           runtimeInputs = [
             crossplane
             dockerCredentialUp
@@ -159,6 +159,29 @@
               set -- --tag "${version}" "$@"
             fi
             crossplane project push "$@"
+          '';
+        }
+      );
+    };
+
+  # Tear down the local dev control plane created by `nix run .#run`, removing
+  # its KIND cluster and OCI registry.
+  stop =
+    { crossplane }:
+    {
+      type = "app";
+      meta.description = "Tear down the local dev control plane";
+      program = pkgs.lib.getExe (
+        pkgs.writeShellApplication {
+          name = "modelplane-stop";
+          runtimeInputs = [
+            crossplane
+            pkgs.kind
+            pkgs.docker-client
+          ];
+          inheritPath = false;
+          text = ''
+            crossplane project stop "$@"
           '';
         }
       );

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -98,6 +98,42 @@
       );
     };
 
+  # Build the project and run it in a local dev control plane (a KIND cluster
+  # with its own OCI registry, managed by `crossplane project run`). This is
+  # the fast local iteration loop: no real registry push - the CLI sideloads
+  # packages into the local registry itself.
+  dev =
+    {
+      crossplane,
+      dockerCredentialUp,
+      functionsPkg,
+    }:
+    {
+      type = "app";
+      meta.description = "Build and run the project in a local dev control plane";
+      program = pkgs.lib.getExe (
+        pkgs.writeShellApplication {
+          name = "modelplane-dev";
+          runtimeInputs = [
+            crossplane
+            dockerCredentialUp
+            pkgs.coreutils
+            pkgs.kind
+            pkgs.kubectl
+            pkgs.docker-client
+          ];
+          inheritPath = false;
+          text = ''
+            mkdir -p _output
+            rm -f _output/functions
+            ln -s ${functionsPkg} _output/functions
+
+            crossplane project run "$@"
+          '';
+        }
+      );
+    };
+
   # Push the Crossplane project to a registry. Uses a dev version tag unless
   # --tag is passed, e.g.: nix run .#push-crossplane -- --tag v0.1.0
   pushCrossplane =

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -48,9 +48,9 @@
     );
   };
 
-  # Build the Crossplane project. On Linux, materialises Nix-built function
-  # runtime images into _output/functions/ before invoking the CLI. The CLI
-  # loads them via the Tarball function source in crossplane-project.yaml.
+  # Build the Crossplane project. Materialises the Nix-built function runtime
+  # images into _output/functions/ before invoking the CLI, which loads them
+  # via the Tarball function source in crossplane-project.yaml.
   #
   # This is also the schema generation entrypoint. crossplane project build
   # generates the Pydantic models under schemas/python/ from both the XRDs in
@@ -86,23 +86,14 @@
             pkgs.coreutils
           ];
           inheritPath = false;
-          text =
-            (
-              if functionsPkg != null then
-                ''
-                  mkdir -p _output
-                  rm -f _output/functions
-                  ln -s ${functionsPkg} _output/functions
-                ''
-              else
-                ''
-                  echo "Note: function image builds are only supported on Linux." >&2
-                ''
-            )
-            + ''
-              rm -rf schemas
-              crossplane project build "$@"
-            '';
+          text = ''
+            mkdir -p _output
+            rm -f _output/functions
+            ln -s ${functionsPkg} _output/functions
+
+            rm -rf schemas
+            crossplane project build "$@"
+          '';
         }
       );
     };

--- a/nix/functions.nix
+++ b/nix/functions.nix
@@ -1,7 +1,24 @@
 # OCI image tarballs for each composition function.
 #
-# Builds one image per (function, architecture) pair using uv2nix. The uv.lock
-# at the workspace root is the source of truth for Python dependencies.
+# Builds one image per (function, architecture) pair. The uv.lock at the
+# workspace root is the source of truth for Python dependencies.
+#
+# Images are assembled without running the target-arch Python, so any arch's
+# image builds on any host - Linux x86, Linux arm, or macOS - with no
+# cross-compilation and no QEMU emulation. For a given architecture we
+# reference:
+#
+#   * the target-arch CPython, a Nix store path substituted from cache.nixos.org
+#   * the target-arch wheels, fixed-output downloads from PyPI (uv.lock pins
+#     their hashes)
+#   * our own pure-Python source (the function and the generated schemas)
+#
+# We assemble these into a site-packages tree with `uv pip install`, passing
+# --python-platform to target the image's arch rather than the build host's. uv
+# selects and lays out wheels by reading their metadata - it never runs the
+# target interpreter - so the build needs no cross-compilation or QEMU.
+# --no-deps and --offline with the exact wheels uv2nix resolved keep it pinned
+# and hermetic.
 #
 # The resulting tarballs are consumed by `crossplane project build` via the
 # Tarball function source in crossplane-project.yaml.
@@ -14,6 +31,8 @@
   pyproject-build-systems,
 }:
 let
+  inherit (pkgs) lib;
+
   architectures = [
     "amd64"
     "arm64"
@@ -24,39 +43,54 @@ let
     "arm64" = "aarch64-linux";
   };
 
+  archToUvArch = {
+    "amd64" = "x86_64";
+    "arm64" = "aarch64";
+  };
+
+  pythonVersion = "3.12";
+
+  # uv's --python-platform for a target arch, e.g. "x86_64-manylinux_2_40". The
+  # glibc baseline is taken from the interpreter we actually ship, so uv accepts
+  # every wheel that interpreter can load (manylinux tags <= our glibc). Some
+  # deps, e.g. google-re2, only publish wheels for a fairly recent glibc.
+  uvPlatform =
+    targetPkgs: arch:
+    let
+      glibc = lib.versions.majorMinor targetPkgs.stdenv.cc.libc.version;
+    in
+    "${archToUvArch.${arch}}-manylinux_${lib.replaceStrings [ "." ] [ "_" ] glibc}";
+
+  # uv runs on the build host, so take it from the host package set.
+  inherit (pkgs.unstable) uv;
+
   workspace = uv2nix.lib.workspace.loadWorkspace { workspaceRoot = self; };
 
-  # Build a Python package set for a given architecture. Uses pkgsCross when
-  # the target differs from the host so the Python interpreter matches the
-  # target while build tools (hatchling etc.) run on the host.
+  # A uv2nix package set for the target arch's nixpkgs. We use it only as data:
+  # to resolve each function's dependency closure and reference the target-arch
+  # CPython and wheel sources. We never call mkVirtualEnv.
   #
-  # Uses overlays.wheel (not overlays.default) because the default overlay
-  # builds hatchling from source, which is missing pathspec as a native build
-  # input for cross-compilation targets.
+  # overlays.wheel (not overlays.default) so dependencies resolve to prebuilt
+  # wheels rather than sdists that would need building.
   pythonSetForArch =
     arch:
     let
       targetSystem = archToNixSystem.${arch};
       targetPkgs =
-        if targetSystem == pkgs.system then
-          pkgs
-        else
-          pkgs.pkgsCross.${
-            {
-              "x86_64-linux" = "gnu64";
-              "aarch64-linux" = "aarch64-multiplatform";
-            }
-            .${targetSystem}
-          };
+        if targetSystem == pkgs.system then pkgs else import pkgs.path { system = targetSystem; };
     in
-    (targetPkgs.callPackage pyproject-nix.build.packages { python = targetPkgs.python312; })
-    .overrideScope
-      (
-        pkgs.lib.composeManyExtensions [
-          pyproject-build-systems.overlays.wheel
-          (workspace.mkPyprojectOverlay { sourcePreference = "wheel"; })
-        ]
-      );
+    {
+      inherit targetPkgs;
+      set =
+        (targetPkgs.callPackage pyproject-nix.build.packages { python = targetPkgs.python312; })
+        .overrideScope
+          (
+            lib.composeManyExtensions [
+              pyproject-build-systems.overlays.wheel
+              (workspace.mkPyprojectOverlay { sourcePreference = "wheel"; })
+            ]
+          );
+    };
 
   etcPasswd = pkgs.writeTextDir "etc/passwd" ''
     root:x:0:0:root:/root:/sbin/nologin
@@ -67,26 +101,92 @@ let
     nonroot:x:65532:
   '';
 
+  # Host Python carrying the build backends our workspace packages declare
+  # (uv_build for the functions, hatchling for crossplane-models). With
+  # --no-build-isolation, uv imports them from here instead of building an
+  # isolated env.
+  buildBackends = pkgs.python312.withPackages (ps: [
+    ps.uv-build
+    ps.hatchling
+  ]);
+
+  # Build a function's site-packages tree with a single `uv pip install`. uv2nix
+  # gives us the resolved closure: prebuilt wheels for third-party deps, source
+  # trees for our own workspace members (which uv builds from their backends).
+  mkSitePackages =
+    { name, arch }:
+    let
+      inherit (pythonSetForArch arch) targetPkgs set;
+      resolved = set.resolveVirtualEnv { ${name} = [ ]; };
+
+      # A package's src is a prebuilt wheel or a source tree, which uv takes on
+      # the command line differently: a wheel must be staged under its original
+      # filename (the Nix store hash prefix breaks uv's version parsing), a
+      # source tree is passed as-is.
+      isWheel = p: (p ? src) && (p.src ? name);
+      wheels = map (p: p.src) (builtins.filter isWheel resolved);
+      sources = map (p: p.src) (builtins.filter (p: !isWheel p) resolved);
+      python = targetPkgs.python312;
+    in
+    pkgs.runCommand "${name}-${arch}-site-packages"
+      {
+        nativeBuildInputs = [ uv ];
+      }
+      ''
+        # Stage wheels under their original filenames (see isWheel).
+        mkdir wheels
+        ${lib.concatMapStringsSep "\n" (w: "cp ${w} wheels/${w.name}") wheels}
+
+        mkdir -p $out
+        export HOME=$TMPDIR
+        # Make the build backends importable for the --no-build-isolation
+        # source builds.
+        export PYTHONPATH=${buildBackends}/${buildBackends.sitePackages}
+
+        # --python points at the target interpreter so uv reads its install
+        # layout (paths, site-packages) from there rather than the Python-less
+        # sandbox; --python-platform selects the wheels.
+        uv pip install \
+          --no-deps --offline --no-cache --link-mode=copy \
+          --no-build-isolation \
+          --python ${python}/bin/python${pythonVersion} \
+          --python-platform ${uvPlatform targetPkgs arch} \
+          --target $out \
+          wheels/*.whl ${lib.concatStringsSep " " (map toString sources)}
+      '';
+
   mkFunctionImage =
     { name, arch }:
     let
-      venv = (pythonSetForArch arch).mkVirtualEnv "${name}-env" {
-        ${name} = [ ];
-      };
+      inherit (pythonSetForArch arch) targetPkgs;
+      sitePackages = mkSitePackages { inherit name arch; };
+      python = targetPkgs.python312;
     in
     pkgs.dockerTools.buildLayeredImage {
       name = "${name}-${arch}";
       tag = "latest";
       architecture = arch;
       contents = [
-        venv
+        python
+        sitePackages
+        targetPkgs.stdenv.cc.cc.lib # libstdc++.so.6, libgcc_s.so.1 for wheels
         etcPasswd
         etcGroup
       ];
       config = {
-        Entrypoint = [ "${venv}/bin/function" ];
+        Entrypoint = [
+          "${python}/bin/python${pythonVersion}"
+          "-m"
+          "function.main"
+        ];
         User = "nonroot:nonroot";
         WorkingDir = "/";
+        Env = [
+          "PYTHONPATH=${sitePackages}"
+          # The manylinux wheels' extensions carry no RPATH, so their libs need
+          # to be on the loader path. The interpreter finds its own via RPATH.
+          "LD_LIBRARY_PATH=${lib.makeLibraryPath [ targetPkgs.stdenv.cc.cc.lib ]}"
+        ];
         ExposedPorts = {
           "9443/tcp" = { };
         };

--- a/skills/crossplane-python-functions/SKILL.md
+++ b/skills/crossplane-python-functions/SKILL.md
@@ -77,8 +77,8 @@ is sufficient — Crossplane sees the new digests and updates the Functions
 automatically:
 
 ```bash
-nix run .#build-crossplane
-nix run .#push-crossplane              # auto-generates v0.1.0-dev.<count>.g<hash>
+nix run .#build
+nix run .#push                         # auto-generates v0.1.0-dev.<count>.g<hash>
 kubectl patch configuration <name> --type=merge \
   -p '{"spec":{"package":"xpkg.upbound.io/<org>/<project>:<tag>"}}'
 ```


### PR DESCRIPTION
### Description of your changes

Fixes #168.
Unblocks #151.

CI's `push-package` job took ~2 hours on every run. Building the arm64 function images on the x86_64 runner used `pkgsCross`, whose derivations don't match what Hydra builds, so they missed `cache.nixos.org` and compiled CPython and its whole native closure from source. Function images could also only be built on Linux, since assembling a venv runs the target-arch interpreter.

A function image needs nothing that must *run* target-arch code to assemble — the interpreter and dependency wheels are prebuilt, and the function code is pure Python. This builds each image's `site-packages` from those prebuilt parts with a single `uv pip install`, passing `--python-platform` to target the image's arch rather than the build host's. uv lays out wheels by reading their metadata, never executing the target interpreter, so images for any architecture build on any host (Linux x86_64, Linux aarch64, or macOS) with no cross-compilation and no QEMU emulation. The multi-arch CI build now takes seconds rather than hours.

This also enables the local-dev and release workflows that #151 needs:

- `nix run .#run` builds the project and runs it on a local dev control plane (a KIND cluster with its own registry, via `crossplane project run`), with `nix run .#stop` to tear it down. The edit→test loop needs no real registry.
- The CI workflow gains an optional `tag` input so releases can be cut by running it against a release tag; ordinary runs still push a dev version.

The project apps are renamed to match the Crossplane CLI verbs (`build`, `push`, `run`, plus the new `stop`).

The commits are independent and best reviewed in order: the build-system change, then the dev app, the rename, and the release support.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~ No composition function logic changed; this is build tooling.
- [x] Signed off every commit with `git commit -s`.
