### PR TITLE
Increase Nix log-lines in CI to show full failure output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: log-lines = 500
 
       # Cache Nix store paths in the GitHub Actions cache so builds reuse work
       # across runs. use-flakehub is off so artifacts stay in the Actions cache
@@ -76,6 +78,8 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: log-lines = 500
 
       # See the check job for why use-flakehub is off.
       - name: Cache Nix store


### PR DESCRIPTION
When a Nix build fails, the error summary shows "Last 25 log lines" - the `log-lines` nix.conf default. Even though `--print-build-logs` streams the full output during the build, the truncated summary at the bottom is what people scroll to. For a check like htmltest that produces 41 errors across 22 documents, this hides the first half of the failures, making it hard to fix a failing CI run without Nix installed locally.

This sets `log-lines` to 500 via `extra_nix_config` in the `cachix/install-nix-action` step, so the error summary includes the full build output.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
