### PR TITLE
Constrain ModelDeployment placement to its ModelCache footprint

### DIFF
--- a/docs/content/models/model-cache.md
+++ b/docs/content/models/model-cache.md
@@ -29,7 +29,11 @@ Each cache has:
   (`Dragonfly` for P2P distribution, `OCI` for NIM-style bundled artifacts).
 - An optional **clusterSelector** to scope replication. Omitting
   `spec.clusterSelector` stages the cache on every matched cluster; setting
-  `matchLabels` restricts it to clusters carrying those labels.
+  `matchLabels` restricts it to clusters carrying those labels. A
+  `ModelDeployment` that references the cache places *new* replicas only onto
+  clusters within this footprint, so narrowing the selector also narrows where
+  replicas can land - a replica never schedules to a cluster the cache didn't
+  stage to. Replicas already running are left where they are.
 
 The cache mounts at `/mnt/models` on every consuming pod; engine container args
 should reference this path (`--model=/mnt/models` for vLLM).

--- a/docs/content/models/model-deployment.md
+++ b/docs/content/models/model-deployment.md
@@ -26,7 +26,16 @@ injected by Modelplane.
 When you create a `ModelDeployment`, the scheduler:
 
 1. Discovers all ready `InferenceClusters` (filtered by `clusterSelector` labels
-   if set).
+   if set). When the deployment references a [ModelCache]({{< ref "model-cache.md" >}})
+   via `spec.modelCacheRef`, the candidate clusters for *new* replicas are
+   further narrowed to the cache's own `clusterSelector` footprint, so a replica
+   never lands on a cluster the cache didn't stage to (where its PVC wouldn't
+   exist). Existing replicas are always retained where they're pinned. If the
+   referenced cache can't be read yet, the deployment reports
+   `ModelCacheResolved=False` and holds off placing new replicas until it
+   resolves, but keeps the replicas it already has - deleting a cache out from
+   under a running deployment doesn't tear it down, since the cache is only read
+   when weights are first staged.
 2. Derives each member's node cost: a Standalone or Leader is one pod, Workers
    are `worker.nodes` worker pods, times the engine's `copies`. A member that
    claims no devices costs no nodes.

--- a/functions/compose-model-deployment/function/fn.py
+++ b/functions/compose-model-deployment/function/fn.py
@@ -6,11 +6,14 @@ selected cluster, and creates one ModelEndpoint per replica for
 ModelService to route to.
 """
 
+import enum
+
 import grpc
 from crossplane.function import logging, request, resource, response
 from crossplane.function.proto.v1 import run_function_pb2 as fnv1
 from crossplane.function.proto.v1 import run_function_pb2_grpc as grpcv1
 from models.ai.modelplane.inferencecluster import v1alpha1 as icv1alpha1
+from models.ai.modelplane.modelcache import v1alpha1 as mcv1alpha1
 from models.ai.modelplane.modeldeployment import v1alpha1
 from models.ai.modelplane.modelendpoint import v1alpha1 as mev1alpha1
 from models.ai.modelplane.modelreplica import v1alpha1 as mrv1alpha1
@@ -21,8 +24,15 @@ from function import cel, name, scheduling
 # Condition types and reasons for the ModelDeployment XR.
 CONDITION_TYPE_REPLICAS_SCHEDULED = "ReplicasScheduled"
 CONDITION_TYPE_REPLICAS_READY = "ReplicasReady"
+# ModelCacheResolved reports whether the referenced ModelCache could be read.
+# It's independent of ReplicasScheduled: a deployment can hold retained replicas
+# (scheduled) while its cache is momentarily unresolved (not resolved).
+CONDITION_TYPE_MODEL_CACHE_RESOLVED = "ModelCacheResolved"
 
 CONDITION_REASON_NO_CLUSTERS = "NoClusters"
+CONDITION_REASON_CACHE_RESOLVED = "ModelCacheResolved"
+CONDITION_REASON_CACHE_UNRESOLVED = "ModelCacheUnresolved"
+CONDITION_REASON_CACHE_NOT_FOUND = "ModelCacheNotFound"
 CONDITION_REASON_INSUFFICIENT_CAPACITY = "InsufficientCapacity"
 CONDITION_REASON_INVALID_NODE_SELECTOR = "InvalidNodeSelector"
 CONDITION_REASON_REPLICAS_CREATED = "ReplicasCreated"
@@ -44,6 +54,38 @@ _LABEL_INDEX = "modelplane.ai/replica-index"
 # Scheme for gateway-facing URLs. Traffic between the control plane gateway
 # and remote cluster gateways uses plain HTTP; TLS terminates at the edge.
 _GATEWAY_SCHEME = "http"
+
+
+# TODO(https://github.com/crossplane/function-sdk-python/issues/217): Replace
+# Resolution and resolve_required with the SDK helper once it lands upstream.
+class Resolution(enum.Enum):
+    """The state of a required resource the function asked Crossplane to fetch.
+
+    request.get_required_resource returns None both before Crossplane has
+    resolved a requirement and after it resolved one to nothing; only the
+    requirement key's presence in the request tells them apart (see the
+    crossplane.function.request docstring). This makes that distinction
+    explicit so callers can treat "not fetched yet" (transient, self-clearing)
+    differently from "fetched, doesn't exist" (a deleted resource or a typo).
+    """
+
+    UNRESOLVED = "unresolved"  # Crossplane hasn't fetched the requirement yet.
+    ABSENT = "absent"  # Resolved, but no resource matched.
+    PRESENT = "present"  # Resolved and found.
+
+
+def resolve_required(req, name: str) -> tuple[Resolution, dict | None]:
+    """Classify a required resource into a Resolution and its value.
+
+    Returns (PRESENT, resource) when one was found, (ABSENT, None) when the
+    requirement resolved but matched nothing, and (UNRESOLVED, None) when
+    Crossplane hasn't fetched it yet. The caller declares the requirement with
+    response.require_resources; this only reads the result back.
+    """
+    if name not in req.required_resources:
+        return Resolution.UNRESOLVED, None
+    got = request.get_required_resource(req, name)
+    return (Resolution.PRESENT, got) if got is not None else (Resolution.ABSENT, None)
 
 
 def _inference_cluster(
@@ -86,6 +128,12 @@ class Composer:
         self.clusters = []
         self.all_replicas = []
 
+        # Whether the scheduler may place NEW replicas this reconcile. Cleared
+        # when a referenced ModelCache can't be resolved: we keep retained
+        # replicas but don't spread new ones onto clusters that might be outside
+        # the (then-unknown) cache footprint. Set by resolve_inputs.
+        self.fill = True
+
     def compose(self):
         if not self.resolve_inputs():
             return
@@ -114,12 +162,36 @@ class Composer:
     def resolve_inputs(self):
         """Declare and fetch required resources. Returns False if critical
         inputs are missing."""
-        # Match all InferenceClusters by default — require_resources with no
-        # match field matches every resource of the kind — narrowing only when
-        # the user sets a clusterSelector.
+        # Candidate clusters are those matching the deployment's own
+        # clusterSelector, narrowed further to where the referenced ModelCache
+        # stages its weights. Both selectors are matchLabels (AND semantics), so
+        # the candidate set is their intersection. Constraining placement to the
+        # cache's footprint keeps a replica from landing on a cluster the cache
+        # never staged to, where its PVC wouldn't exist and the pod would be
+        # stuck on a volume mount (#186).
         clusters_match_labels = None
         if self.xr.spec.clusterSelector and self.xr.spec.clusterSelector.matchLabels:
             clusters_match_labels = dict(self.xr.spec.clusterSelector.matchLabels)
+
+        if self.xr.spec.modelCacheRef:
+            resolution, cache_match_labels = self.resolve_cache_footprint(self.xr.spec.modelCacheRef)
+            if resolution is Resolution.PRESENT:
+                # The cache resolved, so its footprint is known; merge its labels
+                # so new replicas land only where it stages. Empty labels (the
+                # cache stages everywhere) add no constraint.
+                if cache_match_labels:
+                    clusters_match_labels = {**(clusters_match_labels or {}), **cache_match_labels}
+            else:
+                # A referenced cache we couldn't read leaves the footprint
+                # unknown. Keep retained replicas where they are (retain ignores
+                # fill) but don't place new ones onto clusters the cache might
+                # not stage to; we'd risk pinning a replica outside the footprint
+                # that retain then holds. resolve_cache_footprint surfaced why;
+                # placement resumes once the cache resolves.
+                self.fill = False
+
+        # require_resources with no match field matches every resource of the
+        # kind, so an unset selector leaves all clusters as candidates.
         response.require_resources(
             self.rsp,
             name="clusters",
@@ -156,9 +228,83 @@ class Composer:
 
         return True
 
+    def resolve_cache_footprint(self, ref) -> tuple[Resolution, dict[str, str] | None]:
+        """Resolve the cluster footprint of the ModelCache named by ref.
+
+        Returns a (Resolution, matchLabels) pair:
+
+        * PRESENT - the referenced cache was read. matchLabels is its
+          clusterSelector labels, possibly empty (the cache stages everywhere).
+          New replicas may be placed.
+        * UNRESOLVED / ABSENT - the cache couldn't be read, either because
+          Crossplane hasn't fetched it yet (UNRESOLVED) or because it doesn't
+          exist (ABSENT). matchLabels is None and the footprint is unknown, so
+          the caller holds off placing new replicas.
+
+        Requires the cache by name in the deployment's own namespace, since
+        modelCacheRef points at a cache there, and sets the ModelCacheResolved
+        condition describing the outcome.
+        """
+        response.require_resources(
+            self.rsp,
+            name="cache",
+            api_version="modelplane.ai/v1alpha1",
+            kind="ModelCache",
+            match_name=ref.name,
+            namespace=self.xr.metadata.namespace,
+        )
+
+        resolution, cache_dict = resolve_required(self.req, "cache")
+        if resolution is Resolution.UNRESOLVED:
+            # Transient: Crossplane will re-call once it fetches the cache. A
+            # condition records the wait; no event, since it self-clears and one
+            # every reconcile would just be noise.
+            response.set_conditions(
+                self.rsp,
+                resource.Condition(
+                    typ=CONDITION_TYPE_MODEL_CACHE_RESOLVED,
+                    status="False",
+                    reason=CONDITION_REASON_CACHE_UNRESOLVED,
+                    message=f"Waiting for ModelCache {ref.name}",
+                ),
+            )
+            return resolution, None
+
+        if resolution is Resolution.ABSENT:
+            # The cache doesn't exist - a deleted cache, or a typo in the ref.
+            # User-actionable and persistent, so warn as well as condition.
+            response.set_conditions(
+                self.rsp,
+                resource.Condition(
+                    typ=CONDITION_TYPE_MODEL_CACHE_RESOLVED,
+                    status="False",
+                    reason=CONDITION_REASON_CACHE_NOT_FOUND,
+                    message=f"ModelCache {ref.name} not found; holding replica placement",
+                ),
+            )
+            response.warning(self.rsp, f"ModelCache {ref.name} not found; holding replica placement")
+            return resolution, None
+
+        response.set_conditions(
+            self.rsp,
+            resource.Condition(
+                typ=CONDITION_TYPE_MODEL_CACHE_RESOLVED,
+                status="True",
+                reason=CONDITION_REASON_CACHE_RESOLVED,
+            ),
+        )
+
+        cache = mcv1alpha1.ModelCache.model_validate(cache_dict)
+        if cache.spec.clusterSelector and cache.spec.clusterSelector.matchLabels:
+            return resolution, dict(cache.spec.clusterSelector.matchLabels)
+
+        # A cache with no selector stages to every cluster, so it adds no
+        # constraint beyond the deployment's own selector.
+        return resolution, {}
+
     def schedule(self):
         """Match the deployment's engines against available clusters."""
-        matched = scheduling.schedule(self.xr, self.clusters, self.all_replicas)
+        matched = scheduling.schedule(self.xr, self.clusters, self.all_replicas, fill=self.fill)
 
         # Transition: emit which clusters were matched (first time only). A
         # cluster can host several replicas, so report it once.

--- a/functions/compose-model-deployment/function/scheduling.py
+++ b/functions/compose-model-deployment/function/scheduling.py
@@ -886,6 +886,8 @@ def schedule(
     deployment: mdv1alpha1.ModelDeployment,
     clusters: list[icv1alpha1.InferenceCluster],
     all_replicas: list[mrv1alpha1.ModelReplica],
+    *,
+    fill: bool = True,
 ) -> list[Candidate]:
     """Pick clusters for a deployment's ModelReplicas.
 
@@ -893,6 +895,15 @@ def schedule(
     shortfall by spreading new replicas across clusters (packing onto fewer only
     when capacity forces it). Returns up to deployment.spec.replicas candidates,
     fewer if not enough capacity exists.
+
+    Existing replicas are always retained. fill gates only the placement of NEW
+    replicas: with fill=False the schedule is retain-only, holding steady at the
+    current placement and adding nothing. A caller passes fill=False when it
+    can't yet trust the candidate set - for instance when an input that narrows
+    the candidate clusters is unresolved, so placing new replicas now risks
+    landing them on clusters that input would have excluded. Retain never
+    consults fill: a narrowing input only ever shrinks the candidate set, so its
+    absence can't evict a pinned replica.
     """
     desired = int(deployment.spec.replicas)
     clusters_by_name = {c.metadata.name: c for c in clusters}
@@ -915,14 +926,13 @@ def schedule(
     if len(retained) > desired:
         retained = _scale_down(retained, desired)
 
-    # Build the ledger AFTER retain and scale-down: it charges the replicas in
-    # the final `retained` set (plus other deployments' replicas), and must not
-    # charge our dropped or scaled-down replicas, whose nodes are freeing up.
-    # Fill then decrements it only as it places NEW replicas.
-    ledger = _build_ledger(deployment, clusters, retained, all_replicas)
-
     placed: list[Candidate] = []
-    if len(retained) < desired:
+    if fill and len(retained) < desired:
+        # Build the ledger AFTER retain and scale-down: it charges the replicas
+        # in the final `retained` set (plus other deployments' replicas), and
+        # must not charge our dropped or scaled-down replicas, whose nodes are
+        # freeing up. Fill then decrements it only as it places NEW replicas.
+        ledger = _build_ledger(deployment, clusters, retained, all_replicas)
         placed = _fill(engines, clusters, retained, ledger, desired - len(retained))
 
     result = retained + placed

--- a/functions/compose-model-deployment/tests/test_fn.py
+++ b/functions/compose-model-deployment/tests/test_fn.py
@@ -10,6 +10,7 @@ from google.protobuf import duration_pb2 as durationpb
 from google.protobuf import json_format
 from google.protobuf import struct_pb2 as structpb
 from models.ai.modelplane.inferencecluster import v1alpha1 as icv1alpha1
+from models.ai.modelplane.modelcache import v1alpha1 as mcv1alpha1
 from models.ai.modelplane.modeldeployment import v1alpha1
 from models.ai.modelplane.modelreplica import v1alpha1 as mrv1alpha1
 from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
@@ -169,6 +170,23 @@ def _cluster(name: str, *, ready: bool = True, address: str | None = "10.0.0.1",
 _CLUSTER_A = _cluster("cluster-a")
 
 
+def _cache(name: str, *, match_labels: dict[str, str] | None = None) -> dict:
+    """Build an observed ModelCache in the ml-team namespace.
+
+    match_labels, when given, sets spec.clusterSelector.matchLabels - the
+    footprint the deployment scheduler intersects with its own selector.
+    """
+    selector = mcv1alpha1.ClusterSelector(matchLabels=match_labels) if match_labels else None
+    return mcv1alpha1.ModelCache(
+        metadata=metav1.ObjectMeta(name=name, namespace="ml-team"),
+        spec=mcv1alpha1.Spec(
+            source="HuggingFace",
+            huggingFace=mcv1alpha1.HuggingFace(repo="Qwen/Qwen2.5-7B", sizeGiB=20),
+            clusterSelector=selector,
+        ),
+    ).model_dump(exclude_none=True, mode="json")
+
+
 def _replica_status(replica: dict, *, ready: bool) -> dict:
     """Return a copy of an observed ModelReplica with a Ready condition.
 
@@ -239,12 +257,25 @@ _CLUSTER_SEL = fnv1.ResourceSelector(api_version="modelplane.ai/v1alpha1", kind=
 _REPLICA_SEL = fnv1.ResourceSelector(api_version="modelplane.ai/v1alpha1", kind="ModelReplica")
 
 
-def _req(xr: dict, *, clusters: list[dict], replicas: list[dict] | None = None, observed: dict | None = None):
+def _req(
+    xr: dict,
+    *,
+    clusters: list[dict] | None = None,
+    replicas: list[dict] | None = None,
+    observed: dict | None = None,
+    cache: dict | None = None,
+    cache_resolved_empty: bool = False,
+):
     """Build a RunFunctionRequest with the standard required_resources.
 
     clusters and replicas populate the "clusters" and "all-replicas" required
     resources respectively; both keys are always present (empty when there are
-    no items). observed populates observed.resources.
+    no items). cache, when given, populates the "cache" required resource the
+    function declares for a deployment that sets modelCacheRef.
+    cache_resolved_empty marks the "cache" requirement resolved-but-empty (the
+    key present with no items, i.e. the cache doesn't exist) - distinct from
+    omitting it, which leaves the requirement unresolved. observed populates
+    observed.resources.
     """
     req = fnv1.RunFunctionRequest(
         observed=fnv1.State(
@@ -262,13 +293,39 @@ def _req(xr: dict, *, clusters: list[dict], replicas: list[dict] | None = None, 
             req.required_resources["all-replicas"].items.append(fnv1.Resource(resource=resource.dict_to_struct(r)))
     else:
         req.required_resources["all-replicas"].SetInParent()
+    if cache is not None:
+        req.required_resources["cache"].items.append(fnv1.Resource(resource=resource.dict_to_struct(cache)))
+    elif cache_resolved_empty:
+        req.required_resources["cache"].SetInParent()
     return req
 
 
-def _want(resp: fnv1.RunFunctionResponse) -> fnv1.RunFunctionResponse:
-    """Attach the standard requirements selectors to a response."""
-    resp.requirements.resources["clusters"].CopyFrom(_CLUSTER_SEL)
+def _want(
+    resp: fnv1.RunFunctionResponse,
+    *,
+    cluster_labels: dict[str, str] | None = None,
+    cache_name: str | None = None,
+) -> fnv1.RunFunctionResponse:
+    """Attach the requirements selectors a reconcile echoes back.
+
+    cluster_labels narrows the "clusters" selector (the intersection of the
+    deployment's and the referenced cache's clusterSelectors). cache_name adds
+    the "cache" selector the function declares for a referenced ModelCache.
+    """
+    cluster_sel = fnv1.ResourceSelector(api_version="modelplane.ai/v1alpha1", kind="InferenceCluster")
+    if cluster_labels:
+        cluster_sel.match_labels.labels.update(cluster_labels)
+    resp.requirements.resources["clusters"].CopyFrom(cluster_sel)
     resp.requirements.resources["all-replicas"].CopyFrom(_REPLICA_SEL)
+    if cache_name is not None:
+        resp.requirements.resources["cache"].CopyFrom(
+            fnv1.ResourceSelector(
+                api_version="modelplane.ai/v1alpha1",
+                kind="ModelCache",
+                match_name=cache_name,
+                namespace="ml-team",
+            )
+        )
     return resp
 
 
@@ -300,6 +357,18 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
             metadata=metav1.ObjectMeta(name="my-model", namespace="ml-team"),
             spec=v1alpha1.SpecModel(
                 replicas=1,
+                modelCacheRef=v1alpha1.ModelCacheRef(name="qwen"),
+                engines=[_ENGINE],
+            ),
+        ).model_dump(exclude_none=True, mode="json")
+
+        # A cached deployment that also sets its own clusterSelector, so the
+        # scheduler intersects it with the cache's footprint.
+        xr_cached_selector = v1alpha1.ModelDeployment(
+            metadata=metav1.ObjectMeta(name="my-model", namespace="ml-team"),
+            spec=v1alpha1.SpecModel(
+                replicas=1,
+                clusterSelector=v1alpha1.ClusterSelector(matchLabels={"region": "us-east"}),
                 modelCacheRef=v1alpha1.ModelCacheRef(name="qwen"),
                 engines=[_ENGINE],
             ),
@@ -712,7 +781,7 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
             ),
             Case(
                 name="modelCacheRef is propagated onto the composed replica",
-                req=_req(xr_cached, clusters=[_CLUSTER_A]),
+                req=_req(xr_cached, clusters=[_CLUSTER_A], cache=_cache("qwen")),
                 want=_want(
                     fnv1.RunFunctionResponse(
                         meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
@@ -747,6 +816,11 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                         ),
                         conditions=[
                             fnv1.Condition(
+                                type="ModelCacheResolved",
+                                status=fnv1.STATUS_CONDITION_TRUE,
+                                reason="ModelCacheResolved",
+                            ),
+                            fnv1.Condition(
                                 type="ReplicasScheduled",
                                 status=fnv1.STATUS_CONDITION_FALSE,
                                 reason="Scheduling",
@@ -765,7 +839,225 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                             ),
                         ],
                         context=structpb.Struct(),
-                    )
+                    ),
+                    cache_name="qwen",
+                ),
+            ),
+            Case(
+                # The cache stages only to a subset of clusters; the scheduler
+                # intersects the cache's footprint with the deployment's own
+                # clusterSelector so replicas never land where the cache isn't.
+                name="cache clusterSelector is intersected with the deployment's",
+                req=_req(
+                    xr_cached_selector,
+                    clusters=[_CLUSTER_A],
+                    cache=_cache("qwen", match_labels={"tier": "gpu"}),
+                ),
+                want=_want(
+                    fnv1.RunFunctionResponse(
+                        meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
+                        desired=fnv1.State(
+                            composite=fnv1.Resource(
+                                resource=resource.dict_to_struct({"status": {"replicas": {"total": 1, "ready": 0}}}),
+                            ),
+                            resources={
+                                "replica-cluster-a-0": fnv1.Resource(
+                                    resource=resource.dict_to_struct(
+                                        {
+                                            "apiVersion": "modelplane.ai/v1alpha1",
+                                            "kind": "ModelReplica",
+                                            "metadata": {
+                                                "name": "my-model-5ab63",
+                                                "namespace": "ml-team",
+                                                "labels": {
+                                                    "modelplane.ai/deployment": "my-model",
+                                                    "modelplane.ai/cluster": "cluster-a",
+                                                    "modelplane.ai/replica-index": "0",
+                                                },
+                                            },
+                                            "spec": {
+                                                "clusterName": "cluster-a",
+                                                "modelCacheRef": {"name": "qwen"},
+                                                "engines": _REPLICA_ENGINES,
+                                            },
+                                        }
+                                    ),
+                                ),
+                            },
+                        ),
+                        conditions=[
+                            fnv1.Condition(
+                                type="ModelCacheResolved",
+                                status=fnv1.STATUS_CONDITION_TRUE,
+                                reason="ModelCacheResolved",
+                            ),
+                            fnv1.Condition(
+                                type="ReplicasScheduled",
+                                status=fnv1.STATUS_CONDITION_FALSE,
+                                reason="Scheduling",
+                            ),
+                            fnv1.Condition(
+                                type="ReplicasReady",
+                                status=fnv1.STATUS_CONDITION_FALSE,
+                                reason="ModelStarting",
+                                message="0 of 1 ready",
+                            ),
+                        ],
+                        results=[
+                            fnv1.Result(
+                                severity=fnv1.SEVERITY_NORMAL,
+                                message="Scheduled 1 replicas across 1 clusters: cluster-a",
+                            ),
+                        ],
+                        context=structpb.Struct(),
+                    ),
+                    cluster_labels={"region": "us-east", "tier": "gpu"},
+                    cache_name="qwen",
+                ),
+            ),
+            Case(
+                # A referenced cache Crossplane hasn't fetched yet leaves the
+                # footprint unknown. With no replicas to retain, the function
+                # holds off placing any rather than risk landing them outside the
+                # footprint: fill is suppressed, so nothing is composed, and
+                # ModelCacheResolved=False (Unresolved) says why. The wait is
+                # transient and self-clearing, so it's a condition, not an event.
+                # The cluster and replica requirements are still declared so the
+                # cache can resolve alongside them.
+                name="unresolved cache suppresses new placement",
+                req=_req(xr_cached, clusters=[_CLUSTER_A]),
+                want=_want(
+                    fnv1.RunFunctionResponse(
+                        meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
+                        desired=fnv1.State(
+                            composite=fnv1.Resource(
+                                resource=resource.dict_to_struct({"status": {"replicas": {"total": 0, "ready": 0}}}),
+                                ready=fnv1.READY_FALSE,
+                            ),
+                        ),
+                        conditions=[
+                            fnv1.Condition(
+                                type="ModelCacheResolved",
+                                status=fnv1.STATUS_CONDITION_FALSE,
+                                reason="ModelCacheUnresolved",
+                                message="Waiting for ModelCache qwen",
+                            ),
+                            fnv1.Condition(
+                                type="ReplicasScheduled",
+                                status=fnv1.STATUS_CONDITION_FALSE,
+                                reason="InsufficientCapacity",
+                                message="0 of 1 replicas scheduled (checked 1 clusters)",
+                            ),
+                            fnv1.Condition(
+                                type="ReplicasReady",
+                                status=fnv1.STATUS_CONDITION_FALSE,
+                                reason="NoReplicasScheduled",
+                            ),
+                        ],
+                        context=structpb.Struct(),
+                    ),
+                    cache_name="qwen",
+                ),
+            ),
+            Case(
+                # The cache a live deployment depends on is deleted (the cache
+                # requirement resolves but matches nothing - ABSENT). The cache
+                # only matters when loading weights, which already happened, so
+                # its disappearance must not tear the deployment down: the
+                # existing replica is retained (retain ignores fill) even as
+                # ModelCacheResolved goes False (NotFound) and new placement is
+                # suppressed.
+                name="deleted cache retains existing replicas",
+                req=_req(
+                    xr_cached,
+                    clusters=[_CLUSTER_A],
+                    replicas=[_EXISTING_REPLICA],
+                    observed={"replica-cluster-a-0": _replica_status(_EXISTING_REPLICA, ready=True)},
+                    cache_resolved_empty=True,
+                ),
+                want=_want(
+                    fnv1.RunFunctionResponse(
+                        meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
+                        desired=fnv1.State(
+                            composite=fnv1.Resource(
+                                resource=resource.dict_to_struct({"status": {"replicas": {"total": 1, "ready": 1}}}),
+                            ),
+                            resources={
+                                "replica-cluster-a-0": fnv1.Resource(
+                                    resource=resource.dict_to_struct(
+                                        {
+                                            "apiVersion": "modelplane.ai/v1alpha1",
+                                            "kind": "ModelReplica",
+                                            "metadata": {
+                                                "name": "my-model-5ab63",
+                                                "namespace": "ml-team",
+                                                "labels": {
+                                                    "modelplane.ai/deployment": "my-model",
+                                                    "modelplane.ai/cluster": "cluster-a",
+                                                    "modelplane.ai/replica-index": "0",
+                                                },
+                                            },
+                                            "spec": {
+                                                "clusterName": "cluster-a",
+                                                "modelCacheRef": {"name": "qwen"},
+                                                "engines": _REPLICA_ENGINES,
+                                            },
+                                        }
+                                    ),
+                                    ready=fnv1.READY_TRUE,
+                                ),
+                                "endpoint-cluster-a-0": fnv1.Resource(
+                                    resource=resource.dict_to_struct(
+                                        {
+                                            "apiVersion": "modelplane.ai/v1alpha1",
+                                            "kind": "ModelEndpoint",
+                                            "metadata": {
+                                                "name": "my-model-5ab63",
+                                                "namespace": "ml-team",
+                                                "labels": {
+                                                    "modelplane.ai/deployment": "my-model",
+                                                    "modelplane.ai/cluster": "cluster-a",
+                                                    "modelplane.ai/replica-index": "0",
+                                                },
+                                            },
+                                            "spec": {
+                                                "url": "http://10.0.0.1/ml-team/my-model-5ab63/v1",
+                                                "rewritePath": "/ml-team/my-model-5ab63/",
+                                            },
+                                        }
+                                    ),
+                                ),
+                            },
+                        ),
+                        conditions=[
+                            fnv1.Condition(
+                                type="ModelCacheResolved",
+                                status=fnv1.STATUS_CONDITION_FALSE,
+                                reason="ModelCacheNotFound",
+                                message="ModelCache qwen not found; holding replica placement",
+                            ),
+                            fnv1.Condition(
+                                type="ReplicasScheduled",
+                                status=fnv1.STATUS_CONDITION_TRUE,
+                                reason="ReplicasCreated",
+                                message="Scheduled 1 of 1 replicas",
+                            ),
+                            fnv1.Condition(
+                                type="ReplicasReady",
+                                status=fnv1.STATUS_CONDITION_TRUE,
+                                reason="AllReplicasReady",
+                                message="1 of 1 ready",
+                            ),
+                        ],
+                        results=[
+                            fnv1.Result(
+                                severity=fnv1.SEVERITY_WARNING,
+                                message="ModelCache qwen not found; holding replica placement",
+                            ),
+                        ],
+                        context=structpb.Struct(),
+                    ),
+                    cache_name="qwen",
                 ),
             ),
             Case(
@@ -917,3 +1209,24 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                     json_format.MessageToDict(got),
                     "-want, +got",
                 )
+
+
+class TestResolveRequired(unittest.TestCase):
+    """Tests for fn.resolve_required - the three-state required-resource read."""
+
+    def test_resolve_required(self) -> None:
+        cache = {"apiVersion": "modelplane.ai/v1alpha1", "kind": "ModelCache", "metadata": {"name": "qwen"}}
+
+        # PRESENT: the requirement resolved and matched a resource.
+        req = fnv1.RunFunctionRequest()
+        req.required_resources["cache"].items.append(fnv1.Resource(resource=resource.dict_to_struct(cache)))
+        self.assertEqual((fn.Resolution.PRESENT, cache), fn.resolve_required(req, "cache"))
+
+        # ABSENT: the requirement resolved but matched nothing (key present, no items).
+        req = fnv1.RunFunctionRequest()
+        req.required_resources["cache"].SetInParent()
+        self.assertEqual((fn.Resolution.ABSENT, None), fn.resolve_required(req, "cache"))
+
+        # UNRESOLVED: Crossplane has not fetched the requirement (key absent).
+        req = fnv1.RunFunctionRequest()
+        self.assertEqual((fn.Resolution.UNRESOLVED, None), fn.resolve_required(req, "cache"))

--- a/functions/compose-model-deployment/tests/test_scheduling.py
+++ b/functions/compose-model-deployment/tests/test_scheduling.py
@@ -714,6 +714,42 @@ class TestSchedule(unittest.TestCase):
                 got = scheduling.schedule(case.deployment, case.clusters, case.all_replicas)
                 self.assertEqual(case.want, got, f"{case.name}: -want, +got")
 
+    def test_fill_false_is_retain_only(self) -> None:
+        """fill=False retains existing replicas but places no new ones.
+
+        A caller passes fill=False when it can't yet trust the candidate set
+        (for the ModelDeployment, when a referenced ModelCache is unresolved).
+        Retain runs unconditionally; only the placement of new replicas is held.
+        """
+        cases = [
+            Case(
+                name="no replicas yet: nothing is placed",
+                deployment=_deployment(),
+                clusters=[_cluster("cluster-a")],
+                all_replicas=[],
+                want=[],
+            ),
+            Case(
+                name="existing replica is retained despite fill=False",
+                deployment=_deployment(),
+                clusters=[_cluster("cluster-a")],
+                all_replicas=[_replica_with_pool("my-model", "cluster-a", pool="default")],
+                want=[_cand(name="cluster-a", gateway_address="10.0.0.1")],
+            ),
+            Case(
+                name="scale-up shortfall is not filled, only the retained replica remains",
+                deployment=_deployment(replicas=3),
+                clusters=[_cluster("cluster-a"), _cluster("cluster-b", gateway_address="10.0.0.2")],
+                all_replicas=[_replica_with_pool("my-model", "cluster-a", pool="default")],
+                want=[_cand(name="cluster-a", gateway_address="10.0.0.1")],
+            ),
+        ]
+
+        for case in cases:
+            with self.subTest(case.name):
+                got = scheduling.schedule(case.deployment, case.clusters, case.all_replicas, fill=False)
+                self.assertEqual(case.want, got, f"{case.name}: -want, +got")
+
 
 class TestScheduleNodeSelector(unittest.TestCase):
     """Tests for nodeSelector device-request matching and pool pinning."""


### PR DESCRIPTION
### Description of your changes

Relates to #186.

A `ModelCache` stages a model's weights onto the `InferenceCluster`s its `clusterSelector` matches. A `ModelDeployment` that references the cache via `spec.modelCacheRef` has its placement decided independently — the scheduler filters candidate clusters only by the deployment's own `clusterSelector` and ignores the cache entirely. A replica can land on a cluster the cache never staged to, where its PVC doesn't exist, and the pod gets stuck on a volume mount that never resolves. Nothing surfaces this at apply time on the `ModelDeployment` or `ModelCache`; it shows up only at runtime.

This makes `compose-model-deployment` read the referenced `ModelCache` and intersect its `clusterSelector` with the deployment's own when filtering the candidate clusters for *new* replicas. Both are `matchLabels` selectors, so the candidate set is their AND, and a new replica can't schedule to a cluster outside the cache's footprint.

The constraint applies to new placement only. The scheduler already retains existing replicas on their pinned cluster; it gains a `fill` flag that gates only the placement of *new* replicas, leaving retain untouched. Losing the cache therefore can't evict or re-place a running replica — dropping a narrowing input only ever broadens the candidate set. Since the cache is read only when weights are first staged, deleting it out from under a live deployment is a no-op for the replicas already running: they're retained, and `fill` is held off only for new ones.

When the referenced cache can't be read, the footprint is unknown, so the function holds off placing new replicas while still retaining the ones it has. It reports this on a `ModelCacheResolved` condition, kept separate from `ReplicasScheduled` so a deployment can be scheduled (retaining replicas) and waiting on its cache at the same time. A cache Crossplane hasn't fetched yet is transient and reported with a condition alone; a cache that resolved to nothing — deleted, or a typo'd ref — also emits a warning event. `get_required_resource` returns `None` for both of those cases, so a small `Resolution` helper classifies a required resource as unresolved / absent / present; I've opened crossplane/function-sdk-python#217 to upstream it, with a `TODO` to drop the local copy once it lands.

#186 raises a broader question: whether `ModelCache` should remain an explicit resource at all, or whether caching should be derived from placement so the footprint can't be authored out of sync in the first place. That's a conceptual and architectural change, and not one to rush into v0.1. This PR doesn't foreclose it — it's the small, safe change that removes the silent-failure footgun now and buys us time to align on how `ModelCache` should work without a runtime sharp edge in the meantime.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
