### PR TITLE
Build function image wheels on the build host, not the target arch

### DIFF
--- a/nix/functions.nix
+++ b/nix/functions.nix
@@ -141,7 +141,17 @@ let
         };
       wheels = map (p: hostWheel p.src) (builtins.filter isWheel resolved);
       sources = map (p: p.src) (builtins.filter (p: !isWheel p) resolved);
-      python = targetPkgs.python312;
+
+      # uv needs an interpreter it can run, to resolve the install and to build
+      # our pure-Python source packages under --no-build-isolation. It must not
+      # be the target arch's interpreter: uv queries it by executing it, which
+      # fails (Exec format error) when the target arch isn't the build host's
+      # and there's no emulation. We use the build host's CPython instead, of
+      # the same minor version as the target's, and let --python-platform and
+      # --python-version describe the target. --target writes a flat layout that
+      # doesn't depend on the resolving interpreter's install scheme, so the
+      # result is the same wherever it's built.
+      hostPython = pkgs.python312;
     in
     pkgs.runCommand "${name}-${arch}-site-packages"
       {
@@ -158,14 +168,15 @@ let
         # source builds.
         export PYTHONPATH=${buildBackends}/${buildBackends.sitePackages}
 
-        # --python points at the target interpreter so uv reads its install
-        # layout (paths, site-packages) from there rather than the Python-less
-        # sandbox; --python-platform selects the wheels.
+        # --python is the build-host interpreter uv runs to resolve the install;
+        # --python-platform and --python-version describe the target image's
+        # arch and Python, selecting the wheels uv lays out.
         uv pip install \
           --no-deps --offline --no-cache --link-mode=copy \
           --no-build-isolation \
-          --python ${python}/bin/python${pythonVersion} \
+          --python ${hostPython}/bin/python${pythonVersion} \
           --python-platform ${uvPlatform targetPkgs arch} \
+          --python-version ${pythonVersion} \
           --target $out \
           wheels/*.whl ${lib.concatStringsSep " " (map toString sources)}
       '';

--- a/nix/functions.nix
+++ b/nix/functions.nix
@@ -124,7 +124,22 @@ let
       # filename (the Nix store hash prefix breaks uv's version parsing), a
       # source tree is passed as-is.
       isWheel = p: (p ? src) && (p.src ? name);
-      wheels = map (p: p.src) (builtins.filter isWheel resolved);
+
+      # uv2nix builds each wheel's src with the target arch's fetchurl, so the
+      # download derivation carries system = the target arch. A wheel download is
+      # a fixed-output derivation - content-addressed and byte-identical on every
+      # system - but Nix still refuses to *build* one whose system doesn't match
+      # the host. On an x86_64 host with no aarch64 substitute available that
+      # leaves the arm64 image unbuildable. Re-fetch each wheel with the host's
+      # fetchurl, preserving name, url, and hash: same output path, but a
+      # derivation that builds on whatever host we're on.
+      hostWheel =
+        src:
+        pkgs.fetchurl {
+          inherit (src) name url;
+          hash = src.outputHash;
+        };
+      wheels = map (p: hostWheel p.src) (builtins.filter isWheel resolved);
       sources = map (p: p.src) (builtins.filter (p: !isWheel p) resolved);
       python = targetPkgs.python312;
     in


### PR DESCRIPTION
### Description of your changes

The `push-package` job fails building the arm64 function images on the x86_64 CI runner ([failed run](https://github.com/modelplaneai/modelplane/actions/runs/27722149409/job/82010382835)). There are two distinct cross-arch problems, both of which this PR fixes.

**1. Wheel downloads stamped with the target system.** Since #181 we assemble each function image from prebuilt parts so that any arch's image builds on any host. To get a target arch's wheels we import nixpkgs for that system and use uv2nix as data. But uv2nix builds each wheel's `src` with the target arch's `fetchurl`, so the download derivation is stamped with the target `system`:

```
error: Cannot build '...-annotated_types-0.7.0-py3-none-any.whl.drv'.
       Reason: platform mismatch
       Required system: 'aarch64-linux'
       Current system: 'x86_64-linux'
```

A wheel download is a fixed-output derivation — content-addressed and byte-identical on every system — but Nix still refuses to *build* one whose `system` doesn't match the host unless it can substitute it from a cache. On the x86_64 runner the aarch64 wheel wasn't cached, so Nix tried to build it and hit the platform check. The first commit re-fetches each wheel with the build host's `fetchurl`, preserving its `name`, `url`, and `hash`. Because the derivation is fixed-output the result is the same store path the target-arch site-packages already references, just stamped with the build host's system.

**2. uv executing the target arch's interpreter.** With the first fix in place the next cross-arch problem appears:

```
error: Failed to inspect Python interpreter from provided path at '...-python3-3.12.13/bin/python3.12'
  Caused by: Exec format error (os error 8)
```

We assemble each image's site-packages with `uv pip install`, passing `--python` so uv knows the layout to install into. We passed the target arch's interpreter, on the assumption uv only reads it as data. It doesn't — uv inspects an interpreter by executing it, which needs emulation when the target arch isn't the host's. This passed locally only because my host had QEMU binfmt registered, transparently running the cross-arch interpreter, which is exactly the emulation this build is meant to avoid. The second commit passes the build host's own CPython to `--python` (same minor version as the target) and adds `--python-version` alongside the existing `--python-platform` so uv still selects the target's wheels. `--target` writes a flat layout independent of the resolving interpreter's install scheme, so the result is identical wherever it's built, with no emulation. I verified the cross-built amd64 site-packages contains genuine x86-64 ELF extensions.

The commits are independent and best reviewed in order.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~ No composition function logic changed; this is build tooling.
- [x] Signed off every commit with `git commit -s`.
