### PR TITLE
Repin crossplane-cli from negz/cli fork to crossplane/cli main

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,16 +7,15 @@
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1781759845,
-        "narHash": "sha256-cGTUbtLWeCjziuw9R5Gf6ppP/Ln4tilMK+OYFbmApqE=",
-        "owner": "negz",
+        "lastModified": 1781939520,
+        "narHash": "sha256-VLe6oJkS/OSQj9wte2jS+ZBeZRn+XZso7GnId0o0dCU=",
+        "owner": "crossplane",
         "repo": "cli",
-        "rev": "5466a88456e3e25d35676af5f74f5e8d4d565f56",
+        "rev": "25f568197dce50c0520efd94ec07f2e1e65556b8",
         "type": "github"
       },
       "original": {
-        "owner": "negz",
-        "ref": "default-to-go",
+        "owner": "crossplane",
         "repo": "cli",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,21 +12,22 @@
     # tracking the latest uv_build releases.
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    # Pinned to negz/cli's default-to-go branch rather than a released version,
-    # because we depend on several CLI changes that aren't in a release yet:
+    # Pinned to crossplane/cli main rather than a released version, because we
+    # depend on several CLI changes that aren't in a release yet:
     #
     #   * #24, #64: a datamodel-code-generator bump that fixes Python model
     #     generation for fields named int/bool.
     #   * #119: stops an XRD's scale subresource from clobbering the generated
     #     model with the autoscaling Scale type.
-    #   * #126 (unmerged): makes the flake's default package the host-native CLI
-    #     binary instead of the full multi-platform release bundle. Building one
-    #     platform instead of seven cuts the CLI build from ~55 minutes to ~8 on
-    #     a cold machine.
+    #   * #126: makes the flake's default package the host-native CLI binary
+    #     instead of the full multi-platform release bundle. Building one platform
+    #     instead of seven cuts the CLI build from ~55 minutes to ~8 on a cold
+    #     machine.
+    #   * #127: decompresses function runtime tarballs once when loading them,
+    #     rather than once per layer.
     #
-    # #24, #64, and #119 are merged; the branch is based on them. Repin to
-    # crossplane/cli main once #126 merges, then to a tag once they all release.
-    crossplane-cli.url = "github:negz/cli/default-to-go";
+    # Repin to a tag once these all release.
+    crossplane-cli.url = "github:crossplane/cli";
 
     # uv2nix reads a uv workspace's uv.lock and generates Nix derivations
     # for each Python package, using pyproject.nix's build infrastructure.


### PR DESCRIPTION
### Description of your changes

The flake pinned `crossplane-cli` to the `negz/cli` `default-to-go` branch because the CLI changes modelplane depends on weren't yet merged upstream. They now are: crossplane/cli#126 (host-native default flake package) merged, joining the already-merged #24, #64, and #119, and crossplane/cli#127 (decompress function runtime tarballs once when loading) merged on top.

This repoints the input at `crossplane/cli` main and bumps the lock to that commit, so we no longer depend on a personal fork. It stays on main rather than a tag because the fixes aren't in a release yet. #126 changes how the CLI's default flake package builds, so I ran a full `nix run .#build` to confirm it works end to end; the build passed and left no generated-file drift.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~ No composition function changes.
- [x] Signed off every commit with `git commit -s`.
