### PR TITLE
Index the docs site for search with its own Algolia app

### DIFF
--- a/.github/workflows/docsearch.yml
+++ b/.github/workflows/docsearch.yml
@@ -1,0 +1,38 @@
+name: DocSearch index
+
+# Crawls the live docs site (docs.modelplane.ai) with Algolia's open-source
+# DocSearch scraper and pushes the records into the `modelplane` index that the
+# docs search box queries. Modelplane owns this Algolia app (it is not shared
+# with Crossplane), so the only secret needed is the admin (write) API key.
+#
+# Runs on a daily schedule to pick up deployed content changes, and on demand
+# (run it right after a docs deploy for an immediate refresh). The crawler reads
+# the production site over HTTP, so it does not depend on the build here.
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 7 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docsearch
+  cancel-in-progress: true
+
+jobs:
+  crawl:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Crawl docs.modelplane.ai into Algolia
+        env:
+          ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
+        run: |
+          docker run --rm \
+            -e APPLICATION_ID=CQDMTRM1TJ \
+            -e API_KEY="$ALGOLIA_ADMIN_KEY" \
+            -e "CONFIG=$(jq -r tostring docs/utils/docsearch/config.json)" \
+            algolia/docsearch-scraper

--- a/docs/themes/geekboot/layouts/partials/scripts.html
+++ b/docs/themes/geekboot/layouts/partials/scripts.html
@@ -12,9 +12,9 @@
 
     docsearch({
     container: '#docSearch',
-    appId: '9UXKYX61NK',
+    appId: 'CQDMTRM1TJ',
     indexName: 'modelplane',
-    apiKey: 'e07e181044d561f6a4cb7261931d980a',
+    apiKey: 'd3056ed34b0725f5eb96a188e3df70a3',
     placeholder: 'Search the docs'
     });
 

--- a/docs/utils/docsearch/config.json
+++ b/docs/utils/docsearch/config.json
@@ -1,0 +1,24 @@
+{
+  "index_name": "modelplane",
+  "start_urls": ["https://docs.modelplane.ai/"],
+  "sitemap_urls": ["https://docs.modelplane.ai/sitemap.xml"],
+  "sitemap_alternate_links": true,
+  "stop_urls": [],
+  "selectors": {
+    "lvl0": {
+      "selector": ".bd-title",
+      "global": true,
+      "default_value": "Documentation"
+    },
+    "lvl1": ".bd-content h2",
+    "lvl2": ".bd-content h3",
+    "lvl3": ".bd-content h4",
+    "lvl4": ".bd-content h5",
+    "lvl5": ".bd-content h6",
+    "text": ".bd-content p, .bd-content li, .bd-content td"
+  },
+  "strip_chars": " .,;:#",
+  "custom_settings": {
+    "attributesForFaceting": ["language", "version", "type", "lang"]
+  }
+}

--- a/docs/vercel-build.sh
+++ b/docs/vercel-build.sh
@@ -46,15 +46,20 @@ export PATH="/nix/var/nix/profiles/default/bin:$PATH"
 # into a plain, writable directory Vercel can serve.
 #
 # Production keeps the canonical https://docs.modelplane.ai/ baseURL baked into
-# nix/docs.nix: a pure, cached build identical to what CI verifies. PR previews
-# are served standalone at the deployment's own root, so we rebuild with the
-# preview URL as the baseURL, making links and assets resolve against the
-# preview itself instead of production. --impure lets the derivation read
-# HUGO_BASEURL from the environment (getEnv is "" in pure eval).
+# nix/docs.nix: a pure, cached build identical to what CI verifies.
+#
+# Previews rebuild with a root-relative ("/") baseURL. A preview is reachable on
+# several hostnames (the per-deployment URL and the branch alias) and sits behind
+# Vercel Deployment Protection, so an absolute baseURL baked to one host breaks
+# the page when it's viewed on another: the cross-host request for the
+# stylesheet/JS hits the auth wall and returns HTML instead of the asset, leaving
+# the page unstyled. Root-relative URLs resolve against whatever host serves the
+# page, so the preview renders correctly on all of them. --impure lets the
+# derivation read HUGO_BASEURL from the environment (getEnv is "" in pure eval).
 if [ "${VERCEL_ENV:-}" = "production" ]; then
 	nix build .#docs --print-build-logs
 else
-	export HUGO_BASEURL="https://${VERCEL_URL}/"
+	export HUGO_BASEURL="/"
 	nix build .#docs --impure --print-build-logs
 fi
 rm -rf public


### PR DESCRIPTION
### Description of your changes

Two related docs-infra fixes.

**1. Search returned no results.** The search box queries the `modelplane` Algolia index, but that index never existed: the DocSearch credentials baked into the theme belong to **Crossplane's** app (appId `9UXKYX61NK`, whose only index is `crossplane`). The index name was originally `crossplane` (so search surfaced Crossplane's docs), and a later rename to `modelplane` just pointed at a 404. Modelplane content was never indexed.

This gives Modelplane its **own** Algolia app, kept separate from Crossplane:
- `scripts.html` now uses the new app id + search-only key (both public).
- `docs/utils/docsearch/config.json` is an Algolia DocSearch scraper config that crawls `https://docs.modelplane.ai` via its sitemap, mapping the page title (`.bd-title`) to `lvl0` and the in-page headings under `.bd-content` to the lower levels.
- `.github/workflows/docsearch.yml` runs Algolia's open-source scraper daily and on demand to keep the index fresh; it needs only the admin (write) key, read from the `ALGOLIA_ADMIN_KEY` secret.

The index has already been populated with an initial crawl (496 records). Worth a reviewer's eye: the `selectors` (whether the lvl0/lvl1 split groups results well) and the crawl cadence.

**2. Preview deployments rendered unstyled.** `vercel-build.sh` baked an absolute baseURL from `VERCEL_URL`, so CSS/JS were referenced on the per-deployment host. A preview is reachable on multiple hostnames (per-deployment URL and branch alias) and sits behind Vercel Deployment Protection, so viewing it on the branch alias made the browser fetch the stylesheet cross-host from the protected deployment, get the auth wall (HTML) instead of CSS, and render unstyled. Previews now build with a root-relative (`/`) baseURL so assets resolve against whatever host serves the page. Production is unchanged (still bakes the canonical `https://docs.modelplane.ai/`).

Fixes #

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes. <!-- Ran docs, docs-vale, docs-htmltest, and shell-lint inputs; all pass. -->
- [ ] ~Added or updated tests covering any composition function changes.~ No composition function changes.
- [x] Signed off every commit with `git commit -s`.