### PR TITLE
Docs site: restyle, app-shell layout, and docs.modelplane.ai

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -82,7 +82,7 @@ See [issues labeled `enhancement`][enhancements] for what's planned.
 
 Follow the [getting started guide]({{< ref "getting-started.md" >}}) to deploy Modelplane
 on a local kind cluster and serve a model on GKE. The [concepts
-glossary]({{< ref "concepts.md" >}}) defines the key resources and how they relate.
+glossary]({{< ref "/overview/concepts.md" >}}) defines the key resources and how they relate.
 
 The [`examples/`][examples] directory has annotated manifests covering the full
 workflow: gateway setup, cluster provisioning, and model deployments.

--- a/docs/content/models/_index.md
+++ b/docs/content/models/_index.md
@@ -1,15 +1,9 @@
 ---
 title: Deploy Models
 weight: 30
+navLabel: "Models"
 description: Resources for ML teams deploying models and getting unified endpoints.
 ---
 <!-- vale write-good.Passive = NO -->
 ML teams deploy models and get unified endpoints.
-
-## Resources
-
-- [ModelDeployment]({{< ref "model-deployment.md" >}}) - deploy a model to the fleet with replica count and engine config
-- [ModelCache]({{< ref "model-cache.md" >}}) - stage model weights on cluster storage before serving
-- [ModelService]({{< ref "model-service.md" >}}) - expose endpoints via a unified OpenAI-compatible URL
-- [ModelEndpoint]({{< ref "model-endpoint.md" >}}) - a reachable inference endpoint, composed or manually created
 <!-- vale write-good.Passive = YES -->

--- a/docs/content/overview/_index.md
+++ b/docs/content/overview/_index.md
@@ -1,0 +1,49 @@
+---
+title: Overview
+weight: 5
+description: What Modelplane is, why it exists, and how it works.
+---
+<!-- vale write-good.Passive = NO -->
+Modelplane is the open source control plane for AI inference. It sits above your
+inference clusters across cloud, neocloud, and on-premise, and turns a fleet of
+GPU clusters into a single place to serve models. Platform teams set policy and
+capacity; developers declare a model and get a serving endpoint. Modelplane
+continuously reconciles the whole fleet: provisioning, scheduling, autoscaling,
+routing, and caching. All of it runs entirely under your control.
+
+This Overview is the place to start. It answers three questions:
+
+- [Why Modelplane]({{< ref "/overview/why" >}}): the problem it solves and how it
+  compares to building inference yourself or buying it as a service.
+- [How Modelplane works]({{< ref "/overview/how-it-works" >}}): the architecture, the
+  two-team boundary, and what happens when you deploy a model.
+
+When you're ready to deploy, [Getting started]({{< ref "/getting-started" >}}) takes
+you from nothing to a live OpenAI-compatible endpoint in about 45 minutes.
+
+## Two teams, one control plane
+
+Modelplane draws a clear boundary between the people who run the infrastructure
+and the people who ship models on it.
+
+{{< personas >}}
+
+**Platform teams** describe their GPU fleet as resources: which clusters exist,
+what hardware each offers, and the policy and capacity the fleet runs within.
+**Developers** declare a model and replica count, and get back one
+OpenAI-compatible endpoint per service. Neither team has to know the details of
+the other's job.
+
+## What Modelplane is not
+
+Modelplane is the fleet-level control plane *above* the inference engine. It
+doesn't compete with vLLM or Dynamo; it manages them across clusters. It isn't a
+managed inference service either: Modelplane is open source and runs in your own
+clusters, so the models, the data, and the infrastructure stay yours.
+
+It builds on [Crossplane](https://crossplane.io): platform teams describe their
+GPU fleet as resources, developers describe a deployment, and Modelplane composes
+the clusters, schedules replicas, and exposes one OpenAI-compatible endpoint per
+service. The [Concepts]({{< ref "/concepts" >}}) page covers every resource and
+how they relate.
+<!-- vale write-good.Passive = YES -->

--- a/docs/content/overview/_index.md
+++ b/docs/content/overview/_index.md
@@ -10,7 +10,7 @@ inference clusters across cloud, neocloud, and on-premise, and turns a fleet of
 GPU clusters into a single place to serve models. Platform teams set policy and
 capacity; developers declare a model and get a serving endpoint. Modelplane
 continuously reconciles the whole fleet: provisioning, scheduling, autoscaling,
-routing, and caching. All of it runs entirely under your control.
+routing, and caching. It all runs under your control.
 
 This Overview is the place to start. It answers three questions:
 
@@ -39,7 +39,7 @@ the other's job.
 
 Modelplane is the fleet-level control plane *above* the inference engine. It
 doesn't compete with vLLM or Dynamo; it manages them across clusters. It isn't a
-managed inference service either: Modelplane is open source and runs in your own
+managed inference service either. Modelplane is open source and runs in your own
 clusters, so the models, the data, and the infrastructure stay yours.
 
 It builds on [Crossplane](https://crossplane.io): platform teams describe their

--- a/docs/content/overview/_index.md
+++ b/docs/content/overview/_index.md
@@ -2,6 +2,7 @@
 title: Overview
 weight: 5
 description: What Modelplane is, why it exists, and how it works.
+navLanding: "Introduction"
 ---
 <!-- vale write-good.Passive = NO -->
 Modelplane is the open source control plane for AI inference. It sits above your
@@ -44,6 +45,6 @@ clusters, so the models, the data, and the infrastructure stay yours.
 It builds on [Crossplane](https://crossplane.io): platform teams describe their
 GPU fleet as resources, developers describe a deployment, and Modelplane composes
 the clusters, schedules replicas, and exposes one OpenAI-compatible endpoint per
-service. The [Concepts]({{< ref "/concepts" >}}) page covers every resource and
+service. The [Concepts]({{< ref "/overview/concepts" >}}) page covers every resource and
 how they relate.
 <!-- vale write-good.Passive = YES -->

--- a/docs/content/overview/concepts.md
+++ b/docs/content/overview/concepts.md
@@ -1,13 +1,15 @@
 ---
 title: Concepts
-weight: 40
+weight: 30
 description: Key resources and how they relate.
+aliases:
+  - /concepts/
 ---
 <!-- vale write-good.Passive = NO -->
 Modelplane manages AI model inference across a fleet of GPU clusters. It draws a
-boundary between two teams: [platform engineers]({{< ref "platform/_index.md" >}})
+boundary between two teams: [platform engineers]({{< ref "/platform/_index.md" >}})
 who provision infrastructure and define hardware classes, and
-[ML teams]({{< ref "models/_index.md" >}}) who deploy models and get unified
+[ML teams]({{< ref "/models/_index.md" >}}) who deploy models and get unified
 endpoints.
 
 ## Resource model
@@ -49,42 +51,42 @@ graph TD
 
 ## Glossary
 
-**[InferenceGateway]({{< ref "platform/inference-gateway.md" >}})**
+**[InferenceGateway]({{< ref "/platform/inference-gateway.md" >}})**
 The unified, OpenAI-compatible endpoint on the control plane cluster. Installs
 Envoy Gateway and routes requests to model endpoints on remote inference clusters.
 One per control plane, always named `default`.
 
-**[InferenceClass]({{< ref "platform/inference-class.md" >}})**
+**[InferenceClass]({{< ref "/platform/inference-class.md" >}})**
 A hardware recipe for a GPU node pool. Includes GPU type, count, DRA device definitions,
 and optional cloud provisioning config. Platform teams define one class per GPU
 SKU and cloud combination.
 
-**[InferenceCluster]({{< ref "platform/inference-cluster.md" >}})**
+**[InferenceCluster]({{< ref "/platform/inference-cluster.md" >}})**
 A Kubernetes cluster registered with Modelplane for model serving. Can be
 provisioned by Modelplane (GKE, EKS) or brought as-is (`Existing`). Modelplane
 installs the inference stack on every registered cluster.
 
-**[ModelDeployment]({{< ref "models/model-deployment.md" >}})**
+**[ModelDeployment]({{< ref "/models/model-deployment.md" >}})**
 The ML team's primary resource. Declares the inference engines, replica count,
 and optional model cache. The scheduler places each replica onto a ready cluster
 with matching GPU capacity.
 
-**[ModelCache]({{< ref "models/model-cache.md" >}})**
+**[ModelCache]({{< ref "/models/model-cache.md" >}})**
 Stages model weights on cluster storage ahead of serving. Composes a
 ReadWriteMany PVC per cluster and hydrates it once from the configured source
 (HuggingFace today). Required for multi-node deployments; optional for
 single-node cold-start optimization.
 
-**[ModelReplica]({{< ref "models/model-replica.md" >}})**
+**[ModelReplica]({{< ref "/models/model-replica.md" >}})**
 One instance of a `ModelDeployment` placed on a specific cluster. Created
 automatically by Modelplane. Don't create these directly.
 
-**[ModelEndpoint]({{< ref "models/model-endpoint.md" >}})**
+**[ModelEndpoint]({{< ref "/models/model-endpoint.md" >}})**
 A reachable inference endpoint. Modelplane composes one per `ModelReplica`.
 ML teams can also create them manually to point a `ModelService` at an external
 provider (Together, BaseTen).
 
-**[ModelService]({{< ref "models/model-service.md" >}})**
+**[ModelService]({{< ref "/models/model-service.md" >}})**
 Exposes one or more `ModelEndpoints` as a single, OpenAI-compatible URL.
 Selects endpoints by label and composes a Gateway API HTTPRoute that
 load-balances across them.

--- a/docs/content/overview/how-it-works.md
+++ b/docs/content/overview/how-it-works.md
@@ -1,0 +1,98 @@
+---
+title: How Modelplane works
+weight: 20
+description: The architecture, the two-team boundary, and what happens when you deploy a model.
+---
+<!-- vale write-good.Passive = NO -->
+Modelplane runs as a control plane on its own cluster, above the inference
+clusters that actually serve models. It's built on [Crossplane](https://crossplane.io):
+platform teams and developers describe what they want as Kubernetes resources, and
+Modelplane composes the clusters, schedules replicas, and exposes endpoints to
+match. This page is the high-altitude tour. The [Concepts]({{< ref "/concepts" >}})
+page covers each resource in full.
+
+## The two-team boundary
+
+Two sets of resources map onto the two teams, and Modelplane fills in everything
+between them.
+
+- **Platform teams** create an `InferenceGateway` (one unified, OpenAI-compatible
+  entry point on the control plane), `InferenceClasses` (tested hardware recipes:
+  GPU type and count), and `InferenceClusters` (the clusters themselves, labeled
+  with tier, region, and provider).
+- **Developers** create a `ModelDeployment` (the inference engine and replica
+  count, with an optional `ModelCache` for staged weights) and a `ModelService`
+  (one endpoint that routes across replicas).
+- **Modelplane** composes the rest: a `ModelReplica` per cluster a model lands on,
+  and a `ModelEndpoint` per replica for routing.
+
+```mermaid
+graph TD
+    subgraph "Platform team"
+        IG[InferenceGateway]
+        ICL[InferenceClass<br><i>gke-l4-1x-g2</i>]
+        IC1[InferenceCluster<br><i>prod-gke-us-central</i>]
+        IC2[InferenceCluster<br><i>prod-byo-us-east</i>]
+    end
+
+    subgraph "Developer"
+        MC[ModelCache<br><i>kimi-k2</i>]
+        MD[ModelDeployment<br><i>qwen-demo</i>]
+        MS[ModelService<br><i>qwen</i>]
+    end
+
+    subgraph "Created by Modelplane"
+        MR1[ModelReplica<br><i>qwen-demo-prod-gke-us-central</i>]
+        MR2[ModelReplica<br><i>qwen-demo-prod-byo-us-east</i>]
+        ME1[ModelEndpoint<br><i>qwen-demo-prod-gke-us-central</i>]
+        ME2[ModelEndpoint<br><i>qwen-demo-prod-byo-us-east</i>]
+    end
+
+    IC1 -- "references" --> ICL
+    MD -- "references" --> MC
+    MD -. "creates" .-> MR1
+    MD -. "creates" .-> MR2
+    MD -. "creates" .-> ME1
+    MD -. "creates" .-> ME2
+    MR1 -- "deploys to" --> IC1
+    MR2 -- "deploys to" --> IC2
+    MS -- "selects" --> ME1
+    MS -- "selects" --> ME2
+    MS -. "routing" .-> IG
+```
+
+## What the control plane reconciles
+
+Once the resources exist, Modelplane keeps the fleet matching them. Five concerns
+run continuously:
+
+1. **Provisioning.** From an `InferenceCluster`, Modelplane creates a full GKE or
+   EKS cluster and its GPU node pools, or onboards a cluster you bring on any
+   Kubernetes, and installs the serving stack on each.
+2. **Scheduling.** A two-level scheduler places work. The fleet scheduler pins each
+   `ModelReplica` to a cluster and node pool whose GPUs satisfy the model's device
+   requests; the cluster's own scheduler, with Dynamic Resource Allocation (DRA),
+   then binds the GPUs to the serving pods.
+3. **Autoscaling.** Replicas are the scaling axis. Scaling a `ModelDeployment`'s
+   `spec.replicas` adds or removes whole serving instances through the standard
+   Kubernetes scale subresource.
+4. **Routing.** A `ModelService` exposes one OpenAI-compatible endpoint through the
+   gateway and load-balances across the deployment's `ModelEndpoints`, with weights
+   for canary and A/B rollouts.
+5. **Caching.** A `ModelCache` stages model weights on cluster storage once, so
+   serving pods read them locally instead of re-downloading on every start.
+
+## What happens when you deploy a model
+
+Creating a `ModelDeployment` kicks off the loop end to end. The scheduler discovers
+the ready clusters (filtered by your label selector if you set one), matches each
+engine's GPU requests against their node pools, and pins the replicas to clusters
+that fit. Modelplane composes a `ModelReplica` on each chosen cluster, creates a
+`ModelEndpoint` per replica, and your `ModelService` routes traffic across them
+through one stable endpoint. Scale the deployment up or down and the same loop
+re-converges.
+
+For the full resource reference, including multi-node inference, disaggregation,
+and cache backends, read [Concepts]({{< ref "/concepts" >}}). To do it yourself,
+start with [Getting started]({{< ref "/getting-started" >}}).
+<!-- vale write-good.Passive = YES -->

--- a/docs/content/overview/how-it-works.md
+++ b/docs/content/overview/how-it-works.md
@@ -8,7 +8,7 @@ Modelplane runs as a control plane on its own cluster, above the inference
 clusters that actually serve models. It's built on [Crossplane](https://crossplane.io):
 platform teams and developers describe what they want as Kubernetes resources, and
 Modelplane composes the clusters, schedules replicas, and exposes endpoints to
-match. This page is the high-altitude tour. The [Concepts]({{< ref "/concepts" >}})
+match. This page is the high-altitude tour. The [Concepts]({{< ref "/overview/concepts" >}})
 page covers each resource in full.
 
 ## The two-team boundary
@@ -93,6 +93,6 @@ through one stable endpoint. Scale the deployment up or down and the same loop
 re-converges.
 
 For the full resource reference, including multi-node inference, disaggregation,
-and cache backends, read [Concepts]({{< ref "/concepts" >}}). To do it yourself,
+and cache backends, read [Concepts]({{< ref "/overview/concepts" >}}). To do it yourself,
 start with [Getting started]({{< ref "/getting-started" >}}).
 <!-- vale write-good.Passive = YES -->

--- a/docs/content/overview/how-it-works.md
+++ b/docs/content/overview/how-it-works.md
@@ -67,10 +67,10 @@ Once the resources exist, Modelplane keeps the fleet matching them. Five concern
 run continuously:
 
 1. **Provisioning.** From an `InferenceCluster`, Modelplane creates a full GKE or
-   EKS cluster and its GPU node pools, or onboards a cluster you bring on any
-   Kubernetes, and installs the serving stack on each.
+   EKS cluster and its GPU node pools, or brings in a cluster you already run on
+   any Kubernetes, and installs the serving stack on each.
 2. **Scheduling.** A two-level scheduler places work. The fleet scheduler pins each
-   `ModelReplica` to a cluster and node pool whose GPUs satisfy the model's device
+   `ModelReplica` to a cluster and node pool whose GPUs meet the model's device
    requests; the cluster's own scheduler, with Dynamic Resource Allocation (DRA),
    then binds the GPUs to the serving pods.
 3. **Autoscaling.** Replicas are the scaling axis. Scaling a `ModelDeployment`'s

--- a/docs/content/overview/why.md
+++ b/docs/content/overview/why.md
@@ -1,0 +1,52 @@
+---
+title: Why Modelplane
+weight: 10
+description: The problem Modelplane solves and how it compares to the alternatives.
+---
+<!-- vale write-good.Passive = NO -->
+Serving your own models in production is a fleet problem long before it's a model
+problem. GPU capacity is scarce and scattered: some in a hyperscaler, some on a
+neocloud, some on hardware you already own. Getting a model in front of users
+means provisioning clusters, scheduling replicas onto the right GPUs, scaling
+them with demand, routing traffic to a stable endpoint, and staging weights so
+pods don't re-download them on every restart. Every team that serves models ends
+up building the same control plane to do it.
+
+There are two usual ways out, and each costs something.
+
+- **Build it yourself on Kubernetes.** You keep full control, but you own all the
+  glue: cluster provisioning, GPU scheduling, autoscaling, gateways, and caching,
+  across every cloud you touch. That's a platform to build and maintain, not a
+  feature.
+- **Buy managed inference as a service.** You skip the glue, but you give up
+  control: your models and traffic run on someone else's infrastructure, you take
+  on lock-in, and you serve where the vendor has capacity rather than where you do.
+
+## What Modelplane does instead
+
+Modelplane is the control plane you'd otherwise build, as open source that runs in
+your own clusters. You describe your GPU fleet and your models as resources, and
+Modelplane reconciles the rest.
+
+- **One fleet, many clouds.** Modelplane treats every cluster, cloud, and region
+  as one pool. It provisions GKE and EKS clusters, and brings in any other
+  Kubernetes cluster, on a neocloud or on-prem, that you point it at.
+- **One endpoint per service.** Every model is exposed through a single
+  OpenAI-compatible endpoint, with weighted routing for canary and A/B rollouts
+  across replicas and endpoints.
+- **A clean team boundary.** Platform teams set capacity and policy once;
+  developers deploy against it without filing tickets for infrastructure.
+- **Yours, end to end.** The models, the data, and the clusters stay under your
+  control. Modelplane is [Apache 2.0](https://github.com/modelplaneai/modelplane/blob/main/LICENSE)
+  and builds on the open [Crossplane](https://crossplane.io) ecosystem, so there's
+  no proprietary control plane to lock into.
+
+## Where it is today
+
+Modelplane is at v0.1: early, focused, and moving fast. What ships today provisions
+GKE and EKS (and runs on any cluster you bring), schedules and scales replicas,
+routes through one OpenAI-compatible endpoint, and caches weights from Hugging
+Face. See [How Modelplane works]({{< ref "/overview/how-it-works" >}}) for the
+mechanics, and the [platform docs]({{< ref "/platform" >}}) for provisioning
+clusters across clouds, accelerators, and engines, including what's on the roadmap.
+<!-- vale write-good.Passive = YES -->

--- a/docs/content/overview/why.md
+++ b/docs/content/overview/why.md
@@ -12,7 +12,7 @@ them with demand, routing traffic to a stable endpoint, and staging weights so
 pods don't re-download them on every restart. Every team that serves models ends
 up building the same control plane to do it.
 
-There are two usual ways out, and each costs something.
+Most teams take one of two paths, and each costs something.
 
 - **Build it yourself on Kubernetes.** You keep full control, but you own all the
   glue: cluster provisioning, GPU scheduling, autoscaling, gateways, and caching,
@@ -38,7 +38,7 @@ Modelplane reconciles the rest.
   developers deploy against it without filing tickets for infrastructure.
 - **Yours, end to end.** The models, the data, and the clusters stay under your
   control. Modelplane is [Apache 2.0](https://github.com/modelplaneai/modelplane/blob/main/LICENSE)
-  and builds on the open [Crossplane](https://crossplane.io) ecosystem, so there's
+  and builds on open [Crossplane](https://crossplane.io), so there's
   no proprietary control plane to lock into.
 
 ## Where it is today

--- a/docs/content/overview/why.md
+++ b/docs/content/overview/why.md
@@ -16,7 +16,7 @@ Most teams take one of two paths, and each costs something.
 
 - **Build it yourself on Kubernetes.** You keep full control, but you own all the
   glue: cluster provisioning, GPU scheduling, autoscaling, gateways, and caching,
-  across every cloud you touch. That's a platform to build and maintain, not a
+  across every cloud you use. That's a platform to build and maintain, not a
   feature.
 - **Buy managed inference as a service.** You skip the glue, but you give up
   control: your models and traffic run on someone else's infrastructure, you take
@@ -41,7 +41,7 @@ Modelplane reconciles the rest.
   and builds on open [Crossplane](https://crossplane.io), so there's
   no proprietary control plane to lock into.
 
-## Where it is today
+## Where it stands today
 
 Modelplane is at v0.1: early, focused, and moving fast. What ships today provisions
 GKE and EKS (and runs on any cluster you bring), schedules and scales replicas,

--- a/docs/content/platform/_index.md
+++ b/docs/content/platform/_index.md
@@ -1,15 +1,9 @@
 ---
 title: Build the Inference Stack Platform
 weight: 20
+navLabel: "Platform"
 description: Resources for platform engineers provisioning GPU clusters and hardware classes for ML teams.
 ---
 <!-- vale write-good.Passive = NO -->
 Platform teams provision infrastructure and define hardware classes.
-
-## Resources
-
-- [InferenceGateway]({{< ref "inference-gateway.md" >}}) - unified OpenAI-compatible endpoint on the control plane
-- [InferenceClass]({{< ref "inference-class.md" >}}) - hardware recipe defining GPU type, count, and provisioning
-- [InferenceCluster]({{< ref "inference-cluster.md" >}}) - a Kubernetes cluster registered for model serving
-- [ServingStack]({{< ref "serving-stack.md" >}}) - the serving substrate Modelplane installs on every managed cluster
 <!-- vale write-good.Passive = YES -->

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -28,8 +28,8 @@ ignoreFiles = ["themes/geekboot/content/.*", "README.md"]
   [markup.highlight]
     codeFences = true
     noClasses = false
-    linenos = true
-    anchorLineNos = true
+    linenos = false
+    anchorLineNos = false
     lineNumbersInTable = false
 
 [module]

--- a/docs/postcss.config.js
+++ b/docs/postcss.config.js
@@ -23,7 +23,10 @@ const purgecss = require("@fullhuman/postcss-purgecss")({
       ...(els.ids || []),
     ];
   },
-  safelist: [],
+  // Classes added/injected by JS at runtime never appear in hugo_stats.json,
+  // so keep their rules from being purged: the floating copy button we hide
+  // (bd-clipboard/btn-clipboard) and the code-card copy "copied" state.
+  safelist: ["bd-clipboard", "btn-clipboard", "copied"],
 });
 
 // PostCSS Media sort

--- a/docs/themes/geekboot/assets/scss/_api-reference.scss
+++ b/docs/themes/geekboot/assets/scss/_api-reference.scss
@@ -50,24 +50,12 @@
 
   // ── Example code block ────────────────────────────────────────────────────
 
+  // Wrapper around Hugo's highlighted output (.highlight > .chroma); the code
+  // theme supplies the background and syntax colours for both light and dark.
   .api-ref__example {
-    background-color: var(--code-background);
-    border-radius: 0;
-    padding: 1.25rem 1.5rem;
-    font-family: var(--bs-font-monospace);
-    font-size: 0.8125rem;
-    line-height: 1.65;
-    overflow-x: auto;
     margin: 0;
-    white-space: pre;
 
-    code {
-      background: none !important;
-      color: var(--body-font-color) !important;
-      padding: 0;
-      border-radius: 0;
-      font-size: inherit;
-    }
+    .highlight { margin: 0; }
   }
 
   // ── Field list ────────────────────────────────────────────────────────────

--- a/docs/themes/geekboot/assets/scss/_code-theme-base.scss
+++ b/docs/themes/geekboot/assets/scss/_code-theme-base.scss
@@ -14,6 +14,10 @@
   .highlight {
     overflow-x: auto;
     width: 100% !important;
+    // Allow the flex box to shrink below its content so long code lines scroll
+    // inside the block instead of widening it past its column (which pushed
+    // content off-centre and into the "On this page" rail).
+    min-width: 0;
     background-color: var(--code-block-background-color);
     display: flex !important;
     margin-top: 1rem; // prevent boxes from running together
@@ -60,6 +64,7 @@
     // code pre elements.
     .chroma {
       width: 100%;
+      min-width: 0;
       font-size: .95rem !important;
       line-height: 1.45em;
       display: flex !important;
@@ -69,6 +74,7 @@
       padding-top: .5rem;
 
       code {
+        min-width: 0;
         color: #f8f9fa;   // Code color if there is no defined highlighter style
         background-color: var(--code-block-background-color);
 

--- a/docs/themes/geekboot/assets/scss/_code-theme-base.scss
+++ b/docs/themes/geekboot/assets/scss/_code-theme-base.scss
@@ -4,9 +4,10 @@
       content: "$ "
   }
 
-  // Style for highlighted lines when hovering over copy button
+  // Style for highlighted lines when hovering over copy button. Theme-aware so
+  // it stays a subtle tint (not a dark block) in light mode.
   .copyHover {
-    background-color: #{$fog-800};
+    background-color: var(--nav-highlight-color);
   }
 
   // Code box div
@@ -88,7 +89,7 @@
             scroll-margin-top: 90px;
             &:hover{
               // text-decoration: none !important;
-              color: #fff;
+              color: var(--body-font-color);
               font-weight: 800;
               text-decoration: none !important;
             }

--- a/docs/themes/geekboot/assets/scss/_code-theme-dark.scss
+++ b/docs/themes/geekboot/assets/scss/_code-theme-dark.scss
@@ -1,6 +1,6 @@
 @mixin code-theme-dark {
 
-  --code-block-background-color: #{$fog-900};
+  --code-block-background-color: #{$mp-bg-card};
   --code-line-number-color: #{$fog-300};
 
   /* Theme: Colors customized for Crossplane. Was originally Dracula */

--- a/docs/themes/geekboot/assets/scss/_code-theme-dark.scss
+++ b/docs/themes/geekboot/assets/scss/_code-theme-dark.scss
@@ -3,6 +3,9 @@
   --code-block-background-color: #{$mp-bg-card};
   --code-line-number-color: #{$fog-300};
 
+  // Subtle border so code blocks read as elevated panels on the dark spruce bg.
+  .highlight { border: 1px solid #{$mp-border}; }
+
   /* Theme: Colors customized for Crossplane. Was originally Dracula */
 
   /* Background */

--- a/docs/themes/geekboot/assets/scss/_code-theme-light.scss
+++ b/docs/themes/geekboot/assets/scss/_code-theme-light.scss
@@ -1,26 +1,30 @@
 @mixin code-theme-light {
 
-  --code-block-background-color: #{$fog-900};
-  --code-line-number-color: #{$fog-300};
+  --code-block-background-color: #{$fog-50};
+  --code-line-number-color: #{$fog-500};
 
-  /* Theme: Colors customized for Crossplane. Was originally Dracula */
+  /* Light code theme — dark text on a light surface, brand-coordinated tokens. */
 
   /* Background */
   .bg {
-    color: #f8f8f2;
-    background-color: #1b1c16;
+    color: #{$fog-1000};
+    background-color: #{$fog-50};
   }
   /* PreWrapper */
   .chroma {
-    color: #f8f8f2;
-    //background-color: #1b1c16;
+    color: #{$fog-1000};
+    //background-color: #{$fog-50};
+
+    // Override the base mixin's near-white default code colour so unhighlighted
+    // tokens (plain names, punctuation) stay legible on the light surface.
+    code { color: #{$fog-1000}; }
   }
   /* Other */
   .chroma .x {
   }
   /* Error */
   .chroma .err {
-    border-color: #{$salmon-300};
+    border-color: #{$salmon-700};
   }
   /* CodeLine */
   .chroma .cl {
@@ -41,7 +45,7 @@
   }
   /* LineHighlight */
   .chroma .hl {
-    background-color: #{$fog-800};
+    background-color: #{$fog-100};
   }
   /* LineNumbersTable */
   .chroma .lnt {
@@ -49,7 +53,7 @@
     user-select: none;
     margin-right: 0.4em;
     padding: 0 0.4em 0 0.4em;
-    color: #{$fog-300};
+    color: #{$fog-500};
   }
   /* LineNumbers */
   .chroma .ln {
@@ -57,11 +61,11 @@
     user-select: none;
     margin-right: 0.4em;
     padding: 0 0.4em 0 0.4em;
-    color: #{$fog-300};
+    color: #{$fog-500};
   }
   /* LineNumber Right Border */
   .highlight .chroma code .ln {
-    border-right: 1px solid #{$fog-700};
+    border-right: 1px solid #{$fog-200};
   }
   /* Line */
   .chroma .line {
@@ -69,30 +73,31 @@
   }
   /* Keyword, KeywordDeclaration, KeywordCosntant, KeywordPseudo, KeywordReserved, KeywordType, NameConstant, GenericOutput */
   .chroma .k, .chroma .kd, .chroma .kc, .chroma .kp, .chroma .kr, .chroma .kt, .chroma .no, .chroma .go {
-    color: #{$tangerine-300};
+    color: #{$mp-purple-dark};
   }
   /* KeywordNamespace, NameTag, Operator, OperatorWord */
   .chroma .kn, .chroma .nt, .chroma .o, .chroma .ow {
-    color: #{$aqua-300};
+    color: #{$aqua-700};
   }
   /* Name, NameBuiltin, NameBuiltinPseudo, NameEntity, NameFunctionMagic, NameLabel, NameNamespace, NameProperty, NameVariable, NameVariableClass, NameVariableGlobal, NameVariableInstance, NameVariableMagic, Punctuation, Generic, GenericHeading, GenericError, GenericPrompt, GenericTraceback, GenericUnderline, TextWhitespace */
   .chroma .n, .chroma .nb, .chroma .bp, .chroma .ni, .chroma .fm, .chroma .nl, .chroma .nn, .chroma .py, .chroma .nv, .chroma .vc, .chroma .vg, .chroma .vi, .chroma .vm, .chroma .p, .chroma .g, .chroma .gh, .chroma .gr, .chroma .gp, .chroma .gt, .chroma .gl, .chroma .w {
   }
   /* NameAttribute, NameClass, NameDecorator, NameException, NameFunction, NameOther, GenericInserted, Unsure what GH is */
   .chroma .na, .chroma .nc, .chroma .nd, .chroma .ne, .chroma .nf, .chroma .nx, .chroma .gi, .chroma .gh {
-    color: #{$grass-300};
+    color: #{$grass-800};
   }
   /* Literal, LiteralStringEscape, LiteralNumber, LiteralNumberBin, LiteralNumberFloat, LiteralNumberHex, LiteralNumberInteger, LiteralNumberIntegerLong, LiteralNumberOct, GenericDeleted */
   .chroma .l, .chroma .se, .chroma .m, .chroma .mb, .chroma .mf, .chroma .mh, .chroma .mi, .chroma .il, .chroma .mo, .chroma .gd {
-    color: #{$salmon-300};
+    color: #{$salmon-700};
   }
   /* LiteralDate, LiteralString, LiteralStringAffix, LiteralStringBacktick, LiteralStringChar, LiteralStringDelimiter, LiteralStringDoc, LiteralStringDouble, LiteralStringHeredoc, LiteralStringInterpol, LiteralStringOther, LiteralStringRegex, LiteralStringSingle, LiteralStringSymbol */
   .chroma .ld, .chroma .s, .chroma .sa, .chroma .sb, .chroma .sc, .chroma .dl, .chroma .sd, .chroma .s2, .chroma .sh, .chroma .si, .chroma .sx, .chroma .sr, .chroma .s1, .chroma .ss {
-    color: #{$sun-300};
+    color: #{$sun-800};
   }
   /* Comment, CommentHashbang, CommentMultiline, CommentSingle, CommentSpecial, CommentPreproc, CommentPreprocFile, GenericSubheading */
   .chroma .c, .chroma .ch, .chroma .cm, .chroma .c1, .chroma .cs, .chroma .cp, .chroma .cpf, .chroma .gu {
-    color: #{$fog-300};
+    color: #{$fog-600};
+    font-style: italic;
   }
   /* GenericEmph */
   .chroma .ge {
@@ -105,5 +110,15 @@
   // Add custom border radius
   .highlight {
     border-radius: 0.375rem;
+  }
+
+  // The base mixin colours the clipboard/edit affordances for a dark surface;
+  // darken them so they read on the light code block.
+  .highlight {
+    .text-white { fill: #{$fog-500}; }
+    .bd-clipboard .btn-clipboard {
+      color: #{$fog-500};
+      &:hover { color: #{$fog-1000}; }
+    }
   }
 }

--- a/docs/themes/geekboot/assets/scss/_code-theme-light.scss
+++ b/docs/themes/geekboot/assets/scss/_code-theme-light.scss
@@ -1,19 +1,28 @@
 @mixin code-theme-light {
 
-  --code-block-background-color: #{$fog-50};
+  --code-block-background-color: #{$fog-0};
   --code-line-number-color: #{$fog-500};
 
-  /* Light code theme — dark text on a light surface, brand-coordinated tokens. */
+  /* Light code theme — dark text on a white surface, brand-coordinated tokens. */
+
+  // White code blocks need a border to read against the white page. The default
+  // code colour from the base mixin is near-white, so force dark text here at a
+  // matching specificity (kubectl/shell lines are plain, uncoloured text).
+  .highlight {
+    border: 1px solid #{$fog-150};
+    .chroma,
+    .chroma code { color: #{$fog-1000}; }
+  }
 
   /* Background */
   .bg {
     color: #{$fog-1000};
-    background-color: #{$fog-50};
+    background-color: #{$fog-0};
   }
   /* PreWrapper */
   .chroma {
     color: #{$fog-1000};
-    //background-color: #{$fog-50};
+    //background-color: #{$fog-0};
 
     // Override the base mixin's near-white default code colour so unhighlighted
     // tokens (plain names, punctuation) stay legible on the light surface.

--- a/docs/themes/geekboot/assets/scss/_components.scss
+++ b/docs/themes/geekboot/assets/scss/_components.scss
@@ -1,0 +1,266 @@
+// Modelplane docs components: support matrix, catalog cards, example blocks,
+// persona path cards, and badges. Brand palette comes from _variables.scss.
+//
+// Tuned for the dark default (matching the website). Light-mode overrides at the
+// end keep them legible when the theme toggle is set to light.
+
+// Per-component tokens, dark by default.
+.bd-content {
+  --mp-card-bg: #{$mp-bg-card};
+  --mp-card-border: #{$mp-border};
+  --mp-card-border-hi: #{$mp-border-hi};
+  --mp-card-muted: #{$mp-muted};
+}
+
+// ── Support matrix ────────────────────────────────────────────
+.mp-matrix-group { margin: 1.5rem 0 2rem; }
+
+.mp-matrix-title {
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin-bottom: 0.25rem;
+}
+
+.mp-matrix-desc {
+  color: var(--mp-card-muted);
+  font-size: 0.9rem;
+  margin: 0 0 0.75rem;
+}
+
+.mp-matrix-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+
+  th, td {
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    border-top: 1px solid var(--mp-card-border);
+    vertical-align: top;
+  }
+  th[scope="row"] { font-weight: 600; white-space: nowrap; }
+  .mp-matrix-status { width: 1%; white-space: nowrap; }
+  .mp-matrix-note { color: var(--mp-card-muted); }
+}
+
+// ── Status pills ──────────────────────────────────────────────
+.mp-status {
+  display: inline-block;
+  font-family: #{$font-family-monospace};
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  padding: 1px 8px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.mp-status--available {
+  color: #{$mp-green};
+  background: rgba(52, 211, 153, 0.08);
+  border-color: rgba(52, 211, 153, 0.25);
+}
+.mp-status--preview {
+  color: #{$mp-cyan};
+  background: rgba(0, 220, 232, 0.10);
+  border-color: rgba(0, 220, 232, 0.30);
+}
+.mp-status--planned {
+  color: #{$mp-muted-hi};
+  background: rgba(139, 138, 174, 0.08);
+  border-color: rgba(139, 138, 174, 0.25);
+}
+
+// ── Catalog cards (models, recipes) ───────────────────────────
+.mp-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 16px;
+  margin: 1.5rem 0;
+}
+
+.mp-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  background: var(--mp-card-bg);
+  border: 1px solid var(--mp-card-border);
+  border-radius: 8px;
+  transition: border-color 0.2s;
+
+  &:hover { border-color: var(--mp-card-border-hi); }
+}
+
+.mp-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.mp-card-title {
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  &.mp-card-title--mono { font-family: #{$font-family-monospace}; font-size: 0.95rem; }
+}
+
+.mp-card-tag {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--mp-card-muted);
+  border: 1px solid var(--mp-card-border);
+  border-radius: 4px;
+  padding: 1px 7px;
+  white-space: nowrap;
+  &.mp-card-tag--ok { color: #{$mp-green}; border-color: rgba(52, 211, 153, 0.3); }
+}
+
+.mp-card-meta {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  div { display: flex; justify-content: space-between; gap: 12px; font-size: 0.85rem; }
+  dt { color: var(--mp-card-muted); margin: 0; font-weight: 400; }
+  dd { margin: 0; text-align: right; }
+}
+
+.mp-card-note {
+  font-size: 0.82rem;
+  color: var(--mp-card-muted);
+  margin: 0;
+}
+
+.mp-card-link {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-top: auto;
+  color: #{$mp-purple-hi};
+  text-decoration: none;
+  &:hover { color: #{$mp-purple}; text-decoration: none; }
+}
+
+// ── Example-from-source block ─────────────────────────────────
+.mp-example {
+  margin: 1.25rem 0;
+  border: 1px solid var(--mp-card-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.mp-example-cap {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 12px;
+  font-family: #{$font-family-monospace};
+  font-size: 0.75rem;
+  color: var(--mp-card-muted);
+  background: rgba(255, 255, 255, 0.02);
+  border-bottom: 1px solid var(--mp-card-border);
+}
+
+.mp-copy-code-btn {
+  font-family: inherit;
+  font-size: 0.72rem;
+  color: var(--mp-card-muted);
+  background: none;
+  border: 1px solid var(--mp-card-border);
+  border-radius: 4px;
+  padding: 1px 8px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  &:hover { color: #{$mp-muted-hi}; border-color: #{$mp-border-hi}; }
+}
+
+.mp-example-code pre { margin: 0; border-radius: 0; }
+
+// ── Persona path cards ────────────────────────────────────────
+.mp-personas {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+  margin: 1.5rem 0;
+}
+
+.mp-persona {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 20px;
+  background: var(--mp-card-bg);
+  border: 1px solid var(--mp-card-border);
+  border-radius: 10px;
+  text-decoration: none;
+  transition: border-color 0.2s, transform 0.2s;
+
+  &:hover { border-color: var(--mp-card-border-hi); transform: translateY(-2px); text-decoration: none; }
+}
+
+.mp-persona-role {
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--bs-body-color, inherit);
+}
+.mp-persona--platform .mp-persona-role { color: #{$mp-cyan}; }
+.mp-persona--developer .mp-persona-role { color: #{$mp-purple-hi}; }
+
+.mp-persona-desc { font-size: 0.9rem; color: var(--mp-card-muted); }
+
+.mp-persona-cta { font-size: 0.85rem; font-weight: 600; margin-top: auto; }
+.mp-persona--platform .mp-persona-cta { color: #{$mp-cyan}; }
+.mp-persona--developer .mp-persona-cta { color: #{$mp-purple-hi}; }
+
+// ── Inline persona badge ──────────────────────────────────────
+.mp-badge {
+  display: inline-block;
+  font-family: #{$font-family-monospace};
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  padding: 1px 8px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  vertical-align: middle;
+}
+.mp-badge--platform {
+  color: #{$mp-cyan};
+  background: rgba(0, 220, 232, 0.08);
+  border-color: rgba(0, 220, 232, 0.30);
+}
+.mp-badge--developer {
+  color: #{$mp-purple-hi};
+  background: rgba(154, 94, 252, 0.08);
+  border-color: rgba(154, 94, 252, 0.30);
+}
+
+// ── Light-mode overrides ──────────────────────────────────────
+[color-theme="light"] .bd-content {
+  --mp-card-bg: #{$fog-25};
+  --mp-card-border: #{$fog-150};
+  --mp-card-border-hi: rgba(154, 94, 252, 0.4);
+  --mp-card-muted: #{$fog-600};
+}
+[color-theme="light"] {
+  // Brand accents need darker shades to stay legible on white (the dark-mode
+  // purple/sky/green wash out at WCAG-AA contrast).
+  .mp-persona--developer .mp-persona-role,
+  .mp-persona--developer .mp-persona-cta,
+  .mp-badge--developer,
+  .mp-card-link { color: #{$mp-purple-dark}; }
+
+  .mp-persona--platform .mp-persona-role,
+  .mp-persona--platform .mp-persona-cta,
+  .mp-badge--platform,
+  .mp-status--preview { color: #{$aqua-700}; }
+
+  .mp-status--available { color: #{$grass-800}; }
+  .mp-status--planned { color: #{$fog-700}; }
+
+  .mp-example-cap { background: #{$fog-50}; }
+}

--- a/docs/themes/geekboot/assets/scss/_components.scss
+++ b/docs/themes/geekboot/assets/scss/_components.scss
@@ -327,7 +327,12 @@
 // Copy lives in the card header (and we don't want it on plain blocks either) —
 // hide the JS-injected floating copy button everywhere. The base rule lives
 // inside :root[color-theme="…"], so the override has to match that specificity.
+// `.bd-clipboard` is injected by JS at runtime, so it isn't in hugo_stats.json;
+// the purgecss-ignore guard keeps this rule from being stripped in production
+// (which is why the button reappeared on Vercel but not in `hugo server`).
+/* purgecss start ignore */
 :root[color-theme="light"] .highlight .bd-clipboard,
 :root[color-theme="dark"] .highlight .bd-clipboard {
   display: none !important;
 }
+/* purgecss end ignore */

--- a/docs/themes/geekboot/assets/scss/_components.scss
+++ b/docs/themes/geekboot/assets/scss/_components.scss
@@ -264,3 +264,70 @@
 
   .mp-example-cap { background: #{$fog-50}; }
 }
+
+// ── Code card: a code block with a filename header + copy button ────────────
+.code-card {
+  margin: 1.1rem 0;
+  border: 1px solid var(--dropdown-border-color);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.code-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 8px 6px 12px;
+  background: #{$mp-purple}; // Purple from the stylescape
+}
+.code-card__name {
+  font-family: #{$font-family-monospace};
+  font-size: 0.8rem;
+  color: #ffffff;
+}
+.code-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.code-card__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 4px;
+  background: none;
+  border: none;
+  border-radius: 5px;
+  color: rgba(255, 255, 255, 0.8);
+  cursor: pointer;
+  transition: color 0.12s ease, background 0.12s ease, transform 0.08s ease;
+
+  svg { display: block; }
+  .icon-check { display: none; }
+
+  &:hover { color: #ffffff; background: rgba(255, 255, 255, 0.18); }
+  // Pressed state — visibly depresses on click.
+  &:active { transform: scale(0.88); background: rgba(255, 255, 255, 0.28); }
+
+  // Copied — swap the main icon for a checkmark.
+  &.copied {
+    color: #ffffff;
+    background: rgba(255, 255, 255, 0.22);
+    .icon-main { display: none; }
+    .icon-check { display: block; }
+  }
+}
+// Code sits flush under the header — no gap, no separate border/radius/margin.
+.code-card__body {
+  .highlight, .chroma, pre { margin: 0 !important; }
+  .highlight { border: none; border-radius: 0; }
+}
+
+// Copy lives in the card header (and we don't want it on plain blocks either) —
+// hide the JS-injected floating copy button everywhere. The base rule lives
+// inside :root[color-theme="…"], so the override has to match that specificity.
+:root[color-theme="light"] .highlight .bd-clipboard,
+:root[color-theme="dark"] .highlight .bd-clipboard {
+  display: none !important;
+}

--- a/docs/themes/geekboot/assets/scss/_content.scss
+++ b/docs/themes/geekboot/assets/scss/_content.scss
@@ -9,6 +9,9 @@ body {
 .bd-content {
   font-size: $body-font-size;
   line-height: 1.6;
+  // Cap the measure for readability on wide screens; wide elements (tables,
+  // mermaid, code) scroll within their own containers.
+  max-width: 52rem;
 
   code {
     background-color: var(--code-background);
@@ -64,8 +67,10 @@ blockquote {
 
 h1,h2,h3,h4,h5,h6 {
   padding-top: 1rem;
-  font-weight: 900;
-  line-height: 1.25;
+  font-family: #{$font-family-headings};
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
 
   &.accordion-header {
     padding-top: 0 !important;

--- a/docs/themes/geekboot/assets/scss/_content.scss
+++ b/docs/themes/geekboot/assets/scss/_content.scss
@@ -6,12 +6,25 @@ body {
   scroll-behavior: smooth;
 }
 
+// Caps the readable measure and centres it within the (full-width) content
+// column. Block margin:auto centres without shrink-to-fit, so wide children
+// (code, mermaid) scroll within rather than overflowing into the rail.
+.bd-content-inner,
+.bd-intro-inner {
+  max-width: 52rem;
+  margin-inline: auto;
+}
+
 .bd-content {
   font-size: $body-font-size;
   line-height: 1.6;
-  // Cap the measure for readability on wide screens; wide elements (tables,
-  // mermaid, code) scroll within their own containers.
-  max-width: 52rem;
+  // The grid item fills its track (do NOT cap/margin-auto it here — that would
+  // size it to its content and overflow the track into the rail). The inner
+  // wrapper caps and centres the measure instead.
+  min-width: 0;
+  overflow-wrap: break-word;
+
+  img { max-width: 100%; height: auto; }
 
   code {
     background-color: var(--code-background);

--- a/docs/themes/geekboot/assets/scss/_content.scss
+++ b/docs/themes/geekboot/assets/scss/_content.scss
@@ -16,7 +16,7 @@ body {
   code {
     background-color: var(--code-background);
     color: var(--code-color);
-    padding: 0.2em 0.4em;
+    padding: 0;
   }
 
   a {
@@ -34,19 +34,36 @@ body {
 
   }
 
-  // Offset content from fixed navbar when jumping to headings
-  & :target {
-    padding-top: 5rem;
-    margin-top: -5rem;
+  // When jumping to an anchor, leave room above it for the sticky header —
+  // via scroll-margin (offsets the scroll position) instead of padding, so no
+  // visible spacing is added before the section.
+  [id] { scroll-margin-top: 4.5rem; }
+
+  // Vertical rhythm
+  p, ul, ol, dl, pre, blockquote,
+  .table-responsive, .mp-cards, .mp-personas, .mp-matrix-group, .code-card {
+    margin-bottom: 0.75rem;
   }
+  ul, ol { padding-left: 1.5rem; }
+  li { margin-bottom: 0.25rem; }
+  li > ul, li > ol { margin-top: 0.25rem; margin-bottom: 0; }
 
+  // Code blocks match the body text size.
+  .chroma { font-size: 1rem !important; }
 
+  // The first block sits flush under the page title.
+  > :first-child {
+    margin-top: 0 !important;
+    padding-top: 0 !important;
+    border-top: none !important;
+  }
 }
 
 .bd-title {
   font-size: 2rem;
   font-weight: 600;
-  line-height: 2.75rem;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
   margin-top: 0;
 }
 
@@ -65,38 +82,49 @@ blockquote {
   font-size: 1rem
 }
 
-h1,h2,h3,h4,h5,h6 {
-  padding-top: 1rem;
+.bd-content h1,
+.bd-content h2,
+.bd-content h3,
+.bd-content h4,
+.bd-content h5,
+.bd-content h6 {
   font-family: #{$font-family-headings};
   font-weight: 600;
   letter-spacing: -0.01em;
-  line-height: 1.2;
+  line-height: 1.25;
 
   &.accordion-header {
     padding-top: 0 !important;
   }
 }
 // H1s when manually added
-h1 {
+.bd-content h1 {
   margin-top: 3rem;
-  margin-bottom: 1.5rem !important;
-  font-size: 2rem !important;
+  margin-bottom: 1rem !important;
+  font-size: 1.9rem !important;
 }
 // Section titles
-h2 {
-  margin-top: 3rem !important;
-  margin-bottom: 1.5rem !important;
-  font-size: 1.5rem !important;
+.bd-content h2 {
+  margin-top: 2.25rem !important;
+  margin-bottom: 0.85rem !important;
+  font-size: 1.55rem !important;
 }
-h2.accordion-header {
-  margin-top: 0px !important;
-  margin-bottom: 0px !important;
+.bd-content h2.accordion-header {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
 }
 // Subhead titles
-h3, h4, h5, h6 {
-  margin-top: 2.5rem !important;
-  margin-bottom: 1.25rem !important;
-  font-size: 1.25rem !important;
+.bd-content h3 {
+  margin-top: 2rem !important;
+  margin-bottom: 0.6rem !important;
+  font-size: 1.2rem !important;
+}
+.bd-content h4,
+.bd-content h5,
+.bd-content h6 {
+  margin-top: 1.75rem !important;
+  margin-bottom: 0.5rem !important;
+  font-size: 1.05rem !important;
 }
 .d-none.d-md-block.h6.my-2 {
   margin-top: 0px !important;
@@ -116,35 +144,34 @@ h3, h4, h5, h6 {
 
 // Tables
 .table {
-  border-radius: 6px;
   border-collapse: separate;
-  border-spacing: 0px;
-  margin-bottom: 0px !important;
+  border-spacing: 0;
+  margin-bottom: 0 !important;
+  color: var(--body-font-color);
 }
 
 .table-responsive {
-  margin-bottom: 1rem;
-  border: 1px solid #{$fog-200};
+  margin-bottom: 1.1rem;
+  border: 1px solid var(--dropdown-border-color);
+  border-radius: 8px;
+  overflow: hidden;
   background-color: var(--body-background) !important;
   color: var(--body-font-color);
 }
 
-// Hide bottom borders and wider padding for header items
+// Header row: subtle surface + emphasis so columns read clearly.
 .table th {
-  border-bottom: none;
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 12px;
-  padding-bottom: 12px;
+  background-color: var(--expand-box-background);
+  font-weight: 600;
+  border-bottom: 1px solid var(--dropdown-border-color);
+  padding: 11px 20px;
 }
-// Add only top borders and wider padding for content items
+// Body rows: hairline separators in the theme border colour.
 .table td {
   border-bottom: none;
-  padding-left: 24px;
-  padding-right: 24px;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  border-top: 1px solid #{$fog-300};
+  padding: 11px 20px;
+  border-top: 1px solid var(--dropdown-border-color);
+  vertical-align: top;
 }
 // Decrease padding for small tables
 .table.table-sm th {

--- a/docs/themes/geekboot/assets/scss/_fonts.scss
+++ b/docs/themes/geekboot/assets/scss/_fonts.scss
@@ -1,7 +1,13 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=DM+Mono:wght@400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@500;600;700&family=Inter:wght@400;500;600;700;800&family=DM+Mono:wght@400;500&display=swap');
 
 body {
   font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+// Headings use Outfit (the stylescape display face); body stays Inter.
+h1, h2, h3, h4, h5, h6,
+.bd-title {
+  font-family: #{$font-family-headings};
 }
 
 code, pre, .font-mono {

--- a/docs/themes/geekboot/assets/scss/_fonts.scss
+++ b/docs/themes/geekboot/assets/scss/_fonts.scss
@@ -12,5 +12,5 @@ h1, h2, h3, h4, h5, h6,
 
 code, pre, .font-mono {
   font-family: "DM Mono", "Fira Code", monospace;
-  font-size: .95rem;
+  font-size: 1rem;
 }

--- a/docs/themes/geekboot/assets/scss/_layout.scss
+++ b/docs/themes/geekboot/assets/scss/_layout.scss
@@ -19,7 +19,12 @@
   body.docs-app { overflow: hidden; }
   .bd-layout.docs-container { height: 100dvh; }
   .bd-sidebar { height: 100dvh; overflow: hidden; }
-  .bd-main { height: 100dvh; overflow-y: auto; }
+  // Reserve the scrollbar gutter always, so tall (scrolling) pages and short
+  // pages compute the same content width — otherwise the scrollbar that only
+  // appears on long pages narrows the area and the "On this page" rail can
+  // overlap the content.
+  .bd-main { height: 100dvh; overflow-y: auto; scrollbar-gutter: stable; }
+  .bd-sidebar-scroll { scrollbar-gutter: stable; }
 }
 
 .bd-sidebar {
@@ -70,34 +75,40 @@
     gap: inherit;
   }
 
+  // lg–1280: sidebar + content only. The "On this page" rail is dropped here so
+  // the content stays comfortably wide (favour content over the rails).
   @include media-breakpoint-up(lg) {
+    grid-template-areas:
+      "intro"
+      "content";
+    grid-template-rows: auto 1fr;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  // Wide screens: bring back the "On this page" rail, pinned to the right edge.
+  @media (min-width: 1280px) {
     grid-template-areas:
       "intro   toc"
       "content toc";
-    grid-template-rows: auto 1fr;
-    // Content capped near its measure; the "On this page" rail sits right
-    // alongside it. Centre the content+rail group in the main area so the
-    // whitespace is balanced between the left nav and the right edge.
-    grid-template-columns: minmax(0, 52rem) 17rem;
+    grid-template-columns: minmax(0, 1fr) 17rem;
     column-gap: 2.5rem;
-    justify-content: center;
   }
 
-  &.no-toc{
-
-    @include media-breakpoint-up(lg) {
-      grid-template-areas:
-        "intro   toc"
-        "content content" !important;
-      grid-template-rows: auto 1fr;
-      grid-template-columns: 4fr 1fr;
+  // Pages with no "On this page" rail: never reserve the right column, so the
+  // content centres across the full width instead of being shifted left.
+  &.no-toc {
+    @media (min-width: 1280px) {
+      grid-template-areas: "intro" "content";
+      grid-template-columns: minmax(0, 1fr);
     }
+    .bd-toc { display: none; }
   }
 }
 
 .bd-intro {
   grid-area: intro;
   padding-bottom: 1.5rem;
+  min-width: 0;
 }
 
 .bd-toc {

--- a/docs/themes/geekboot/assets/scss/_layout.scss
+++ b/docs/themes/geekboot/assets/scss/_layout.scss
@@ -7,9 +7,19 @@
   @include media-breakpoint-up(lg) {
     display: grid;
     grid-template-areas: "sidebar main";
-    grid-template-columns: 1fr 5fr;
-    gap: $grid-gutter-width;
+    grid-template-columns: 17rem minmax(0, 1fr);
+    gap: 0;
   }
+}
+
+// App shell: on large screens the page itself does not scroll — the sidebar and
+// the main content each scroll independently within the viewport height.
+@include media-breakpoint-up(lg) {
+  html, body { height: 100%; }
+  body.docs-app { overflow: hidden; }
+  .bd-layout.docs-container { height: 100dvh; }
+  .bd-sidebar { height: 100dvh; overflow: hidden; }
+  .bd-main { height: 100dvh; overflow-y: auto; }
 }
 
 .bd-sidebar {
@@ -18,10 +28,36 @@
 
 .bd-main {
   grid-area: main;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+// Static header nav (Documentation / Reference tabs) at the top of the content
+// column. Sticky on desktop so it stays put while the content scrolls.
+.doc-content-nav {
+  flex: 0 0 auto;
+  background: var(--body-background);
+  border-bottom: 1px solid var(--dropdown-border-color);
+  padding: 0 18px;
+
+  // On phones the Documentation/Reference switch moves into the sidebar drawer.
+  @include media-breakpoint-down(lg) { display: none; }
+
+  @include media-breakpoint-up(lg) {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+}
+
+.bd-main-grid {
   padding: 18px;
+
   @include media-breakpoint-down(lg) {
     max-width: 760px;
     margin-inline: auto;
+    width: 100%;
   }
 
   @include media-breakpoint-up(md) {

--- a/docs/themes/geekboot/assets/scss/_layout.scss
+++ b/docs/themes/geekboot/assets/scss/_layout.scss
@@ -76,9 +76,11 @@
       "content toc";
     grid-template-rows: auto 1fr;
     // Content capped near its measure; the "On this page" rail sits right
-    // alongside it and gets noticeably more room than before.
+    // alongside it. Centre the content+rail group in the main area so the
+    // whitespace is balanced between the left nav and the right edge.
     grid-template-columns: minmax(0, 52rem) 17rem;
     column-gap: 2.5rem;
+    justify-content: center;
   }
 
   &.no-toc{

--- a/docs/themes/geekboot/assets/scss/_layout.scss
+++ b/docs/themes/geekboot/assets/scss/_layout.scss
@@ -52,7 +52,7 @@
 }
 
 .bd-main-grid {
-  padding: 18px;
+  padding: 0.4rem 18px 24px;
 
   @include media-breakpoint-down(lg) {
     max-width: 760px;
@@ -75,7 +75,10 @@
       "intro   toc"
       "content toc";
     grid-template-rows: auto 1fr;
-    grid-template-columns: 4fr 1fr;
+    // Content capped near its measure; the "On this page" rail sits right
+    // alongside it and gets noticeably more room than before.
+    grid-template-columns: minmax(0, 52rem) 17rem;
+    column-gap: 2.5rem;
   }
 
   &.no-toc{
@@ -92,6 +95,7 @@
 
 .bd-intro {
   grid-area: intro;
+  padding-bottom: 1.5rem;
 }
 
 .bd-toc {

--- a/docs/themes/geekboot/assets/scss/_mermaid.scss
+++ b/docs/themes/geekboot/assets/scss/_mermaid.scss
@@ -1,5 +1,11 @@
 .mermaid{
     fill: var(--body-font-color) !important;
+    // Keep diagrams inside the content column (scale/scroll) rather than
+    // spilling into the "On this page" rail.
+    max-width: 100%;
+    overflow-x: auto;
+
+    svg { max-width: 100% !important; height: auto; }
 
     .messageText, .loopText>tspan, .marker, .marker.cross{
         color: var(--body-font-color) !important;

--- a/docs/themes/geekboot/assets/scss/_modelplane.scss
+++ b/docs/themes/geekboot/assets/scss/_modelplane.scss
@@ -14,27 +14,7 @@ nav.site-nav a {
   vertical-align: baseline;
 }
 
-// Grid-line background — matches website globals.css body::after exactly
-body::after {
-  content: '';
-  position: fixed; inset: 0; z-index: 0;
-  background-image:
-    linear-gradient(rgba(255,255,255,0.05) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px);
-  background-size: 80px 80px;
-  pointer-events: none;
-  opacity: 0.5;
-}
-
-// Lift layout and footer above the grid (z-index:0).
-// docs-navbar is NOT here — _navbar.scss owns position:sticky + z-index:100
-// and _modelplane.scss loads after _navbar.scss, so adding docs-navbar here
-// would silently override sticky with relative.
-.bd-layout,
-.bd-footer {
-  position: relative;
-  z-index: 1;
-}
+// Plain background (Dark Spruce in dark mode) — no grid overlay.
 
 // Sidebar active border uses purple
 .bd-links-nav {

--- a/docs/themes/geekboot/assets/scss/_modelplane.scss
+++ b/docs/themes/geekboot/assets/scss/_modelplane.scss
@@ -19,8 +19,8 @@ body::after {
   content: '';
   position: fixed; inset: 0; z-index: 0;
   background-image:
-    linear-gradient(rgba(255,255,255,0.07) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255,255,255,0.07) 1px, transparent 1px);
+    linear-gradient(rgba(255,255,255,0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px);
   background-size: 80px 80px;
   pointer-events: none;
   opacity: 0.5;
@@ -79,7 +79,8 @@ body::after {
 
 // Page title
 .bd-title {
-  font-weight: 800;
+  font-family: #{$font-family-headings};
+  font-weight: 700;
   letter-spacing: -0.02em;
 }
 
@@ -112,19 +113,20 @@ body::after {
   font-weight: 600;
   letter-spacing: 0.03em;
   color: #{$mp-cyan};
-  background: rgba(34,211,238,0.07);
-  border: 1px solid rgba(34,211,238,0.2);
+  background: rgba(0,220,232,0.08);
+  border: 1px solid rgba(0,220,232,0.25);
   border-radius: 4px;
   padding: 2px 7px;
   text-decoration: none;
   transition: background 150ms;
 
   &:hover {
-    background: rgba(34,211,238,0.14);
+    background: rgba(0,220,232,0.16);
     color: #{$mp-cyan};
     text-decoration: none;
   }
 }
+[color-theme="light"] .mp-llm-badge { color: #{$aqua-700}; }
 
 .mp-copy-page-btn {
   font-family: inherit;
@@ -139,7 +141,7 @@ body::after {
 
   &:hover {
     color: #{$mp-muted-hi};
-    border-color: rgba(173,123,252,0.3);
+    border-color: rgba(154,94,252,0.3);
   }
 }
 
@@ -217,11 +219,11 @@ body::after {
   .footer-by {
     font-family: #{$font-family-monospace};
     font-size: 12px;
-    color: #3a3a55;
+    color: #2E4A5B;
     letter-spacing: 0.06em;
     margin-top: 24px;
 
-    a { color: #4a4a68; text-decoration: none; }
+    a { color: #3E5A6B; text-decoration: none; }
     a:hover { color: #{$mp-muted}; }
   }
 

--- a/docs/themes/geekboot/assets/scss/_navbar.scss
+++ b/docs/themes/geekboot/assets/scss/_navbar.scss
@@ -70,13 +70,63 @@ nav.site-nav .wrap {
   background: none;
   border: none;
   cursor: pointer;
-  color: #{$mp-muted};
+  color: var(--mp-muted);
   padding: 5px;
   border-radius: 6px;
   transition: color 0.2s, background 0.2s;
 
   svg { display: block; }
-  &:hover { color: #ffffff; background: rgba(255,255,255,0.06); }
+  &:hover { color: var(--body-font-color); background: var(--nav-highlight-color); }
+}
+
+// Mobile-only top bar (the sidebar is a drawer on small screens)
+.docs-topbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--body-background);
+  border-bottom: 1px solid var(--dropdown-border-color);
+}
+.docs-topbar-toggle {
+  display: inline-flex;
+  align-items: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--mp-muted);
+  padding: 4px;
+  &:hover { color: var(--body-font-color); }
+}
+.docs-topbar-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-right: auto;
+  text-decoration: none;
+  color: var(--body-font-color);
+
+  &:hover { color: var(--body-font-color); text-decoration: none; }
+}
+.docs-topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.docs-topbar-search {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--mp-muted);
+  padding: 4px;
+
+  &:hover { color: var(--body-font-color); }
 }
 // Show the sun in dark mode (click → light) and the moon in light mode
 // (click → dark). Default both hidden, then reveal per theme.

--- a/docs/themes/geekboot/assets/scss/_navbar.scss
+++ b/docs/themes/geekboot/assets/scss/_navbar.scss
@@ -5,8 +5,8 @@ nav.site-nav {
   position: sticky; top: 0; z-index: 100;
   margin: 0;
   padding: 0;
-  border-bottom: 1px solid rgba(255,255,255,0.07);
-  background: rgba(7,7,20,0.85);
+  border-bottom: 1px solid #{$mp-border};
+  background: rgba(0,29,47,0.85);
   backdrop-filter: blur(24px);
   -webkit-backdrop-filter: blur(24px);
 }
@@ -40,7 +40,7 @@ nav.site-nav .wrap {
 .nav-links a {
   font-size: 14px;
   font-weight: 400;
-  color: #8b8aae;
+  color: #{$mp-muted};
   text-decoration: none;
   transition: color 0.2s;
 }
@@ -49,17 +49,52 @@ nav.site-nav .wrap {
 .nav-cta {
   font-size: 14px;
   font-weight: 500;
-  color: #070714 !important;
-  background: #AD7BFC;
+  color: #{$mp-bg} !important;
+  background: #{$mp-purple};
   padding: 8px 20px;
   border-radius: 6px;
   text-decoration: none;
   transition: background 0.2s, transform 0.15s, box-shadow 0.2s;
 }
 .nav-cta:hover {
-  background: #C39EFD;
+  background: #{$mp-purple-hi};
   transform: translateY(-1px);
-  box-shadow: 0 4px 20px rgba(173,123,252,0.4);
+  box-shadow: 0 4px 20px rgba(154,94,252,0.4);
+}
+
+// Light/dark theme toggle button
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #{$mp-muted};
+  padding: 5px;
+  border-radius: 6px;
+  transition: color 0.2s, background 0.2s;
+
+  svg { display: block; }
+  &:hover { color: #ffffff; background: rgba(255,255,255,0.06); }
+}
+// Show the sun in dark mode (click → light) and the moon in light mode
+// (click → dark). Default both hidden, then reveal per theme.
+.theme-toggle .icon-sun,
+.theme-toggle .icon-moon { display: none; }
+[color-theme="dark"]  .theme-toggle .icon-sun  { display: block; }
+[color-theme="light"] .theme-toggle .icon-moon { display: block; }
+
+// Mobile dropdown variant — full-width row matching the dropdown links
+.theme-toggle--mobile {
+  width: 100%;
+  justify-content: flex-start;
+  gap: 10px;
+  font-size: 16px;
+  padding: 10px 0;
+  border-radius: 0;
+
+  &:hover { background: none; color: #ffffff; }
 }
 
 .nav-hamburger {
@@ -77,7 +112,7 @@ nav.site-nav .wrap {
 .nav-hamburger span {
   display: block;
   height: 2px;
-  background: #b0afcc;
+  background: #{$mp-muted-hi};
   border-radius: 2px;
   transition: transform 0.2s, opacity 0.2s;
 }
@@ -88,18 +123,18 @@ nav.site-nav .wrap {
 .nav-dropdown {
   display: flex;
   flex-direction: column;
-  background: rgba(7,7,20,0.97);
-  border-top: 1px solid rgba(255,255,255,0.07);
+  background: rgba(0,29,47,0.97);
+  border-top: 1px solid #{$mp-border};
   padding: 16px 20px 24px;
   gap: 4px;
 }
 .nav-dropdown a {
   font-size: 16px;
   font-weight: 400;
-  color: #8b8aae;
+  color: #{$mp-muted};
   text-decoration: none;
   padding: 10px 0;
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+  border-bottom: 1px solid #{$mp-border};
   transition: color 0.2s;
 }
 .nav-dropdown a:last-child { border-bottom: none; }
@@ -107,7 +142,7 @@ nav.site-nav .wrap {
 
 .nav-cta-mobile {
   margin-top: 8px;
-  color: #C39EFD !important;
+  color: #{$mp-purple-hi} !important;
   font-weight: 600 !important;
   border-bottom: none !important;
 }
@@ -126,7 +161,7 @@ nav.site-nav .wrap {
   background: none;
   border: none;
   cursor: pointer;
-  color: #8b8aae;
+  color: #{$mp-muted};
   padding: 4px;
   border-radius: 4px;
   transition: color 0.2s;

--- a/docs/themes/geekboot/assets/scss/_sidebar.scss
+++ b/docs/themes/geekboot/assets/scss/_sidebar.scss
@@ -102,6 +102,17 @@
     transform: rotate(90deg);
   }
 
+  // Nest child page links beneath their uppercase section header so the
+  // section/page hierarchy reads at a glance.
+  .collapse {
+    margin-left: 5px;
+
+    .bd-links {
+      padding-left: 16px;
+      font-size: 0.9rem;
+    }
+  }
+
   .sidebar-icon {
     display: none !important;
   }

--- a/docs/themes/geekboot/assets/scss/_sidebar.scss
+++ b/docs/themes/geekboot/assets/scss/_sidebar.scss
@@ -1,8 +1,6 @@
 .bd-sidebar {
   @include media-breakpoint-up(lg) {
-    align-self: start;
-    position: sticky;
-    top: 4.5rem;
+    grid-area: sidebar;
   }
 }
 
@@ -10,146 +8,257 @@
   background-color: var(--body-background) !important;
 
   @include media-breakpoint-up(lg) {
-    position: static;
+    display: flex;
+    flex-direction: column;
+    height: 100dvh;
+    border-right: 1px solid var(--dropdown-border-color);
   }
-
-  .offcanvas-title{
-    color: var(--body-font-color) !important;
-  }
-
-  .btn-close{
-    filter: var(--btn-close-filter) !important;
-    opacity: 1;
-  }
-
 }
 
-.bd-links-nav {
-  font-size: .95rem !important;
+// ── Brand header (logo + "docs" + theme toggle) ─────────────────
+.bd-sidebar-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 1rem 0.85rem 0.75rem;
+}
 
-  a.bd-links{
-    text-decoration: none !important;
-    color: var(--body-font-color) !important;
+.bd-sidebar-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  text-decoration: none;
+  &:hover { text-decoration: none; }
+}
+
+.brand-mark {
+  display: block;
+  height: 20px;
+  width: auto;
+  flex-shrink: 0;
+}
+.brand-name {
+  font-family: #{$font-family-headings};
+  font-weight: 600;
+  font-size: 1.05rem;
+  line-height: 1;
+  letter-spacing: -0.01em;
+  color: var(--body-font-color);
+}
+.brand-docs {
+  font-family: #{$font-family-headings};
+  font-weight: 600;
+  font-size: 1.05rem;
+  line-height: 1;
+  letter-spacing: -0.01em;
+  color: var(--content-link-color);
+  margin-left: -3px;
+}
+
+.bd-sidebar-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+// ── Segmented light/dark switch ─────────────────────────────────
+.theme-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  padding: 1px;
+  background: var(--expand-box-background);
+  border: 1px solid var(--dropdown-border-color);
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+.theme-switch-opt {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  background: none;
+  border-radius: 999px;
+  color: var(--mp-muted);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+
+  svg { display: block; width: 12px; height: 12px; }
+  &:hover { color: var(--body-font-color); }
+}
+// Highlight the segment matching the active theme.
+[color-theme="light"] .theme-switch-opt[data-theme="light"],
+[color-theme="dark"]  .theme-switch-opt[data-theme="dark"] {
+  background: var(--nav-highlight-color);
+  color: var(--content-link-color);
+}
+
+// ── Documentation / Reference tabs (static header in the content column) ──
+.doc-tabs {
+  display: flex;
+  gap: 20px;
+}
+.doc-tab {
+  padding: 13px 2px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--mp-muted) !important;
+  text-decoration: none !important;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+
+  &:hover { color: var(--body-font-color) !important; }
+  &.active {
+    color: var(--content-link-color) !important;
+    border-bottom-color: var(--content-link-color);
   }
+}
 
-  @include media-breakpoint-down(lg) {
-    margin-top: 0 !important;
-    font-size: 1rem !important;
-  }
+// ── Search ──────────────────────────────────────────────────────
+.search-container {
+  flex: 0 0 auto;
+  padding: 0 1rem 0.85rem;
 
-  .nav-container, .bd-links {
-    margin: 0.35rem 0;
-    border-left-width: 3px;
-    border-left-style: solid;
-    border-left-color: transparent;
-    padding-left: 10px;
+  #docSearch { width: 100%; }
 
-    @include media-breakpoint-down(lg) {
-      margin: .7rem 0 !important;
-    }
+  // On phones, search moves to the top bar (the DocSearch button stays in the
+  // DOM here, just hidden, so the modal still initialises).
+  @include media-breakpoint-down(lg) { display: none; }
+}
 
-    a {
-      text-decoration: none !important;
-      color: var(--body-font-color) !important;
-    }
+// ── Mobile Documentation/Reference switcher (sidebar drawer) ─────
+// A dropdown whose toggle always shows the current section.
+.doc-switch {
+  flex: 0 0 auto;
+  margin: 0 1rem 0.85rem;
+}
+.doc-switch-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 9px 12px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--body-font-color);
+  background: var(--expand-box-background);
+  border: 1px solid var(--dropdown-border-color);
+  border-radius: 8px;
+  cursor: pointer;
+}
+.doc-switch-caret {
+  flex-shrink: 0;
+  color: var(--mp-muted);
+  transition: transform 0.15s ease;
+}
+.doc-switch-toggle[aria-expanded="true"] .doc-switch-caret { transform: rotate(180deg); }
 
-    &.active-parent {
-      border-left-color: #{$mp-purple} !important;
+.doc-switch-menu.dropdown-menu {
+  width: 100%;
+  padding: 4px;
+  background: var(--dropdown-background);
+  border: 1px solid var(--dropdown-border-color);
+  border-radius: 8px;
 
-    }
-    &:hover, &.active {
-      color: var(--body-color);
-      border-left-color: #{$mp-purple};
-      background-color: var(--nav-highlight-color) !important;
-    }
-  }
-
-  .nav-section {
-    cursor: pointer;
-    font-size: 0.75rem;
+  .dropdown-item {
+    padding: 7px 10px;
+    font-size: 0.9rem;
     font-weight: 600;
-    letter-spacing: 0.06em;
+    border-radius: 6px;
+    color: var(--body-font-color);
+
+    &:hover, &:focus {
+      background: var(--nav-highlight-color);
+      color: var(--body-font-color);
+    }
+    &.active {
+      background: var(--nav-highlight-color);
+      color: var(--content-link-color) !important;
+    }
+  }
+}
+
+// ── Scrolling nav area ──────────────────────────────────────────
+.bd-sidebar-scroll {
+  padding: 1rem 0.75rem 2.5rem;
+
+  @include media-breakpoint-up(lg) {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+}
+
+// ── Nav tree ────────────────────────────────────────────────────
+.bd-links-nav {
+  font-size: 0.9rem;
+
+  a { text-decoration: none !important; }
+
+  .nav-group { margin-bottom: 1.5rem; }
+
+  .nav-group-label {
+    font-size: 0.7rem;
+    font-weight: 600;
     text-transform: uppercase;
-    color: var(--mp-muted, #{$mp-muted}) !important;
-    margin-top: 0.75rem;
-    border-left-color: transparent !important;
+    letter-spacing: 0.08em;
+    color: var(--mp-muted);
+    margin-bottom: 0.4rem;
+    padding-left: 10px;
+  }
 
-    a {
-      color: inherit !important;
-      pointer-events: none;
-    }
+  // Section header, and top-level pages (Concepts, API Reference)
+  .nav-section-link {
+    display: block;
+    color: var(--body-font-color) !important;
+    font-weight: 600;
+    padding: 5px 10px;
+    border-radius: 6px;
+    margin-top: 0.15rem;
 
-    &.active-parent {
-      color: var(--body-font-color) !important;
-      border-left-color: transparent !important;
-    }
+    &:hover { color: var(--content-link-color) !important; }
+    &.active { color: var(--content-link-color) !important; }
+  }
+
+  // Child page links, nested under a section header
+  .nav-children {
+    display: flex;
+    flex-direction: column;
+    margin: 2px 0 6px;
+  }
+
+  .bd-links {
+    display: block;
+    color: var(--mp-muted) !important;
+    padding: 4px 10px 4px 16px;
+    margin-left: 10px;
+    border-left: 2px solid transparent;
+    transition: color 0.15s ease, border-color 0.15s ease;
 
     &:hover {
-      background-color: transparent !important;
       color: var(--body-font-color) !important;
-      border-left-color: transparent !important;
+      border-left-color: var(--mp-muted);
+    }
+    &.active {
+      color: var(--content-link-color) !important;
+      border-left-color: var(--content-link-color);
+      font-weight: 500;
     }
   }
+}
 
-  .nav-section-chevron {
-    transition: transform 0.2s ease;
-    color: var(--mp-muted, #{$mp-muted});
-    align-self: center;
-    flex-shrink: 0;
-  }
-
-  [aria-expanded="true"] .nav-section-chevron {
-    transform: rotate(90deg);
-  }
-
-  // Nest child page links beneath their uppercase section header so the
-  // section/page hierarchy reads at a glance.
-  .collapse {
-    margin-left: 5px;
-
-    .bd-links {
-      padding-left: 16px;
-      font-size: 0.9rem;
-    }
-  }
-
-  .sidebar-icon {
-    display: none !important;
-  }
-
-  .sidebar-control-container {
-
-    .sidebar-checkbox{
-      display: none !important;
-    }
-
-    .sidebar-label {
-      &.collapsed{
-
-        svg.sidebar-icon.plus {
-          display: block !important;
-          color: var(--body-font-color);
-          opacity: 1;
-        }
-        svg.sidebar-icon.x {
-          display: none !important;
-          color: var(--body-font-color);
-          opacity: 1;
-        }
-      }
-      &:not(.collapsed){
-
-        svg.sidebar-icon.plus {
-          display: none !important;
-          color: var(--body-font-color);
-          opacity: 1;
-        }
-        svg.sidebar-icon.x {
-          display: block !important;
-          color: var(--body-font-color);
-          opacity: 1;
-        }
-      }
-    }
+// ── Mobile drawer ───────────────────────────────────────────────
+@include media-breakpoint-down(lg) {
+  .bd-sidebar-container.offcanvas-lg {
+    background-color: var(--body-background);
+    width: 320px;
   }
 }

--- a/docs/themes/geekboot/assets/scss/_sidebar.scss
+++ b/docs/themes/geekboot/assets/scss/_sidebar.scss
@@ -174,6 +174,7 @@
     font-weight: 600;
     border-radius: 6px;
     color: var(--body-font-color);
+    text-decoration: none !important;
 
     &:hover, &:focus {
       background: var(--nav-highlight-color);

--- a/docs/themes/geekboot/assets/scss/_toc.scss
+++ b/docs/themes/geekboot/assets/scss/_toc.scss
@@ -3,10 +3,12 @@
 .bd-toc {
   color: var(--toc-font-color);
 
-  // Drop the "On this page" navigation on phones/tablets.
-  @include media-breakpoint-down(lg) { display: none; }
+  // Only shown once the viewport is wide enough for sidebar + comfortable
+  // content + this rail; otherwise content keeps the space.
+  display: none;
 
-  @include media-breakpoint-up(lg) {
+  @media (min-width: 1280px) {
+    display: block;
     align-self: start;
     position: sticky;
     top: 3.5rem;

--- a/docs/themes/geekboot/assets/scss/_toc.scss
+++ b/docs/themes/geekboot/assets/scss/_toc.scss
@@ -3,12 +3,15 @@
 .bd-toc {
   color: var(--toc-font-color);
 
+  // Drop the "On this page" navigation on phones/tablets.
+  @include media-breakpoint-down(lg) { display: none; }
+
   @include media-breakpoint-up(lg) {
     align-self: start;
     position: sticky;
-    top: 4.5rem;
+    top: 3.5rem;
     z-index: 2;
-    max-height: calc(100vh - 4.5rem);
+    max-height: calc(100dvh - 5rem);
     overflow-y: auto;
     border-left: 1px solid var(--dropdown-border-color);
     padding-left: 18px;

--- a/docs/themes/geekboot/assets/scss/_toc.scss
+++ b/docs/themes/geekboot/assets/scss/_toc.scss
@@ -10,7 +10,7 @@
     z-index: 2;
     max-height: calc(100vh - 4.5rem);
     overflow-y: auto;
-    border-left: 1px solid #{$mp-border};
+    border-left: 1px solid var(--dropdown-border-color);
     padding-left: 18px;
   }
 
@@ -21,7 +21,7 @@
     font-weight: 500 !important;
     text-transform: uppercase;
     letter-spacing: 0.16em;
-    color: #{$mp-muted};
+    color: var(--toc-font-color);
     display: block;
     margin-bottom: 14px;
     // reset Bootstrap h6 overrides
@@ -42,14 +42,24 @@
       list-style: none;
       margin-bottom: 0;
 
-      ul { padding-left: 0; margin-top: 0; }
+      // Nested headings (H3+ under an H2) indent and step down a size so the
+      // on-this-page hierarchy is legible.
+      ul {
+        padding-left: 0;
+        margin-top: 0;
+
+        a {
+          padding-left: 30px;
+          font-size: 12px;
+        }
+      }
     }
 
     li { margin-bottom: 0; }
 
     // Matches website .toc a exactly — scoped to list items only
     ul a {
-      color: #{$mp-muted};
+      color: var(--toc-font-color);
       text-decoration: none;
       font-size: 13px;
       line-height: 1.4;
@@ -60,18 +70,18 @@
       transition: color 0.18s ease, border-color 0.18s ease;
 
       &:hover {
-        color: #{$mp-muted-hi};
+        color: var(--body-font-color);
         text-decoration: none !important;
       }
 
       &.active {
-        color: #{$mp-purple-hi};
-        font-weight: 400;
+        color: var(--content-link-color);
+        font-weight: 500;
         letter-spacing: normal;
-        border-left-color: #{$mp-purple};
+        border-left-color: var(--content-link-color);
 
         &:hover {
-          color: #{$mp-purple-hi};
+          color: var(--content-link-color);
           text-decoration: none !important;
         }
       }
@@ -89,11 +99,11 @@
 }
 
 .bd-toc nav.pt-3 a {
-  color: #{$mp-muted};
+  color: var(--toc-font-color);
   font-size: 0.8125rem;
   text-decoration: none;
 
-  &:hover { color: #ffffff; text-decoration: none !important; }
+  &:hover { color: var(--body-font-color); text-decoration: none !important; }
 }
 
 .bd-toc-toggle {

--- a/docs/themes/geekboot/assets/scss/_toc.scss
+++ b/docs/themes/geekboot/assets/scss/_toc.scss
@@ -20,7 +20,7 @@
   // "On this page" heading — matches website .toc summary exactly
   strong.h6 {
     font-family: #{$font-family-monospace} !important;
-    font-size: 11px !important;
+    font-size: 12px !important;
     font-weight: 500 !important;
     text-transform: uppercase;
     letter-spacing: 0.16em;
@@ -53,7 +53,7 @@
 
         a {
           padding-left: 30px;
-          font-size: 12px;
+          font-size: 13px;
         }
       }
     }
@@ -64,8 +64,8 @@
     ul a {
       color: var(--toc-font-color);
       text-decoration: none;
-      font-size: 13px;
-      line-height: 1.4;
+      font-size: 14px;
+      line-height: 1.45;
       display: block;
       border-left: 2px solid transparent;
       margin-left: -20px;

--- a/docs/themes/geekboot/assets/scss/_variables.scss
+++ b/docs/themes/geekboot/assets/scss/_variables.scss
@@ -4,6 +4,8 @@
 $bd-callout-variants: info, warning, danger !default;
 $font-family-sans-serif:      "Inter", -apple-system, BlinkMacSystemFont, sans-serif !default;
 $font-family-monospace:       "DM Mono", "Fira Code", monospace !default;
+// Display/heading face from the Modelplane stylescape.
+$font-family-headings:        "Outfit", "Inter", -apple-system, BlinkMacSystemFont, sans-serif !default;
 // These three are set by Bootstrap before _variables.scss runs (Bootstrap
 // is imported first in docs.scss), so !default has no effect on Bootstrap's
 // output. The actual overrides live in _modelplane.scss body { font-size; line-height }.
@@ -118,18 +120,21 @@ $salmon-900:                   #392827 !default;
 $salmon-950:                   #221C1C !default;
 
 
-// Modelplane brand colors
-$mp-bg:           #070714 !default;
-$mp-bg-mid:       #0d0d1f !default;
-$mp-bg-card:      #0f0f22 !default;
-$mp-border:       rgba(255,255,255,0.07) !default;
-$mp-border-hi:    rgba(173,123,252,0.25) !default;
-$mp-purple:       #AD7BFC !default;
-$mp-purple-hi:    #C39EFD !default;
-$mp-cyan:         #22d3ee !default;
-$mp-green:        #34d399 !default;
-$mp-muted:        #8b8aae !default;
-$mp-muted-hi:     #b0afcc !default;
+// Modelplane brand colors — aligned to the Modelplane stylescape
+// (Dark Spruce #001D2F, Spruce #183D54, Purple #9A5EFC, Sky #00DCE8, White).
+$mp-bg:           #001D2F !default;   // Dark Spruce — page background
+$mp-bg-mid:       #06293B !default;   // lifted surface (navbar, dropdown, accordion header)
+$mp-bg-card:      #0B2D41 !default;   // card / code-block surface
+$mp-surface:      #183D54 !default;   // Spruce — elevated / hover surface
+$mp-border:       rgba(255,255,255,0.10) !default;
+$mp-border-hi:    rgba(154,94,252,0.30) !default;  // Purple tint
+$mp-purple:       #9A5EFC !default;   // Purple — primary accent
+$mp-purple-hi:    #B58BFD !default;   // lighter purple for hover/links on dark
+$mp-purple-dark:  #7C3AED !default;   // darkened purple for links/accents on white (WCAG AA)
+$mp-cyan:         #00DCE8 !default;   // Sky — secondary accent
+$mp-green:        #34d399 !default;   // semantic success (status: available)
+$mp-muted:        #8FA6B4 !default;   // cool slate — muted text on Dark Spruce
+$mp-muted-hi:     #BCCAD4 !default;   // muted text on hover
 
 $body-font-weight:          normal !default;
 $body-min-width:            20rem !default;

--- a/docs/themes/geekboot/assets/scss/_variables.scss
+++ b/docs/themes/geekboot/assets/scss/_variables.scss
@@ -122,10 +122,10 @@ $salmon-950:                   #221C1C !default;
 
 // Modelplane brand colors — aligned to the Modelplane stylescape
 // (Dark Spruce #001D2F, Spruce #183D54, Purple #9A5EFC, Sky #00DCE8, White).
-$mp-bg:           #001D2F !default;   // Dark Spruce — page background
-$mp-bg-mid:       #06293B !default;   // lifted surface (navbar, dropdown, accordion header)
-$mp-bg-card:      #0B2D41 !default;   // card / code-block surface
-$mp-surface:      #183D54 !default;   // Spruce — elevated / hover surface
+$mp-bg:           #030724 !default;   // dark purple — page background (dark mode)
+$mp-bg-mid:       #0A0E2E !default;   // lifted surface (dropdown, accordion header)
+$mp-bg-card:      #0E1338 !default;   // card / code-block surface
+$mp-surface:      #1C2452 !default;   // elevated / hover surface
 $mp-border:       rgba(255,255,255,0.10) !default;
 $mp-border-hi:    rgba(154,94,252,0.30) !default;  // Purple tint
 $mp-purple:       #9A5EFC !default;   // Purple — primary accent

--- a/docs/themes/geekboot/assets/scss/dark-mode.scss
+++ b/docs/themes/geekboot/assets/scss/dark-mode.scss
@@ -16,15 +16,19 @@
     --active-tab-color: #{$mp-purple};
     --inactive-tab-hover-color: #ffffff;
 
+    // Muted text (sidebar section headers, chevrons, etc.)
+    --mp-muted: #{$mp-muted};
+    --mp-muted-hi: #{$mp-muted-hi};
+
     // Sidebar nav
-    --nav-highlight-color: rgba(173,123,252,0.08);
+    --nav-highlight-color: rgba(154,94,252,0.12);
     --btn-close-color: #ffffff;
     --btn-close-filter: invert(1);
 
     //Dropdown
     --dropdown-highlight: #{$mp-bg-mid};
     --dropdown-background: #{$mp-bg-card};
-    --latest-pill-background: rgba(173,123,252,0.15);
+    --latest-pill-background: rgba(154,94,252,0.18);
     --latest-pill-color: #{$mp-purple-hi};
     --dropdown-color: var(--body-font-color);
     --dropdown-border-color: #{$mp-border};
@@ -82,7 +86,7 @@
     --integer-border-color: #{$salmon-300};
 
     --enumDefault-color: #{$fog-400};
-    --tree-line-color: rgba(173,123,252,0.45);  /* mp-purple at 45% — subtle purple tree line */
+    --tree-line-color: rgba(154,94,252,0.45);  /* mp-purple at 45% — subtle purple tree line */
 
     // Override Bootstrap accordion colors — use brand palette instead of
     // $fog-1000 (#0A1111) which has a grey-green cast that conflicts with
@@ -92,7 +96,7 @@
         --bs-accordion-active-bg: #{$mp-bg-card};
         --bs-accordion-btn-focus-border-color: #{$mp-purple};
         --bs-accordion-button-focus-border-color: #{$mp-purple};
-        --bs-accordion-btn-focus-box-shadow: 0 0 0 2px rgba(173,123,252,0.35);
+        --bs-accordion-btn-focus-box-shadow: 0 0 0 2px rgba(154,94,252,0.35);
     }
     // Accordion body sits on the card background; a subtle purple-tinted
     // border-top separates it from the header instead of the thick grey line.

--- a/docs/themes/geekboot/assets/scss/dark-mode.scss
+++ b/docs/themes/geekboot/assets/scss/dark-mode.scss
@@ -6,8 +6,8 @@
     --anchor-link-color: #{$mp-muted};
     --rss-icon-fill: #{$mp-purple};
 
-    // Single code lines inside text. Code blocks are in _code_theme_dark.scss
-    --code-background: rgba(255,255,255,0.07);
+    // Inline code within text: purple text, no background.
+    --code-background: transparent;
     --code-color: #{$mp-purple-hi};
     --code-line-number-color: #{$mp-cyan};
 

--- a/docs/themes/geekboot/assets/scss/docs.scss
+++ b/docs/themes/geekboot/assets/scss/docs.scss
@@ -55,4 +55,5 @@
 @import "mermaid";
 /* purgecss end ignore */
 @import "modelplane";
+@import "components";
 @import "api-reference";

--- a/docs/themes/geekboot/assets/scss/light-mode.scss
+++ b/docs/themes/geekboot/assets/scss/light-mode.scss
@@ -2,9 +2,9 @@
     // body and content
     --body-background: #{$fog-0};
     --body-font-color: #{$fog-1000};
-    --content-link-color: #{$aqua-700};
+    --content-link-color: #{$mp-purple-dark};
     --anchor-link-color: #{$fog-600};
-    --rss-icon-fill: #{$aqua-600};
+    --rss-icon-fill: #{$mp-purple-dark};
 
     // Add underline to light mode small font links due to being similar color to main text
     p > a, .admonition-content > a, li > a, td > a, .home-link-description > a {
@@ -17,15 +17,19 @@
     // Single code lines inside text. Code blocks are in _code_theme_light.scss
     --code-background: #{$fog-1000}20;
     --code-color: #{$fog-1000};
-    --code-line-number-color: #{$aqua-700};
+    --code-line-number-color: #{$mp-purple-dark};
 
     //Tabs
     --nav-tab-background-color: var(--body-background);
-    --active-tab-color: #{$aqua-700};
+    --active-tab-color: #{$mp-purple-dark};
     --inactive-tab-hover-color: #{$fog-1000};
 
+    // Muted text (sidebar section headers, chevrons, etc.)
+    --mp-muted: #{$fog-700};
+    --mp-muted-hi: #{$fog-800};
+
     // Sidebar nav
-    --nav-highlight-color: #{$aqua-50};
+    --nav-highlight-color: #f1ebfe;
     --btn-close-color: #{$fog-1000};
 
     //Version dropdown
@@ -37,7 +41,7 @@
     --dropdown-border-color: #{$fog-100};
 
     //Right-side table of contents
-    --toc-font-color: #{$fog-600};
+    --toc-font-color: #{$fog-700};
     --toc-mobile-menu-outline: #{$fog-200};
     --toc-mobile-menu-background: #{$fog-0};
 
@@ -147,8 +151,8 @@
 
         // Active tab style
         .active, .active:hover {
-            color: #{$aqua-600} !important;
-            border-bottom: 2px solid #{$aqua-600} !important;
+            color: #{$mp-purple-dark} !important;
+            border-bottom: 2px solid #{$mp-purple-dark} !important;
         }
 
         // Dim the text of non-active tabs

--- a/docs/themes/geekboot/assets/scss/light-mode.scss
+++ b/docs/themes/geekboot/assets/scss/light-mode.scss
@@ -14,9 +14,9 @@
         text-decoration: none;
     }
 
-    // Single code lines inside text. Code blocks are in _code_theme_light.scss
-    --code-background: #{$fog-1000}20;
-    --code-color: #{$fog-1000};
+    // Inline code within text: purple text, no background.
+    --code-background: transparent;
+    --code-color: #{$mp-purple-dark};
     --code-line-number-color: #{$mp-purple-dark};
 
     //Tabs

--- a/docs/themes/geekboot/layouts/_default/baseof.html
+++ b/docs/themes/geekboot/layouts/_default/baseof.html
@@ -5,12 +5,11 @@ color-theme="dark">
   <head>
     {{ partial "header" . }}
   </head>
-  {{ block "body_override" . }}<body>{{ end }}
+  {{ block "body_override" . }}<body class="docs-app">{{ end }}
     {{ partialCached "icons" . }}
-    {{ partialCached "docs-navbar" . .IsHome }}
+    {{ partialCached "docs-topbar" . }}
     {{ block "main" . }}
     {{ end }}
-    {{ partialCached "footer" . }}
     {{ partialCached "scripts" . }}
   </body>
 </html>

--- a/docs/themes/geekboot/layouts/partials/brand.html
+++ b/docs/themes/geekboot/layouts/partials/brand.html
@@ -1,0 +1,10 @@
+{{/* Modelplane mark + wordmark + "docs". The mark is the colour icon (legible on
+     both themes); "modelplane" uses the theme text colour and "docs" the accent,
+     so the lockup adapts to light and dark.
+     Usage: {{ partial "brand" (dict "ctx" . "class" "bd-sidebar-brand") }} */}}
+{{ $cls := .class | default "bd-sidebar-brand" }}
+<a class="{{ $cls }}" href="{{ .ctx.Site.Home.Permalink }}" aria-label="Modelplane docs">
+  <img class="brand-mark" src="{{ "img/modelplane-icon-color.svg" | relURL }}" alt="" decoding="async">
+  <span class="brand-name">modelplane</span>
+  <span class="brand-docs">docs</span>
+</a>

--- a/docs/themes/geekboot/layouts/partials/brand.html
+++ b/docs/themes/geekboot/layouts/partials/brand.html
@@ -4,7 +4,7 @@
      Usage: {{ partial "brand" (dict "ctx" . "class" "bd-sidebar-brand") }} */}}
 {{ $cls := .class | default "bd-sidebar-brand" }}
 <a class="{{ $cls }}" href="{{ .ctx.Site.Home.Permalink }}" aria-label="Modelplane docs">
-  <img class="brand-mark" src="{{ "img/modelplane-icon-color.svg" | relURL }}" alt="" decoding="async">
+  <img class="brand-mark" src="{{ "img/modelplane-icon-color.svg" | relURL }}" alt="Modelplane" decoding="async">
   <span class="brand-name">modelplane</span>
   <span class="brand-docs">docs</span>
 </a>

--- a/docs/themes/geekboot/layouts/partials/crds-toc.html
+++ b/docs/themes/geekboot/layouts/partials/crds-toc.html
@@ -1,6 +1,7 @@
 {{/*
   Right-side "On this page" navigation for product: crds pages.
   Builds an alphabetically sorted list of CRD kind names with anchor links.
+  Mirrors the normal TOC's markup so the mobile "On this page" dropdown works.
 */}}
 
 {{ $crdFiles := $.Site.Data.apis.crds }}
@@ -14,9 +15,13 @@
 
 {{ $sorted := sort $kinds }}
 
+<button class="btn btn-link p-md-0 mb-2 mb-md-0 text-decoration-none bd-toc-toggle d-md-none" type="button" data-bs-toggle="collapse" data-bs-target="#tocContents" aria-expanded="false" aria-controls="tocContents">
+  On this page
+  <svg class="bi d-md-none ms-2" aria-hidden="true"><use xlink:href="#chevron-expand"></use></svg>
+</button>
 <strong class="d-none d-md-block h6 my-2">On this page</strong>
 <hr class="d-none d-md-block my-2">
-<div class="collapse bd-toc-collapse show" id="tocContents">
+<div class="collapse bd-toc-collapse" id="tocContents">
   <nav id="TableOfContents">
     <ul>
       {{ range $sorted }}

--- a/docs/themes/geekboot/layouts/partials/crds.html
+++ b/docs/themes/geekboot/layouts/partials/crds.html
@@ -85,7 +85,7 @@
                id="pane-{{ $kindSlug }}-example"
                role="tabpanel"
                aria-labelledby="tab-{{ $kindSlug }}-example">
-            <pre class="api-ref__example"><code>{{ $manifest | htmlEscape }}</code></pre>
+            <div class="api-ref__example">{{ highlight $manifest "yaml" "linenos=false" }}</div>
           </div>
           {{ end }}
 

--- a/docs/themes/geekboot/layouts/partials/docs-navbar.html
+++ b/docs/themes/geekboot/layouts/partials/docs-navbar.html
@@ -12,9 +12,15 @@
     </a>
 
     <ul class="nav-links">
-      <li><a href="https://modelplane.ai/docs">Docs</a></li>
+      <li><a href="https://docs.modelplane.ai">Docs</a></li>
       <li><a href="https://modelplane.ai/blog">Blog</a></li>
       <li><a href="#">Manifesto</a></li>
+      <li>
+        <button type="button" id="darkSwitch" class="theme-toggle" aria-label="Toggle light and dark theme" title="Toggle theme">
+          <svg class="icon-sun" width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.546 0a.5.5 0 0 1 0 .707l-1.414 1.414a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708z"/></svg>
+          <svg class="icon-moon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278z"/></svg>
+        </button>
+      </li>
       <li>
         <a href="https://github.com/modelplaneai" aria-label="GitHub" target="_blank" rel="noopener noreferrer">
           <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false" style="display:block"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
@@ -29,23 +35,42 @@
   </div>
 
   <div class="nav-dropdown" id="docsNavDropdown" style="display:none">
-    <a href="https://modelplane.ai/docs">Docs</a>
+    <a href="https://docs.modelplane.ai">Docs</a>
     <a href="https://modelplane.ai/blog">Blog</a>
     <a href="https://www.modelplane.ai/manifesto">Manifesto</a>
     <a href="https://github.com/modelplaneai" target="_blank" rel="noopener noreferrer">GitHub</a>
-    <a href="https://modelplane.ai#get-started" class="nav-cta-mobile">Get started →</a>
+    <button type="button" class="theme-toggle theme-toggle--mobile" aria-label="Toggle light and dark theme">
+      <svg class="icon-sun" width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.546 0a.5.5 0 0 1 0 .707l-1.414 1.414a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708z"/></svg>
+      <svg class="icon-moon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278z"/></svg>
+      <span class="theme-toggle-label">Toggle theme</span>
+    </button>
   </div>
 </nav>
 
 <script>
 (function() {
+  // Mobile menu toggle
   var btn = document.getElementById('docsNavHamburger');
   var menu = document.getElementById('docsNavDropdown');
-  if (!btn || !menu) return;
-  btn.addEventListener('click', function() {
-    var open = menu.style.display !== 'none';
-    menu.style.display = open ? 'none' : 'flex';
-    btn.classList.toggle('open', !open);
+  if (btn && menu) {
+    btn.addEventListener('click', function() {
+      var open = menu.style.display !== 'none';
+      menu.style.display = open ? 'none' : 'flex';
+      btn.classList.toggle('open', !open);
+    });
+  }
+
+  // Light/dark theme toggle. Writes the same `darkSwitch` localStorage key the
+  // early theme bootstrap (stylesheet-cached) reads, so the choice persists and
+  // applies before first paint on the next load.
+  function toggleTheme() {
+    var root = document.documentElement;
+    var next = root.getAttribute('color-theme') === 'dark' ? 'light' : 'dark';
+    root.setAttribute('color-theme', next);
+    try { localStorage.setItem('darkSwitch', next); } catch (e) {}
+  }
+  document.querySelectorAll('.theme-toggle').forEach(function(el) {
+    el.addEventListener('click', toggleTheme);
   });
 })();
 </script>

--- a/docs/themes/geekboot/layouts/partials/docs-sidebar.html
+++ b/docs/themes/geekboot/layouts/partials/docs-sidebar.html
@@ -1,50 +1,56 @@
 {{ $current := . }}
+{{ $root := .Site.Home }}
+{{ $isRef := eq $current.Params.product "crds" }}
+
+{{/* Home + top-level regular pages + sections, ordered by weight. The home page
+     itself is excluded from the list (the sidebar brand links to it). */}}
+{{ $allItems := (slice $root | append $root.RegularPages | append $root.Sections).ByWeight }}
 
 <nav class="bd-links-nav w-100" aria-label="Docs navigation">
-  {{ $root := .Site.Home }}
-  {{ $allItems := (slice $root | append $root.RegularPages | append $root.Sections).ByWeight }}
 
-  {{ range $allItems }}
-    {{ $id := substr (sha1 .Permalink) 0 8 }}
-    {{ $isSection := .IsSection }}
-    {{ $expand := or (eq $current .) (eq $current.FirstSection .) }}
-
-    {{ if not .Page.Params.tocHidden }}
-      <div class="section-container container pe-0 pt-1">
-        {{ if $isSection }}
-          <div class="container nav-container nav-section pe-0 d-flex w-100 {{if $expand}}active-parent{{end}}"
-               data-bs-toggle="collapse" data-bs-target="#collapse-{{$id}}"
-               aria-expanded="{{if $expand}}true{{else}}false{{end}}"
-               role="button">
-            <a class="d-flex w-100 border-0" href="{{.Permalink}}">{{ .Title }}</a>
-            <svg class="nav-section-chevron bi flex-shrink-0 ms-1" width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-              <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
-            </svg>
-          </div>
-        {{ else }}
-          <div class="container nav-container pe-0 d-flex w-100 {{if eq . $current}}active{{end}}">
-            <a class="d-flex w-100 border-0" href="{{.Permalink}}">{{ .Title }}</a>
-          </div>
+  {{ if $isRef }}
+    {{/* ── Reference tab: the API reference and its CRD kinds ── */}}
+    {{ range $allItems }}
+      {{ if eq .Params.product "crds" }}
+        {{ $ref := . }}
+        {{ $kinds := slice }}
+        {{ range $plural, $dir := $.Site.Data.apis.crds }}
+          {{ if $dir.definition }}{{ $kinds = $kinds | append $dir.definition.spec.names.kind }}{{ end }}
         {{ end }}
-
-        {{ if $isSection }}
-          <div class="collapse {{if $expand}}show{{end}}" id="collapse-{{$id}}">
-            {{ range .Pages.ByWeight }}
-              {{ if not .Page.Params.tocHidden }}
-                <div class="container flex-row">
-                  <div class="d-flex flex-column">
-                    <a class="bd-links d-flex {{if eq $current .}}active{{end}}" href="{{.Permalink}}">{{.Title}}</a>
-                  </div>
-                </div>
+        <div class="nav-group">
+          <a class="nav-section-link nav-top-link{{ if eq . $current }} active{{ end }}" href="{{ $ref.Permalink }}">{{ $ref.Title }}</a>
+          {{ with $kinds }}
+            <div class="nav-children">
+              {{ range (sort .) }}
+                <a class="bd-links d-flex" href="{{ $ref.Permalink }}#crd-{{ . | lower }}">{{ . }}</a>
               {{ end }}
-            {{ end }}
+            </div>
+          {{ end }}
+        </div>
+      {{ end }}
+    {{ end }}
+  {{ else }}
+    {{/* ── Documentation tab: every non-reference section and page ── */}}
+    {{ range $allItems }}
+      {{ if and (ne . $root) (ne .Params.product "crds") (not .Params.tocHidden) }}
+        {{ if .IsSection }}
+          <div class="nav-section-static">
+            <a class="nav-section-link{{ if eq . $current }} active{{ end }}" href="{{ .Permalink }}">{{ .Title }}</a>
           </div>
+          {{ with .Pages.ByWeight }}
+            <div class="nav-children">
+              {{ range . }}
+                {{ if not .Params.tocHidden }}
+                  <a class="bd-links d-flex{{ if eq . $current }} active{{ end }}" href="{{ .Permalink }}">{{ .Title }}</a>
+                {{ end }}
+              {{ end }}
+            </div>
+          {{ end }}
+        {{ else }}
+          <a class="nav-section-link nav-top-link{{ if eq . $current }} active{{ end }}" href="{{ .Permalink }}">{{ .Title }}</a>
         {{ end }}
-      </div>
+      {{ end }}
     {{ end }}
   {{ end }}
 
-  {{ if not ($.Param "docs") }}
-    {{ partialCached "sidebar/user-docs" . }}
-  {{ end }}
 </nav>

--- a/docs/themes/geekboot/layouts/partials/docs-sidebar.html
+++ b/docs/themes/geekboot/layouts/partials/docs-sidebar.html
@@ -34,20 +34,31 @@
     {{ range $allItems }}
       {{ if and (ne . $root) (ne .Params.product "crds") (not .Params.tocHidden) }}
         {{ if .IsSection }}
-          <div class="nav-section-static">
-            <a class="nav-section-link{{ if eq . $current }} active{{ end }}" href="{{ .Permalink }}">{{ .Title }}</a>
-          </div>
-          {{ with .Pages.ByWeight }}
+          {{ $section := . }}
+          <div class="nav-group">
+            {{/* Non-clickable text label; content lives in the sub-pages below. */}}
+            <div class="nav-group-label">{{ .Params.navLabel | default .Title }}</div>
             <div class="nav-children">
-              {{ range . }}
+              {{/* Sections with real landing content expose it as a first child. */}}
+              {{ with .Params.navLanding }}
+                <a class="bd-links d-flex{{ if eq $section $current }} active{{ end }}" href="{{ $section.Permalink }}">{{ . }}</a>
+              {{ end }}
+              {{ range $section.Pages.ByWeight }}
                 {{ if not .Params.tocHidden }}
                   <a class="bd-links d-flex{{ if eq . $current }} active{{ end }}" href="{{ .Permalink }}">{{ .Title }}</a>
                 {{ end }}
               {{ end }}
             </div>
-          {{ end }}
+          </div>
         {{ else }}
-          <a class="nav-section-link nav-top-link{{ if eq . $current }} active{{ end }}" href="{{ .Permalink }}">{{ .Title }}</a>
+          {{/* Standalone top-level page (e.g. Concepts): render like a section —
+               a label with the page as its single entry — so it matches. */}}
+          <div class="nav-group">
+            <div class="nav-group-label">{{ .Params.navLabel | default .Title }}</div>
+            <div class="nav-children">
+              <a class="bd-links d-flex{{ if eq . $current }} active{{ end }}" href="{{ .Permalink }}">{{ .Params.linkTitle | default .Title }}</a>
+            </div>
+          </div>
         {{ end }}
       {{ end }}
     {{ end }}

--- a/docs/themes/geekboot/layouts/partials/docs-topbar.html
+++ b/docs/themes/geekboot/layouts/partials/docs-topbar.html
@@ -1,0 +1,15 @@
+{{/* Compact top bar shown only on small screens (the sidebar is a drawer there). */}}
+<div class="docs-topbar d-lg-none">
+  <button class="docs-topbar-toggle" type="button"
+    data-bs-toggle="offcanvas" data-bs-target="#bdSidebar"
+    aria-controls="bdSidebar" aria-label="Open navigation">
+    {{ partialCached "icons/hamburger.svg" (dict "class" "" "width" "1.25rem" "height" "1.25rem") }}
+  </button>
+  {{ partial "brand" (dict "ctx" . "class" "docs-topbar-brand") }}
+  <div class="docs-topbar-actions">
+    <button class="docs-topbar-search" type="button" aria-label="Search">
+      <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0"/></svg>
+    </button>
+    {{ partial "theme-switch" (dict "withId" false) }}
+  </div>
+</div>

--- a/docs/themes/geekboot/layouts/partials/footer.html
+++ b/docs/themes/geekboot/layouts/partials/footer.html
@@ -10,7 +10,7 @@
       </div>
 
       <div class="footer-right">
-        <a href="https://modelplane.ai/docs">Docs</a>
+        <a href="https://docs.modelplane.ai">Docs</a>
         <a href="https://modelplane.ai/blog" target="_blank" rel="noopener">Blog</a>
         <a href="https://github.com/modelplaneai" target="_blank" rel="noopener" aria-label="GitHub">{{ partialCached "icons/github.svg" . }}</a>
       </div>

--- a/docs/themes/geekboot/layouts/partials/mermaid.html
+++ b/docs/themes/geekboot/layouts/partials/mermaid.html
@@ -1,47 +1,53 @@
 {{ if .Page.Store.Get "hasMermaid" }}
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
 <script type="module">
-
   import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs';
-  document.addEventListener("DOMContentLoaded", setMermaidStyle());
-  document.addEventListener("DOMContentLoaded", colorModeListener());
 
-  function getMermaidConfig(){
-    var style = getComputedStyle(document.body)
-    var font = style.getPropertyValue("font-family")
-    var fontColor = style.getPropertyValue('--body-font-color')
-    var backgroundColor = style.getPropertyValue('--body-background')
+  // Hugo renders ```mermaid fences as <pre class="mermaid">. Stash each
+  // diagram's source up front: once mermaid processes a block it replaces the
+  // source with an <svg>, so we need the original text to re-render when the
+  // theme changes.
+  var blocks = Array.prototype.map.call(
+    document.querySelectorAll('pre.mermaid, .mermaid'),
+    function (el) { return { el: el, src: el.textContent }; }
+  );
 
-    var config = {
-      "theme": "base",
-      "fontFamily": font,
-      "themeVariables": {
-        "background": backgroundColor,
-        "textColor": fontColor,
-        }
+  function mermaidConfig() {
+    var style = getComputedStyle(document.body);
+    return {
+      startOnLoad: false,
+      theme: 'base',
+      fontFamily: style.getPropertyValue('font-family'),
+      themeVariables: {
+        background: style.getPropertyValue('--body-background'),
+        textColor: style.getPropertyValue('--body-font-color'),
+      },
+    };
+  }
+
+  async function render() {
+    if (!blocks.length) return;
+    mermaid.initialize(mermaidConfig());
+    blocks.forEach(function (b) {
+      b.el.removeAttribute('data-processed');
+      b.el.innerHTML = b.src;
+    });
+    await mermaid.run({ nodes: blocks.map(function (b) { return b.el; }) });
+  }
+
+  render();
+
+  // Re-render with theme-matched colors whenever the toggle flips
+  // <html color-theme> (from any switch on the page).
+  var current = document.documentElement.getAttribute('color-theme');
+  new MutationObserver(function () {
+    var next = document.documentElement.getAttribute('color-theme');
+    if (next !== current) {
+      current = next;
+      render();
     }
-
-    return config
-  }
-
-  function setMermaidStyle(){
-    var config = getMermaidConfig()
-    mermaid.initialize( config )
-  }
-
-  function colorModeListener(){
-    darkSwitch.addEventListener("click", resetMermaidStyle())
-  }
-
-  function resetMermaidStyle(){
-    console.log("resetting")
-
-    var config = getMermaidConfig()
-    console.log(config)
-    mermaid.mermaidAPI.setConfig( config )
-    mermaid.mermaidAPI.reset()
-
-  }
-
+  }).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['color-theme'],
+  });
 </script>
 {{ end }}

--- a/docs/themes/geekboot/layouts/partials/scripts.html
+++ b/docs/themes/geekboot/layouts/partials/scripts.html
@@ -19,3 +19,28 @@
     });
 
 </script>
+
+<script>
+  // Segmented light/dark switch. Each segment sets a specific theme and writes
+  // the same `darkSwitch` localStorage key the early theme bootstrap
+  // (stylesheet-cached) reads, so the choice persists and applies before first
+  // paint on the next load. The active segment is shown via CSS keyed off
+  // <html color-theme>, so no JS class toggling is needed.
+  (function () {
+    document.querySelectorAll('.theme-switch-opt').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var theme = btn.getAttribute('data-theme');
+        document.documentElement.setAttribute('color-theme', theme);
+        try { localStorage.setItem('darkSwitch', theme); } catch (e) {}
+      });
+    });
+
+    // Mobile search icon (top bar) opens the DocSearch modal.
+    document.querySelectorAll('.docs-topbar-search').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var b = document.querySelector('.DocSearch-Button');
+        if (b) b.click();
+      });
+    });
+  })();
+</script>

--- a/docs/themes/geekboot/layouts/partials/scripts.html
+++ b/docs/themes/geekboot/layouts/partials/scripts.html
@@ -27,11 +27,15 @@
   // paint on the next load. The active segment is shown via CSS keyed off
   // <html color-theme>, so no JS class toggling is needed.
   (function () {
-    // Clicking anywhere on the switch toggles the theme.
+    // Clicking a segment selects that theme explicitly; clicking the track
+    // between segments falls back to toggling.
     document.querySelectorAll('.theme-switch').forEach(function (sw) {
-      sw.addEventListener('click', function () {
+      sw.addEventListener('click', function (event) {
         var root = document.documentElement;
-        var next = root.getAttribute('color-theme') === 'dark' ? 'light' : 'dark';
+        var opt = event.target.closest('.theme-switch-opt[data-theme]');
+        var next = opt
+          ? opt.getAttribute('data-theme')
+          : (root.getAttribute('color-theme') === 'dark' ? 'light' : 'dark');
         root.setAttribute('color-theme', next);
         try { localStorage.setItem('darkSwitch', next); } catch (e) {}
       });
@@ -51,18 +55,27 @@
       btn.classList.add('copied');
       setTimeout(function () { btn.classList.remove('copied'); }, 1500);
     }
+    // Copy text to the clipboard, guarding for environments where the
+    // Clipboard API is unavailable (non-secure contexts, older browsers) or
+    // where the write is rejected, so a failure never throws or logs noise.
+    function copyToClipboard(text, btn) {
+      if (!navigator.clipboard || !navigator.clipboard.writeText) return;
+      navigator.clipboard.writeText(text).then(function () {
+        flashCopied(btn);
+      }).catch(function () {});
+    }
     document.querySelectorAll('.code-card__copy').forEach(function (btn) {
       btn.addEventListener('click', function () {
         var body = btn.closest('.code-card').querySelector('.code-card__body');
         if (!body) return;
-        navigator.clipboard.writeText(body.innerText).then(function () { flashCopied(btn); });
+        copyToClipboard(body.innerText, btn);
       });
     });
     document.querySelectorAll('.code-card__apply').forEach(function (btn) {
       btn.addEventListener('click', function () {
         var text = btn.getAttribute('data-copy');
         if (!text) return;
-        navigator.clipboard.writeText(text).then(function () { flashCopied(btn); });
+        copyToClipboard(text, btn);
       });
     });
   })();

--- a/docs/themes/geekboot/layouts/partials/scripts.html
+++ b/docs/themes/geekboot/layouts/partials/scripts.html
@@ -27,11 +27,13 @@
   // paint on the next load. The active segment is shown via CSS keyed off
   // <html color-theme>, so no JS class toggling is needed.
   (function () {
-    document.querySelectorAll('.theme-switch-opt').forEach(function (btn) {
-      btn.addEventListener('click', function () {
-        var theme = btn.getAttribute('data-theme');
-        document.documentElement.setAttribute('color-theme', theme);
-        try { localStorage.setItem('darkSwitch', theme); } catch (e) {}
+    // Clicking anywhere on the switch toggles the theme.
+    document.querySelectorAll('.theme-switch').forEach(function (sw) {
+      sw.addEventListener('click', function () {
+        var root = document.documentElement;
+        var next = root.getAttribute('color-theme') === 'dark' ? 'light' : 'dark';
+        root.setAttribute('color-theme', next);
+        try { localStorage.setItem('darkSwitch', next); } catch (e) {}
       });
     });
 
@@ -40,6 +42,27 @@
       btn.addEventListener('click', function () {
         var b = document.querySelector('.DocSearch-Button');
         if (b) b.click();
+      });
+    });
+
+    // Code-card header buttons. Copy = the block's code; apply = the kubectl
+    // apply command (from data-copy). Both flash a checkmark on success.
+    function flashCopied(btn) {
+      btn.classList.add('copied');
+      setTimeout(function () { btn.classList.remove('copied'); }, 1500);
+    }
+    document.querySelectorAll('.code-card__copy').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var body = btn.closest('.code-card').querySelector('.code-card__body');
+        if (!body) return;
+        navigator.clipboard.writeText(body.innerText).then(function () { flashCopied(btn); });
+      });
+    });
+    document.querySelectorAll('.code-card__apply').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var text = btn.getAttribute('data-copy');
+        if (!text) return;
+        navigator.clipboard.writeText(text).then(function () { flashCopied(btn); });
       });
     });
   })();

--- a/docs/themes/geekboot/layouts/partials/search-button.html
+++ b/docs/themes/geekboot/layouts/partials/search-button.html
@@ -10,6 +10,6 @@
 </div> -->
 
 
-<div class="search-container d-flex row pt-3 ps-4 docsearch opacity-50"  data-bs-target="#bdSidebar" data-bs-dismiss="offcanvas" aria-label="Docs navigation">
-    <div class="p-0" id="docSearch"></div>
+<div class="search-container docsearch" aria-label="Search the docs">
+    <div id="docSearch"></div>
 </div>

--- a/docs/themes/geekboot/layouts/partials/single-list.html
+++ b/docs/themes/geekboot/layouts/partials/single-list.html
@@ -1,16 +1,44 @@
+{{ $ref := index (where .Site.RegularPages "Params.product" "crds") 0 }}
+{{ $isRef := eq .Params.product "crds" }}
 <div class="bd-layout docs-container" data-bs-spy="scroll" data-bs-target="#TableOfContents" data-bs-threshold="0,1" data-bs-root-margin="0% 0% -75%">
   <aside class="bd-sidebar">
-    <div class="offcanvas-lg offcanvas-start bd-sidebar-container" tabindex="-1" id="bdSidebar" aria-labelledby="bdSidebarOffcanvasLabel">
-      <div class="offcanvas-header pb-4 border-bottom">
-        <div class="d-flex offcanvas-title fw-bold" id="bdNavbarOffcanvasLabel">
-          Documentation
+    <div class="offcanvas-lg offcanvas-start bd-sidebar-container" tabindex="-1" id="bdSidebar" aria-labelledby="bdSidebarLabel">
+      <div class="bd-sidebar-header">
+        {{ partial "brand" (dict "ctx" . "class" "bd-sidebar-brand") }}
+        <div class="bd-sidebar-actions">
+          {{ partial "theme-switch" (dict "withId" true) }}
+          <button type="button" class="btn-close d-lg-none" data-bs-dismiss="offcanvas" data-bs-target="#bdSidebar" aria-label="Close navigation"></button>
         </div>
-        <div class="d-flex"><button type="button" class="btn-close bi align-self-center p-0" data-bs-dismiss="offcanvas" aria-label="Close" data-bs-target="#bdSidebar"></button></div>
       </div>
-      {{ partial "left-nav" . }}
+      {{ partialCached "search-button" . }}
+      {{ if $ref }}
+        <div class="doc-switch dropdown d-lg-none">
+          <button class="doc-switch-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Switch documentation section">
+            <span>{{ if $isRef }}Reference{{ else }}Documentation{{ end }}</span>
+            <svg class="doc-switch-caret" width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/></svg>
+          </button>
+          <ul class="dropdown-menu doc-switch-menu">
+            <li><a class="dropdown-item{{ if not $isRef }} active{{ end }}" href="{{ .Site.Home.Permalink }}">Documentation</a></li>
+            <li><a class="dropdown-item{{ if $isRef }} active{{ end }}" href="{{ $ref.Permalink }}">Reference</a></li>
+          </ul>
+        </div>
+      {{ end }}
+      <div class="offcanvas-body bd-sidebar-scroll">
+        {{ partial "docs-sidebar" . }}
+      </div>
+    </div>
   </aside>
 
   <main class="bd-main order-1">
+    {{ if $ref }}
+    <header class="doc-content-nav">
+      <nav class="doc-tabs" aria-label="Documentation sections">
+        <a class="doc-tab{{ if not $isRef }} active{{ end }}" href="{{ .Site.Home.Permalink }}">Documentation</a>
+        <a class="doc-tab{{ if $isRef }} active{{ end }}" href="{{ $ref.Permalink }}">Reference</a>
+      </nav>
+    </header>
+    {{ end }}
+    <div class="bd-main-grid">
     <div class="bd-intro pt-2 ps-lg-2">
       <div class="d-md-flex flex-md-row-reverse align-items-center justify-content-between">
         <div class="mb-3 mb-md-0 d-flex">
@@ -91,6 +119,7 @@
           {{ .Content }}
         {{ end }}
       </div>
+    </div>
   </main>
 </div>
 

--- a/docs/themes/geekboot/layouts/partials/single-list.html
+++ b/docs/themes/geekboot/layouts/partials/single-list.html
@@ -1,5 +1,7 @@
 {{ $ref := index (where .Site.RegularPages "Params.product" "crds") 0 }}
 {{ $isRef := eq .Params.product "crds" }}
+{{/* Whether this page shows an "On this page" rail (drives the centred no-toc layout). */}}
+{{ $hasToc := or (eq .Params.product "crds") (and (ne .Page.Params.toc false) (gt (len .TableOfContents) 40)) }}
 <div class="bd-layout docs-container" data-bs-spy="scroll" data-bs-target="#TableOfContents" data-bs-threshold="0,1" data-bs-root-margin="0% 0% -75%">
   <aside class="bd-sidebar">
     <div class="offcanvas-lg offcanvas-start bd-sidebar-container" tabindex="-1" id="bdSidebar" aria-labelledby="bdSidebarLabel">
@@ -38,8 +40,9 @@
       </nav>
     </header>
     {{ end }}
-    <div class="bd-main-grid">
+    <div class="bd-main-grid{{ if not $hasToc }} no-toc{{ end }}">
     <div class="bd-intro pt-2 ps-lg-2">
+      <div class="bd-intro-inner">
       <div class="d-md-flex flex-md-row-reverse align-items-center justify-content-between">
         <div class="mb-3 mb-md-0 d-flex">
         </div>
@@ -57,6 +60,7 @@
       {{ if .Page.Params.ga }}
         {{ partial "ga-tag" . }}
       {{ end }}
+      </div>
     </div>
 
       <div class="bd-toc mt-3 mb-5 my-lg-0 ps-xl-3 mb-lg-5">
@@ -110,7 +114,7 @@
       </div>
 
       <div class="bd-content ps-lg-2 DocSearch-content">
-
+        <div class="bd-content-inner">
         {{ if eq $.Params.Product "Release Notes" }}
           {{ partial "release-notes" . }}
         {{ else if eq $.Params.Product "crds" }}
@@ -118,6 +122,7 @@
         {{ else }}
           {{ .Content }}
         {{ end }}
+        </div>
       </div>
     </div>
   </main>

--- a/docs/themes/geekboot/layouts/partials/theme-switch.html
+++ b/docs/themes/geekboot/layouts/partials/theme-switch.html
@@ -1,0 +1,12 @@
+{{/* Segmented light/dark switch (sun | moon), like Baseten's. The active
+     segment is highlighted via CSS keyed off <html color-theme>.
+     Pass withId=true once per page so mermaid + the bundled script find #darkSwitch.
+     Usage: {{ partial "theme-switch" (dict "withId" true) }} */}}
+<div class="theme-switch"{{ if .withId }} id="darkSwitch"{{ end }} role="group" aria-label="Color theme">
+  <button type="button" class="theme-switch-opt" data-theme="light" aria-label="Light theme" title="Light">
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.546 0a.5.5 0 0 1 0 .707l-1.414 1.414a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708z"/></svg>
+  </button>
+  <button type="button" class="theme-switch-opt" data-theme="dark" aria-label="Dark theme" title="Dark">
+    <svg width="15" height="15" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278z"/></svg>
+  </button>
+</div>

--- a/docs/themes/geekboot/layouts/shortcodes/include.html
+++ b/docs/themes/geekboot/layouts/shortcodes/include.html
@@ -12,7 +12,7 @@
 
 <div class="gdoc-include">
   {{- if (.Get "language") -}}
-    {{- highlight ($file | readFile) $language (default "linenos=table" $options) -}}
+    {{- highlight ($file | readFile) $language (default "linenos=false" $options) -}}
   {{- else if eq $type "html" -}}
     {{- $file | readFile | safeHTML -}}
   {{- else if eq $type "page" -}}

--- a/docs/themes/geekboot/layouts/shortcodes/manifests.html
+++ b/docs/themes/geekboot/layouts/shortcodes/manifests.html
@@ -33,8 +33,32 @@
 {{- $applyCmd := printf "%s %s" $command $url -}}
 
 <div class="gdoc-manifest">
-  {{- highlight $resource.Content "yaml" "linenos=false" -}}
-  {{- if not (eq $apply "false") -}}
-    {{- highlight $applyCmd "shell" "" -}}
-  {{- end -}}
+  <div class="code-card">
+    <div class="code-card__header">
+      <span class="code-card__name">{{ path.Base $path }}</span>
+      <div class="code-card__actions">
+        {{- if not (eq $apply "false") -}}
+        <button class="code-card__btn code-card__apply" type="button" data-copy="{{ $applyCmd }}" aria-label="Copy kubectl apply command" title="Copy kubectl apply command">
+          <svg class="icon-main" width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" aria-hidden="true" focusable="false">
+            <circle cx="12" cy="12" r="7.4"/>
+            <circle cx="12" cy="12" r="2.4"/>
+            <line x1="12" y1="9.6" x2="12" y2="2.6"/>
+            <line x1="12" y1="9.6" x2="12" y2="2.6" transform="rotate(51.43 12 12)"/>
+            <line x1="12" y1="9.6" x2="12" y2="2.6" transform="rotate(102.86 12 12)"/>
+            <line x1="12" y1="9.6" x2="12" y2="2.6" transform="rotate(154.29 12 12)"/>
+            <line x1="12" y1="9.6" x2="12" y2="2.6" transform="rotate(205.71 12 12)"/>
+            <line x1="12" y1="9.6" x2="12" y2="2.6" transform="rotate(257.14 12 12)"/>
+            <line x1="12" y1="9.6" x2="12" y2="2.6" transform="rotate(308.57 12 12)"/>
+          </svg>
+          <svg class="icon-check" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M13.485 1.929a.75.75 0 0 1 .086 1.057l-7 8.5a.75.75 0 0 1-1.117.063l-3.5-3.5a.75.75 0 0 1 1.06-1.06l2.92 2.92 6.494-7.894a.75.75 0 0 1 1.057-.086z"/></svg>
+        </button>
+        {{- end -}}
+        <button class="code-card__btn code-card__copy" type="button" aria-label="Copy contents" title="Copy contents">
+          <svg class="icon-main" width="15" height="15" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1z"/><path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0z"/></svg>
+          <svg class="icon-check" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" focusable="false"><path d="M13.485 1.929a.75.75 0 0 1 .086 1.057l-7 8.5a.75.75 0 0 1-1.117.063l-3.5-3.5a.75.75 0 0 1 1.06-1.06l2.92 2.92 6.494-7.894a.75.75 0 0 1 1.057-.086z"/></svg>
+        </button>
+      </div>
+    </div>
+    <div class="code-card__body">{{ highlight $resource.Content "yaml" "linenos=false" }}</div>
+  </div>
 </div>

--- a/docs/themes/geekboot/layouts/shortcodes/persona.html
+++ b/docs/themes/geekboot/layouts/shortcodes/persona.html
@@ -1,0 +1,6 @@
+{{/*
+  Inline persona badge. Usage: {{< persona platform >}} or {{< persona developer >}}
+*/}}
+{{ $p := .Get 0 | lower }}
+{{ $labels := dict "platform" "Platform" "developer" "Developer" }}
+<span class="mp-badge mp-badge--{{ $p }}">{{ index $labels $p | default ($p | humanize) }}</span>

--- a/docs/themes/geekboot/layouts/shortcodes/personas.html
+++ b/docs/themes/geekboot/layouts/shortcodes/personas.html
@@ -1,0 +1,18 @@
+{{/*
+  Two persona path cards routing each audience to its guide track.
+  Usage: {{< personas >}}
+*/}}
+{{ $platform := "/platform/" | relLangURL }}
+{{ $models := "/models/" | relLangURL }}
+<div class="mp-personas">
+  <a class="mp-persona mp-persona--platform" href="{{ $platform }}">
+    <span class="mp-persona-role">I run the platform</span>
+    <span class="mp-persona-desc">Provision clusters across clouds, define hardware classes, and set the capacity and policy the fleet runs within.</span>
+    <span class="mp-persona-cta">Platform docs &rarr;</span>
+  </a>
+  <a class="mp-persona mp-persona--developer" href="{{ $models }}">
+    <span class="mp-persona-role">I deploy models</span>
+    <span class="mp-persona-desc">Declare a model, expose it as one OpenAI-compatible service, and route traffic across replicas and endpoints.</span>
+    <span class="mp-persona-cta">Model docs &rarr;</span>
+  </a>
+</div>

--- a/docs/utils/vale/styles/config/vocabularies/Modelplane/accept.txt
+++ b/docs/utils/vale/styles/config/vocabularies/Modelplane/accept.txt
@@ -354,6 +354,22 @@ user-defined
 user-provided
 workload-cluster
 
+# Industry and deployment terms
+[Hh]yperscalers?
+[Nn]eoclouds?
+on-prem
+on-premises?
+lock-in
+rollouts?
+two-team
+two-level
+high-altitude
+re-download(s|ing)?
+re-converge[sd]?
+disaggregat(ion|ed)
+Autoscaling
+Dynamo
+
 # Style exceptions
 several
 above

--- a/docs/utils/vale/styles/config/vocabularies/Modelplane/accept.txt
+++ b/docs/utils/vale/styles/config/vocabularies/Modelplane/accept.txt
@@ -247,7 +247,7 @@ subnets?
 tolerations
 pipeline
 parallelism
-autoscaling
+[Aa]utoscaling
 config
 args
 env
@@ -354,21 +354,20 @@ user-defined
 user-provided
 workload-cluster
 
-# Industry and deployment terms
+# Industry and deployment terms.
+# First letter is a character class so sentence-initial capitals match the same
+# entry (avoids Vale.Terms flagging a case the literal entry doesn't cover).
 [Hh]yperscalers?
 [Nn]eoclouds?
-on-prem
-on-premises?
-lock-in
-rollouts?
-two-team
-two-level
-high-altitude
-re-download(s|ing)?
-re-converge[sd]?
-disaggregat(ion|ed)
-Autoscaling
-Dynamo
+[Oo]n-prem
+[Oo]n-premises?
+[Ll]ock-in
+[Rr]ollouts?
+[Tt]wo-team
+[Tt]wo-level
+[Hh]igh-altitude
+[Rr]e-download(s|ing)?
+[Rr]e-converge[sd]?
 
 # Style exceptions
 several

--- a/docs/vercel-build.sh
+++ b/docs/vercel-build.sh
@@ -45,12 +45,12 @@ export PATH="/nix/var/nix/profiles/default/bin:$PATH"
 # Build the site. result is a symlink into the read-only store; dereference it
 # into a plain, writable directory Vercel can serve.
 #
-# Production keeps the canonical https://modelplane.ai/docs/ baseURL baked into
+# Production keeps the canonical https://docs.modelplane.ai/ baseURL baked into
 # nix/docs.nix: a pure, cached build identical to what CI verifies. PR previews
-# are served standalone at the deployment's own root (not under /docs), so we
-# rebuild with the preview URL as the baseURL, making links and assets resolve
-# against the preview itself instead of production. --impure lets the
-# derivation read HUGO_BASEURL from the environment (getEnv is "" in pure eval).
+# are served standalone at the deployment's own root, so we rebuild with the
+# preview URL as the baseURL, making links and assets resolve against the
+# preview itself instead of production. --impure lets the derivation read
+# HUGO_BASEURL from the environment (getEnv is "" in pure eval).
 if [ "${VERCEL_ENV:-}" = "production" ]; then
 	nix build .#docs --print-build-logs
 else

--- a/nix/docs.nix
+++ b/nix/docs.nix
@@ -124,14 +124,14 @@ let
       '';
 in
 {
-  # The built static site, served under modelplane.ai/docs/.
+  # The built static site, served at docs.modelplane.ai.
   site = mkSite {
     name = "modelplane-docs";
     baseURL =
       let
         envBaseURL = builtins.getEnv "HUGO_BASEURL";
       in
-      if envBaseURL != "" then envBaseURL else "https://modelplane.ai/docs/";
+      if envBaseURL != "" then envBaseURL else "https://docs.modelplane.ai/";
   };
 
   # Lint docs prose with Vale. Merges the network-synced style packages with the


### PR DESCRIPTION
The Modelplane docs site needed both a visual/UX overhaul and a hosting change: the look didn't match the Modelplane stylescape, the sidebar didn't distinguish sections from pages, and the site was served under modelplane.ai/docs through a Next.js proxy — awkward for what is a separate Hugo project.

This restyles and restructures the docs and serves them standalone at docs.modelplane.ai. The theme adopts the stylescape palette and type (Outfit/Inter/DM Mono); the layout becomes an app shell with an independently scrolling sidebar and content; the sidebar uses text section labels with Documentation/Reference tabs; light mode is fixed (white code blocks with readable syntax, purple inline code); manifest blocks gain a filename header with copy and a `kubectl apply` copy button; and an Overview section (with Concepts folded into it) is added. The canonical baseURL moves to docs.modelplane.ai in `nix/docs.nix`. The matching marketing-site proxy-to-redirect change is in modelplaneai/website#8 and should merge after this and the `docs.modelplane.ai` domain are live.

Verified the site builds with `hugo` and renders in both light and dark; the production CSS pipeline runs in CI/Vercel.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~ Not run locally; the docs build is validated with `hugo` and CI runs the full check.
- [ ] ~Added or updated tests covering any composition function changes.~ Docs-only change.
- [x] Signed off every commit with `git commit -s`.