### PR TITLE
Stop function images from shipping a second Python and the whole repo

### DIFF
--- a/nix/functions.nix
+++ b/nix/functions.nix
@@ -179,6 +179,13 @@ let
           --python-version ${pythonVersion} \
           --target $out \
           wheels/*.whl ${lib.concatStringsSep " " (map toString sources)}
+
+        # uv writes console-script wrappers under bin/ whose shebang points at
+        # --python, i.e. the build-host interpreter. That interpreter is the
+        # build host's arch, not the image's, so shipping bin/ would drag a
+        # second, wrong-arch CPython (and its glibc) into the image. The image
+        # runs `python -m function.main`, never these wrappers, so drop them.
+        rm -rf $out/bin
       '';
 
   mkFunctionImage =

--- a/nix/functions.nix
+++ b/nix/functions.nix
@@ -186,6 +186,14 @@ let
         # second, wrong-arch CPython (and its glibc) into the image. The image
         # runs `python -m function.main`, never these wrappers, so drop them.
         rm -rf $out/bin
+
+        # uv records each source install's provenance in a PEP 610
+        # direct_url.json under .dist-info, as a file:// URL into the workspace
+        # source tree (the flake's `self`). Nix scans the output for store
+        # paths, finds that hash, and drags the entire repository - apis, design
+        # docs, the docs site - into the image's runtime closure as a "source"
+        # layer. Nothing reads this metadata at runtime, so drop it.
+        find $out -name direct_url.json -path '*.dist-info/*' -delete
       '';
 
   mkFunctionImage =


### PR DESCRIPTION
### Description of your changes

Every composition function image is larger than it needs to be in two independent ways, both rooted in how `mkSitePackages` invokes `uv pip install`.

**A second, wrong-arch CPython.** An `amd64` image built on an `aarch64` host (e.g. CI, or an Apple Silicon dev machine) is ~163M; the equivalent `arm64` image is ~89M. The `amd64` image contains *two* complete CPython installs — one `x86_64` (the one the entrypoint uses) and one `aarch64`. `uv` writes a `bin/function` console-script wrapper whose shebang points at `--python`, which is necessarily the build-host interpreter (uv has to execute it to resolve the install and build our pure-Python sources; the target arch's interpreter can't run on the host without emulation). That shebang is a runtime store reference, so `buildLayeredImage` pulls the entire build-host-arch CPython and glibc closure into the image. The image runs `python -m function.main` and never invokes the wrapper, so the first commit removes `bin/` after the install. `amd64` images drop to ~89M, matching `arm64`.

**The entire repository.** Every image also carries a ~21M layer containing the whole repo — `apis/`, `design/`, the docs site. `uv` records each source install's provenance in a PEP 610 `direct_url.json` under `.dist-info`, as a `file://` URL into the workspace source tree (the flake's `self`). The URL embeds the repo's store path; Nix's reference scanner finds it and drags the repo into the runtime closure as a `source` layer. The second commit removes those `direct_url.json` files; they record where a package was installed from, which is irrelevant in a built image.

Both changes are pure subtractions from the site-packages tree — the function imports are untouched, so there's no behavior change. The part worth a careful look is whether removing `direct_url.json` could matter at runtime; as far as I can tell it's PEP 610 install-time provenance metadata only, read by installer tooling and not by `importlib.metadata` entry-point resolution.

I have: 

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~ No behavior change; this only removes unused files from the image.
- [x] Signed off every commit with `git commit -s`.
