### PR TITLE
Drive docs deploys from GitHub Actions instead of Vercel's app

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,43 @@
+name: Docs Deploy
+
+# Deploy the docs site to Vercel production when docs change land on main.
+# Vercel's GitHub integration is disconnected (see CONTRIBUTING.md), so this
+# workflow is what ships the site. The paths filter keeps it from running on
+# code-only merges.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'examples/**'
+      - 'vercel.json'
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@54.14.2
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
+
+      # Deploy without --prebuilt: Vercel runs docs/vercel-build.sh, which uses
+      # the canonical baseURL baked into nix/docs.nix for production builds.
+      - name: Deploy production
+        run: vercel deploy --prod --token="${{ secrets.VERCEL_TOKEN }}"

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,117 @@
+name: Docs Preview
+
+# Deploy a docs preview to Vercel on demand, when a maintainer comments
+# /preview on a pull request. Vercel's GitHub integration is disconnected (see
+# CONTRIBUTING.md), so PRs get no automatic preview; this is how you ask for one.
+#
+# issue_comment runs in the context of the default branch, not the PR branch, so
+# this workflow's code is always the trusted version from main and has access to
+# secrets even when the PR comes from a fork. We check out the PR's head to build
+# it, but never run code from the PR, so a fork can't exfiltrate VERCEL_TOKEN.
+on:
+  issue_comment:
+    types: [created]
+
+# Don't deploy the same PR twice at once; a newer /preview supersedes an older
+# in-flight one.
+concurrency:
+  group: docs-preview-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  preview:
+    # Only on pull request comments whose body starts with /preview, and only
+    # from someone with write access (author_association is OWNER for the repo
+    # owner, MEMBER for org members, COLLABORATOR for invited collaborators).
+    # Anyone else commenting /preview is ignored, so a fork contributor can't
+    # trigger a deploy with our token. GitHub expressions can't trim or regex, so
+    # this is a prefix match; a maintainer typing /preview as the command works,
+    # and the worst a loose match does is deploy a preview they can ignore.
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/preview') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-24.04
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    permissions:
+      contents: read
+      # React to the triggering comment and post the preview URL back.
+      pull-requests: write
+
+    steps:
+      # Acknowledge the command immediately with an :eyes: reaction, so the
+      # maintainer sees it was picked up before the build finishes.
+      - name: Acknowledge command
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes
+
+      # The comment payload doesn't carry the PR's head ref, so resolve it from
+      # the PR. For a fork PR this is the fork's repo and branch.
+      - name: Resolve PR head
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr view "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --json headRepositoryOwner,headRepository,headRefOid \
+            --jq '"repo=\(.headRepositoryOwner.login)/\(.headRepository.name)\nsha=\(.headRefOid)"' \
+            >>"$GITHUB_OUTPUT"
+
+      # Check out the PR's head commit by SHA. We build this code on Vercel but
+      # never execute it here, so checking out fork code is safe.
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.pr.outputs.repo }}
+          ref: ${{ steps.pr.outputs.sha }}
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@54.14.2
+
+      # Pull project settings (including the vercel.json build config) so the
+      # deploy uses the same build as production.
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=preview --token="${{ secrets.VERCEL_TOKEN }}"
+
+      # Deploy without --prebuilt: Vercel runs docs/vercel-build.sh, where
+      # VERCEL_URL is set, so the preview's baseURL points at the preview itself.
+      # stdout is the deployment URL.
+      - name: Deploy preview
+        id: deploy
+        run: |
+          url=$(vercel deploy --token="${{ secrets.VERCEL_TOKEN }}")
+          echo "url=${url}" >>"$GITHUB_OUTPUT"
+
+      # Post the preview URL back on the PR. The deployment is built from the
+      # head SHA we resolved, so name it to make stale previews obvious after
+      # new pushes.
+      - name: Comment preview URL
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "Docs preview for ${{ steps.pr.outputs.sha }}: ${{ steps.deploy.outputs.url }}"
+
+      # If anything above failed, tell the maintainer rather than leaving the
+      # :eyes: reaction as the only signal.
+      - name: Comment on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "Docs preview failed. See the [run log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,8 +255,28 @@ same `nix build .#docs` derivation that `nix flake check` verifies, so what
 ships matches what CI checks. `vercel.json` points the build at
 [`docs/vercel-build.sh`](docs/vercel-build.sh), which installs Nix into
 Vercel's build image, runs the build, and writes the static site to `public/`.
-Vercel's GitHub app drives deploys as usual: preview URLs on pull requests
-(including from forks) and production on merge to `main`.
+
+GitHub Actions drives deploys, not Vercel's GitHub app, which is disconnected.
+The app deployed every PR, commented on each one, and gated fork PRs behind a
+manual approval that showed as a failing check even on PRs that didn't touch the
+docs. Two workflows replace it:
+
+- [`docs-deploy.yml`](.github/workflows/docs-deploy.yml) deploys production when
+  a change under `docs/`, `examples/`, or `vercel.json` lands on `main`.
+- [`docs-preview.yml`](.github/workflows/docs-preview.yml) deploys a preview
+  when a maintainer comments `/preview` on a pull request, and replies with the
+  URL. It's opt-in, so PRs that don't touch the docs stay quiet. Because it runs
+  on `issue_comment` it executes from `main` with access to the deploy token,
+  so it works for fork PRs too; it builds the PR's code on Vercel but never runs
+  it, so a fork can't reach the token.
+
+Both run `vercel deploy` and let Vercel run the build (no `--prebuilt`), so
+`docs/vercel-build.sh` sees `VERCEL_URL` and a preview's links resolve against
+the preview itself rather than production.
+
+The workflows need three repository secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`,
+and `VERCEL_PROJECT_ID`. Get the org and project IDs by running `vercel link` in
+a checkout and reading `.vercel/project.json`.
 
 ## Submitting changes
 


### PR DESCRIPTION
Vercel's GitHub app deployed every push to every PR, commented on each one, and required manual approval to deploy fork PRs. That approval showed as a failing check on the PR list until granted, so at a glance every open PR looked like it was failing CI, even though most don't touch the docs and couldn't affect the site. PR #216 is a recent example.

This disconnects the app and drives docs deploys from two workflows instead. `docs-deploy.yml` deploys production when a change under `docs/`, `examples/`, or `vercel.json` lands on `main`. `docs-preview.yml` deploys a preview only when a maintainer comments `/preview` on a pull request, then replies with the URL. PRs that don't need a preview stay quiet, and the only check a code-only PR sees is the existing `nix flake check`, which already builds the docs.

The preview workflow runs on `issue_comment`, so it executes from `main` with access to the deploy token even when the PR is from a fork. It checks out and builds the PR's code on Vercel but never runs it locally, so a fork can't reach the token; the `author_association` gate (`OWNER`, `MEMBER`, `COLLABORATOR`) stops anyone but a maintainer triggering a deploy. Both workflows run plain `vercel deploy` and let Vercel run the existing `docs/vercel-build.sh`, so `VERCEL_URL` is set during the build and a preview's links resolve against the preview rather than production.

Two steps are manual and not part of this change: disconnecting Vercel's GitHub app, and adding the `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` repository secrets. Until both are done the old behaviour continues alongside the new workflows.

`examples/**` is in the production path filter because `nix/docs.nix` copies `examples/` into the build and the manifest shortcodes render from it, so an example change can change the rendered site.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~ No composition function changes.
- [x] Signed off every commit with `git commit -s`.