### PR TITLE
Set an explicit 5s readiness probe timeout on the engine container

### DIFF
--- a/functions/compose-model-replica/function/backends/llmd.py
+++ b/functions/compose-model-replica/function/backends/llmd.py
@@ -89,6 +89,9 @@ class LLMDBackend:
                     "httpGet": {"path": "/health", "port": base.ENGINE_PORT},
                     "initialDelaySeconds": 30,
                     "periodSeconds": 10,
+                    # A slow /health (e.g. SGLang's ~1s) flaps the probe under the
+                    # 1s Kubernetes default; 5s gives it room.
+                    "timeoutSeconds": 5,
                 }
             return c
 

--- a/functions/compose-model-replica/function/backends/native.py
+++ b/functions/compose-model-replica/function/backends/native.py
@@ -48,6 +48,11 @@ class NativeBackend:
                 "httpGet": {"path": "/health", "port": base.ENGINE_PORT},
                 "initialDelaySeconds": 30,
                 "periodSeconds": 10,
+                # Kubernetes defaults the probe timeout to 1s. Some engines'
+                # /health isn't instant - SGLang's sits right at ~1s - so a 1s
+                # timeout flaps the probe and the pod never goes Ready. 5s gives
+                # a slow /health room without masking a real hang.
+                "timeoutSeconds": 5,
             },
         }
         # GPUs bind via DRA: the container references the pod-level claim

--- a/functions/compose-model-replica/function/routing.py
+++ b/functions/compose-model-replica/function/routing.py
@@ -278,6 +278,9 @@ def _add_sidecar_to_decode(obj: k8sobjv1alpha1.Object) -> None:
             "httpGet": {"path": "/health", "port": port},
             "initialDelaySeconds": 30,
             "periodSeconds": 10,
+            # Match the timeout the backends set on the standalone probe: a slow
+            # but healthy /health (SGLang's sits at ~1s) flaps the 1s default.
+            "timeoutSeconds": 5,
         }
         containers.append(
             {
@@ -286,9 +289,12 @@ def _add_sidecar_to_decode(obj: k8sobjv1alpha1.Object) -> None:
                 "args": ["--secure-proxy=false", "--kv-connector=nixlv2", f"--vllm-port={port}"],
                 "ports": [{"containerPort": base.ENGINE_PORT}],
                 "readinessProbe": {
+                    # The sidecar proxies /health to the same engine, so it's
+                    # just as slow; give it the same 5s timeout.
                     "httpGet": {"path": "/health", "port": base.ENGINE_PORT},
                     "initialDelaySeconds": 30,
                     "periodSeconds": 10,
+                    "timeoutSeconds": 5,
                 },
             }
         )

--- a/functions/compose-model-replica/tests/test_backends.py
+++ b/functions/compose-model-replica/tests/test_backends.py
@@ -224,6 +224,7 @@ _NATIVE_WANT = {
                                 "httpGet": {"path": "/health", "port": 8000},
                                 "initialDelaySeconds": 30,
                                 "periodSeconds": 10,
+                                "timeoutSeconds": 5,
                             },
                         }
                     ],
@@ -308,6 +309,7 @@ def _engine(*, serving, args=None, command=None, env=None):
             "httpGet": {"path": "/health", "port": 8000},
             "initialDelaySeconds": 30,
             "periodSeconds": 10,
+            "timeoutSeconds": 5,
         }
     return c
 
@@ -790,8 +792,10 @@ class TestDisaggregated(unittest.TestCase):
         self.assertEqual(names, ["engine", "pd-sidecar"])
         engine = next(c for c in containers if c["name"] == "engine")
         self.assertEqual(engine["ports"][0]["containerPort"], 8001)
+        self.assertEqual(engine["readinessProbe"]["timeoutSeconds"], 5)
         sidecar = next(c for c in containers if c["name"] == "pd-sidecar")
         self.assertEqual(sidecar["ports"][0]["containerPort"], 8000)
+        self.assertEqual(sidecar["readinessProbe"]["timeoutSeconds"], 5)
         self.assertIn("--secure-proxy=false", sidecar["args"])
 
     def test_prefill_has_no_sidecar(self):

--- a/functions/compose-model-replica/tests/test_fn.py
+++ b/functions/compose-model-replica/tests/test_fn.py
@@ -181,6 +181,7 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                                                                     "httpGet": {"path": "/health", "port": 8000},
                                                                     "initialDelaySeconds": 30,
                                                                     "periodSeconds": 10,
+                                                                    "timeoutSeconds": 5,
                                                                 },
                                                             },
                                                         ],


### PR DESCRIPTION
Fixes #206.

The native and llm-d backends set a readiness probe on the engine container but no `timeoutSeconds`, so it defaults to Kubernetes' 1s. Serving Qwen3-Coder-480B on SGLang, `GET /health` on the engine measured just over 1s, so the probe kept timing out and the pod flapped between `Ready` and `NotReady`. It went `Ready` long enough to serve traffic, but it's fragile: when `/health` is over 1s as the probe fires, the pod drops out of the Service endpoints and traffic to that replica stops. vLLM's `/health` answered well under 1s, so this hasn't bitten that path.

This sets `timeoutSeconds` to 5 on the readiness probe in both `native.py` and `llmd.py`, giving a slow but healthy `/health` room without masking a genuinely hung engine.

In PrefillDecode mode `routing.py` overwrites the decode engine's probe and adds one for the `pd-sidecar`, both without `timeoutSeconds`, so that path would keep the 1s default. The sidecar proxies `/health` to the same engine, so it's just as slow. Both get the same 5s timeout.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
