### PR TITLE
Free disk space before building and pushing the package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,19 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      # Building and pushing the package needs more disk than the runner has
+      # free by default, so reclaim space we don't use.
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          tool-cache: true
+          swap-storage: false
+          large-packages: false
+          docker-images: false
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
### Description of your changes

The `push-package` job fails with `No space left on device` while building the package — see [run 27733270322](https://github.com/modelplaneai/modelplane/actions/runs/27733270322). The `ubuntu-24.04` runner ships with several preinstalled toolchains we don't use, leaving too little free disk for the Nix build.

This adds a `Cleanup Disk` step (using [`jlumbroso/free-disk-space`](https://github.com/jlumbroso/free-disk-space), the same action crossplane/crossplane uses) before checkout. It removes the Android, .NET, and Haskell runtimes and the runner tool cache, reclaiming over 20GB. The job builds an OCI package with Nix and doesn't use Docker images, swap, or apt packages, so those slower options stay disabled.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~ This only changes a GitHub Actions workflow.
- [ ] ~Added or updated tests covering any composition function changes.~ No composition function changes.
- [x] Signed off every commit with `git commit -s`.
