### PR TITLE
Build the Crossplane CLI for one platform and cache CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,14 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
 
+      # Cache Nix store paths in the GitHub Actions cache so builds reuse work
+      # across runs. use-flakehub is off so artifacts stay in the Actions cache
+      # rather than going to a third party, which matters for a private repo.
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
+        with:
+          use-flakehub: false
+
       - name: Check
         run: nix flake check --print-build-logs
 
@@ -68,6 +76,12 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
+
+      # See the check job for why use-flakehub is off.
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
+        with:
+          use-flakehub: false
 
       # The Crossplane CLI uses Docker's credential store for OCI pushes.
       - name: Login to registry

--- a/flake.lock
+++ b/flake.lock
@@ -7,15 +7,16 @@
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1781565524,
-        "narHash": "sha256-n9G+G1BPQh1dCTSnYB6Jjqq6jlTnBv//xax24h+R84I=",
-        "owner": "crossplane",
+        "lastModified": 1781759845,
+        "narHash": "sha256-cGTUbtLWeCjziuw9R5Gf6ppP/Ln4tilMK+OYFbmApqE=",
+        "owner": "negz",
         "repo": "cli",
-        "rev": "1a0f22906aa52ae01129513e248d3f22cee495ba",
+        "rev": "5466a88456e3e25d35676af5f74f5e8d4d565f56",
         "type": "github"
       },
       "original": {
-        "owner": "crossplane",
+        "owner": "negz",
+        "ref": "default-to-go",
         "repo": "cli",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,12 +12,21 @@
     # tracking the latest uv_build releases.
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    # Pinned to crossplane/cli main for two merged-but-unreleased fixes: the
-    # datamodel-code-generator bump (crossplane/cli#24, #64) that fixes Python
-    # model generation for fields named int/bool, and crossplane/cli#119, which
-    # stops the scale subresource on an XRD from clobbering the generated model
-    # with the autoscaling Scale type. Repin to a tag once released.
-    crossplane-cli.url = "github:crossplane/cli";
+    # Pinned to negz/cli's default-to-go branch rather than a released version,
+    # because we depend on several CLI changes that aren't in a release yet:
+    #
+    #   * #24, #64: a datamodel-code-generator bump that fixes Python model
+    #     generation for fields named int/bool.
+    #   * #119: stops an XRD's scale subresource from clobbering the generated
+    #     model with the autoscaling Scale type.
+    #   * #126 (unmerged): makes the flake's default package the host-native CLI
+    #     binary instead of the full multi-platform release bundle. Building one
+    #     platform instead of seven cuts the CLI build from ~55 minutes to ~8 on
+    #     a cold machine.
+    #
+    # #24, #64, and #119 are merged; the branch is based on them. Repin to
+    # crossplane/cli main once #126 merges, then to a tag once they all release.
+    crossplane-cli.url = "github:negz/cli/default-to-go";
 
     # uv2nix reads a uv workspace's uv.lock and generates Nix derivations
     # for each Python package, using pyproject.nix's build infrastructure.

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -1,28 +1,7 @@
 # External dependencies not available in nixpkgs.
-{ pkgs, crossplane-cli }:
-let
-  platformMap = {
-    "x86_64-linux" = "linux_amd64";
-    "aarch64-linux" = "linux_arm64";
-    "x86_64-darwin" = "darwin_amd64";
-    "aarch64-darwin" = "darwin_arm64";
-  };
-in
+{ crossplane-cli, ... }:
 {
-  # The Crossplane CLI. The upstream flake produces a multi-platform release
-  # bundle; we extract the binary for the current system.
-  crossplane =
-    { system }:
-    let
-      release = crossplane-cli.packages.${system}.default;
-      platform = platformMap.${system};
-    in
-    pkgs.stdenvNoCC.mkDerivation {
-      pname = "crossplane";
-      version = release.version or "0.0.0";
-      dontUnpack = true;
-      installPhase = ''
-        install -Dm755 ${release}/bin/${platform}/crossplane $out/bin/crossplane
-      '';
-    };
+  # The Crossplane CLI. The upstream flake's default package is the host-native
+  # binary for the current system, so we can use it as-is.
+  crossplane = { system }: crossplane-cli.packages.${system}.default;
 }


### PR DESCRIPTION
### Description of your changes

CI takes over an hour to build and push the project. Almost all of it is the Crossplane CLI: our `crossplane-cli` flake input resolves to the upstream flake's `default` package, which is the full multi-platform release bundle, the CLI cross-compiled for all seven supported platforms. `deps.nix` then extracted the one binary matching the host. So every run compiled the entire dependency closure seven times to use one binary, roughly 55 minutes of Go compilation on a cold runner.

crossplane/cli#126 makes the flake's `default` package the host-native binary and moves the release bundle to an explicit name. Pinning to that branch and consuming `default` directly cuts the build to a single platform. The extraction in `deps.nix` is gone; `default` is already a single binary at `bin/crossplane`.

The pin is to the PR branch (`negz/cli/default-to-go`) for now. Repin to `crossplane/cli` main once #126 merges, then to a tag once released.

On top of that, the Magic Nix Cache action persists the Nix store across runs via the GitHub Actions cache, so a warm run reuses earlier work. `use-flakehub` is off so artifacts stay in the Actions cache rather than going to FlakeHub. The Actions cache is capped at 10 GB per repo and evicts least recently used entries, so a large closure can still miss.

Together these take a full build from over an hour to about 10 minutes cold and 1 minute warm, measured by temporarily building all function images as a `nix flake check` on this PR.

Depends on crossplane/cli#126.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~ No function changes.
- [x] Signed off every commit with `git commit -s`.
