### PR TITLE
Make the docs AI-forward: Markdown, llms.txt, and an MCP server

### DIFF
--- a/docs/api/mcp.js
+++ b/docs/api/mcp.js
@@ -1,0 +1,411 @@
+// Modelplane docs MCP server.
+//
+// A zero-dependency Model Context Protocol server that lets AI assistants
+// search and read the Modelplane documentation. It implements the Streamable
+// HTTP transport (JSON-RPC 2.0 over POST) by hand so it ships as a single
+// Vercel function with no npm install: the docs site builds in a sandboxed Nix
+// derivation with `installCommand: true`, which skips dependency installation.
+//
+// The corpus is the llms.json the Hugo build publishes. We fetch it once per
+// cold start, chunk every page by heading, and rank chunks with BM25. The
+// search is lexical, not semantic: the corpus is small and the calling model
+// does the semantic reasoning over the candidates we return. See
+// content/ai-tools.md for the user-facing connection guide.
+
+const CORPUS_URL =
+  process.env.DOCS_LLMS_JSON_URL || "https://docs.modelplane.ai/llms.json";
+const PROTOCOL_VERSION = "2025-06-18";
+const SERVER_INFO = { name: "modelplane-docs", version: "0.1.0" };
+
+// ── Corpus loading and indexing ──────────────────────────────────────────────
+
+let indexPromise = null;
+
+// Cache the built index for the lifetime of the warm function instance.
+function loadIndex() {
+  if (!indexPromise) {
+    indexPromise = buildIndex().catch((err) => {
+      // Don't cache a failed load: let the next request retry.
+      indexPromise = null;
+      throw err;
+    });
+  }
+  return indexPromise;
+}
+
+async function buildIndex() {
+  const res = await fetch(CORPUS_URL, { headers: { accept: "application/json" } });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch corpus ${CORPUS_URL}: ${res.status}`);
+  }
+  const corpus = await res.json();
+  const pages = Array.isArray(corpus.pages) ? corpus.pages : [];
+
+  const chunks = [];
+  for (const page of pages) {
+    for (const chunk of chunkPage(page)) {
+      chunks.push(chunk);
+    }
+  }
+
+  // BM25 statistics.
+  const df = new Map(); // term -> number of chunks containing it
+  let totalLen = 0;
+  for (const chunk of chunks) {
+    chunk.tokens = tokenize(chunk.text);
+    chunk.len = chunk.tokens.length;
+    totalLen += chunk.len;
+    chunk.tf = termFreqs(chunk.tokens);
+    for (const term of chunk.tf.keys()) {
+      df.set(term, (df.get(term) || 0) + 1);
+    }
+  }
+  const avgLen = chunks.length ? totalLen / chunks.length : 0;
+
+  return { pages, chunks, df, avgLen };
+}
+
+// Strip HTML comments (e.g. Vale `<!-- vale ... -->` directives) that are
+// tooling noise, not documentation.
+function stripComments(text) {
+  return String(text).replace(/<!--[\s\S]*?-->/g, "");
+}
+
+// Split a page into chunks at Markdown headings so search ranks at section
+// granularity. The page intro (text before the first heading) is its own chunk.
+function chunkPage(page) {
+  const content = stripComments(page.content || "");
+  const lines = content.split("\n");
+  const chunks = [];
+  let heading = page.title || "";
+  let buf = [];
+
+  const flush = () => {
+    const text = buf.join("\n").trim();
+    if (text || chunks.length === 0) {
+      const anchor = chunks.length === 0 ? "" : "#" + slugify(heading);
+      chunks.push({
+        pageTitle: page.title || "",
+        heading,
+        url: (page.url || "") + anchor,
+        description: page.description || "",
+        text: (heading ? heading + "\n" : "") + text,
+      });
+    }
+    buf = [];
+  };
+
+  for (const line of lines) {
+    const m = /^(#{1,6})\s+(.*)$/.exec(line);
+    if (m) {
+      flush();
+      heading = m[2].trim();
+    } else {
+      buf.push(line);
+    }
+  }
+  flush();
+  return chunks.filter((c) => c.text.trim().length > 0);
+}
+
+const STOPWORDS = new Set(
+  ("a an and are as at be by for from has have in into is it its of on or that the to " +
+    "with you your this these those").split(" ")
+);
+
+function tokenize(text) {
+  const out = [];
+  for (const raw of String(text).toLowerCase().split(/[^a-z0-9]+/)) {
+    if (!raw || raw.length < 2 || STOPWORDS.has(raw)) continue;
+    out.push(stem(raw));
+  }
+  return out;
+}
+
+// Deliberately light stemming: fold common English suffixes so "deployments",
+// "deploying", and "deployed" rank together without a full stemmer dependency.
+function stem(t) {
+  if (t.length > 4) {
+    if (t.endsWith("ing")) return t.slice(0, -3);
+    if (t.endsWith("ed")) return t.slice(0, -2);
+    if (t.endsWith("ies")) return t.slice(0, -3) + "y";
+    if (t.endsWith("es")) return t.slice(0, -2);
+    if (t.endsWith("s")) return t.slice(0, -1);
+  }
+  return t;
+}
+
+function termFreqs(tokens) {
+  const tf = new Map();
+  for (const t of tokens) tf.set(t, (tf.get(t) || 0) + 1);
+  return tf;
+}
+
+function slugify(s) {
+  return String(s)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+// ── Search ───────────────────────────────────────────────────────────────────
+
+function search(index, query, limit) {
+  const { chunks, df, avgLen } = index;
+  const k1 = 1.5;
+  const b = 0.75;
+  const N = chunks.length;
+  const qTerms = [...new Set(tokenize(query))];
+  if (qTerms.length === 0) return [];
+
+  const scored = [];
+  for (const chunk of chunks) {
+    let score = 0;
+    for (const term of qTerms) {
+      const tf = chunk.tf.get(term);
+      if (!tf) continue;
+      const n = df.get(term) || 0;
+      const idf = Math.log(1 + (N - n + 0.5) / (n + 0.5));
+      const denom = tf + k1 * (1 - b + (b * chunk.len) / (avgLen || 1));
+      score += idf * ((tf * (k1 + 1)) / denom);
+    }
+    if (score > 0) scored.push({ chunk, score });
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, limit).map(({ chunk, score }) => ({
+    title: chunk.pageTitle,
+    heading: chunk.heading,
+    url: chunk.url,
+    score: Number(score.toFixed(3)),
+    snippet: snippet(chunk.text),
+  }));
+}
+
+function snippet(text, max = 360) {
+  const clean = text.replace(/\s+/g, " ").trim();
+  return clean.length > max ? clean.slice(0, max).trimEnd() + "..." : clean;
+}
+
+// ── Tools ──────────────────────────────────────────────────────────────────--
+
+const TOOLS = [
+  {
+    name: "search_modelplane_docs",
+    description:
+      "Search the Modelplane documentation and return the most relevant sections " +
+      "with their titles, canonical URLs, and snippets. Modelplane is the open " +
+      "source control plane for AI model serving across a fleet of GPU clusters. " +
+      "Use this to ground answers about Modelplane's CRDs (ModelDeployment, " +
+      "InferenceCluster, InferenceClass, ModelService, and others), scheduling, " +
+      "and setup in the current docs.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query." },
+        limit: {
+          type: "integer",
+          description: "Maximum number of results (default 5, max 20).",
+          default: 5,
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "get_modelplane_doc",
+    description:
+      "Return the full Markdown of a single Modelplane documentation page by its " +
+      "URL or path (for example /models/model-deployment/), as returned by " +
+      "search_modelplane_docs.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Page URL or path, e.g. /models/model-deployment/.",
+        },
+      },
+      required: ["path"],
+    },
+  },
+];
+
+function normalizePath(p) {
+  let s = String(p || "").trim();
+  s = s.replace(/^https?:\/\/[^/]+/, ""); // strip origin if a full URL
+  s = s.replace(/#.*$/, ""); // strip anchor
+  s = s.replace(/index\.md$/, "").replace(/\.md$/, "");
+  if (!s.startsWith("/")) s = "/" + s;
+  if (!s.endsWith("/")) s += "/";
+  return s;
+}
+
+async function callTool(name, args) {
+  const index = await loadIndex();
+
+  if (name === "search_modelplane_docs") {
+    const query = String((args && args.query) || "").trim();
+    if (!query) return toolError("query is required");
+    let limit = Number((args && args.limit) || 5);
+    if (!Number.isFinite(limit) || limit < 1) limit = 5;
+    limit = Math.min(limit, 20);
+
+    const results = search(index, query, limit);
+    if (results.length === 0) {
+      return toolText(`No results for "${query}".`);
+    }
+    const body = results
+      .map(
+        (r, i) =>
+          `${i + 1}. ${r.title}${r.heading && r.heading !== r.title ? " — " + r.heading : ""}\n` +
+          `   ${r.url}\n   ${r.snippet}`
+      )
+      .join("\n\n");
+    return toolText(`Top ${results.length} results for "${query}":\n\n${body}`);
+  }
+
+  if (name === "get_modelplane_doc") {
+    const want = normalizePath(args && args.path);
+    const page = index.pages.find((p) => normalizePath(p.url || p.path) === want);
+    if (!page) {
+      return toolError(
+        `No page found for "${(args && args.path) || ""}". Use search_modelplane_docs to find a path.`
+      );
+    }
+    const header = `# ${page.title}\n${page.url}\n\n`;
+    return toolText(header + stripComments(page.content || "").trim());
+  }
+
+  return toolError(`Unknown tool: ${name}`);
+}
+
+function toolText(text) {
+  return { content: [{ type: "text", text }] };
+}
+
+function toolError(text) {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+// ── JSON-RPC dispatch ─────────────────────────────────────────────────────────
+
+const JSONRPC_VERSION = "2.0";
+
+async function handleMessage(msg) {
+  // Notifications have no id and expect no response.
+  const isNotification = msg.id === undefined || msg.id === null;
+  const respond = (result) => ({ jsonrpc: JSONRPC_VERSION, id: msg.id, result });
+  const fail = (code, message) => ({
+    jsonrpc: JSONRPC_VERSION,
+    id: msg.id ?? null,
+    error: { code, message },
+  });
+
+  try {
+    switch (msg.method) {
+      case "initialize":
+        return respond({
+          protocolVersion:
+            (msg.params && msg.params.protocolVersion) || PROTOCOL_VERSION,
+          capabilities: { tools: { listChanged: false } },
+          serverInfo: SERVER_INFO,
+        });
+      case "notifications/initialized":
+      case "notifications/cancelled":
+        return null; // no response for notifications
+      case "ping":
+        return respond({});
+      case "tools/list":
+        return respond({ tools: TOOLS });
+      case "tools/call": {
+        const params = msg.params || {};
+        const result = await callTool(params.name, params.arguments || {});
+        return respond(result);
+      }
+      default:
+        if (isNotification) return null;
+        return fail(-32601, `Method not found: ${msg.method}`);
+    }
+  } catch (err) {
+    if (isNotification) return null;
+    return fail(-32603, `Internal error: ${err && err.message ? err.message : err}`);
+  }
+}
+
+// ── HTTP transport ────────────────────────────────────────────────────────────
+
+function setCors(res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS");
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Mcp-Session-Id, MCP-Protocol-Version, Authorization"
+  );
+}
+
+async function readBody(req) {
+  if (req.body !== undefined && req.body !== null && req.body !== "") {
+    return typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+  }
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString("utf8");
+  return raw ? JSON.parse(raw) : null;
+}
+
+module.exports = async function handler(req, res) {
+  setCors(res);
+
+  if (req.method === "OPTIONS") {
+    res.statusCode = 204;
+    return res.end();
+  }
+
+  // No server-initiated streams: this server is stateless and request/response.
+  if (req.method === "GET") {
+    res.statusCode = 405;
+    res.setHeader("Allow", "POST, OPTIONS");
+    return res.end("Method Not Allowed");
+  }
+
+  if (req.method !== "POST") {
+    res.statusCode = 405;
+    res.setHeader("Allow", "POST, OPTIONS");
+    return res.end("Method Not Allowed");
+  }
+
+  let payload;
+  try {
+    payload = await readBody(req);
+  } catch (err) {
+    res.statusCode = 400;
+    res.setHeader("Content-Type", "application/json");
+    return res.end(
+      JSON.stringify({
+        jsonrpc: JSONRPC_VERSION,
+        id: null,
+        error: { code: -32700, message: "Parse error" },
+      })
+    );
+  }
+
+  const messages = Array.isArray(payload) ? payload : [payload];
+  const responses = [];
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") continue;
+    const r = await handleMessage(msg);
+    if (r !== null) responses.push(r);
+  }
+
+  // All inputs were notifications: acknowledge with 202 and no body.
+  if (responses.length === 0) {
+    res.statusCode = 202;
+    return res.end();
+  }
+
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "application/json");
+  const out = Array.isArray(payload) ? responses : responses[0];
+  res.end(JSON.stringify(out));
+};

--- a/docs/content/overview/ai-tools.md
+++ b/docs/content/overview/ai-tools.md
@@ -1,0 +1,92 @@
+---
+title: Working with AI tools
+weight: 40
+description: Connect AI assistants and coding agents to the Modelplane docs through MCP, Markdown, and llms.txt.
+---
+
+The Modelplane docs are built to be read by AI assistants as well as people. You can connect a coding agent directly to this site, pull any page as Markdown, or point a model at a single index file that lists the whole documentation set. Every page also carries a **Copy page** menu next to its title with the same shortcuts.
+
+## Connect to the MCP server
+
+The documentation MCP server lets an assistant search these docs and read any page in real time, so its answers track the current content instead of its training data. It exposes two tools:
+
+- `search_modelplane_docs`: search the docs and get back the most relevant sections with their titles, URLs, and snippets.
+- `get_modelplane_doc`: fetch the full Markdown of a single page.
+
+The server URL is:
+
+```
+https://docs.modelplane.ai/mcp
+```
+
+{{< tabs >}}
+{{< tab "Claude Code" >}}
+```bash
+claude mcp add --transport http modelplane-docs https://docs.modelplane.ai/mcp
+```
+{{< /tab >}}
+{{< tab "Claude Desktop" >}}
+Open Settings, go to Connectors, and choose **Add custom connector**. Name it `modelplane-docs`, enter the server URL above, and enable the connector when you start a conversation.
+{{< /tab >}}
+{{< tab "Cursor" >}}
+Open the command palette, run **Cursor Settings: MCP**, and add a server to `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "modelplane-docs": {
+      "url": "https://docs.modelplane.ai/mcp"
+    }
+  }
+}
+```
+{{< /tab >}}
+{{< tab "VS Code" >}}
+Create `.vscode/mcp.json` in your workspace:
+
+```json
+{
+  "servers": {
+    "modelplane-docs": {
+      "type": "http",
+      "url": "https://docs.modelplane.ai/mcp"
+    }
+  }
+}
+```
+{{< /tab >}}
+{{< tab "Other" >}}
+Any MCP client that speaks the streamable HTTP transport can connect to the server URL directly. No authentication is required.
+{{< /tab >}}
+{{< /tabs >}}
+
+The **Copy page** menu on every page also has **Connect to Cursor** and **Connect to VS Code** shortcuts that install the server in one click.
+
+## Read pages as Markdown
+
+Every page is also published as raw Markdown. Add `index.md` to any page URL:
+
+```
+https://docs.modelplane.ai/models/model-deployment/index.md
+```
+
+The **Copy page** control next to each title copies that Markdown to your clipboard, and **View as Markdown** opens it in the browser. Paste it into any assistant when you want to ground a question in a specific page.
+
+## llms.txt
+
+For tools that index a whole site, the docs publish the [`llms.txt`](https://llmstxt.org) format:
+
+- [`llms.txt`](/llms.txt): a short index of every page with links and descriptions.
+- [`llms-full.txt`](/llms-full.txt): every page concatenated into one Markdown file.
+
+## Page menu reference
+
+The **Copy page** menu next to each title has these actions:
+
+| Action | What it does |
+|---|---|
+| Copy page | Copies the page as Markdown to your clipboard. |
+| View as Markdown | Opens the page as raw Markdown. |
+| Copy MCP Server | Copies the MCP server URL to your clipboard. |
+| Connect to Cursor | Installs the MCP server in Cursor. |
+| Connect to VS Code | Installs the MCP server in VS Code. |

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -9,8 +9,32 @@ disableKinds = ["taxonomy", "term"]
 ignoreFiles = ["themes/geekboot/content/.*", "README.md"]
 
 [outputs]
-  home = ["html"]
-  section = ["html", "rss"]
+  home = ["html", "llms", "llmsfull", "llmsjson"]
+  section = ["html", "rss", "markdown"]
+  page = ["html", "markdown"]
+
+# Machine-readable variants for AI agents and LLM tools. The markdown format
+# emits a raw-Markdown sibling of every page (page/index.md); the home page also
+# emits llms.txt (an index), llms-full.txt (every page concatenated), and
+# llms.json (the corpus the docs MCP server searches). See content/ai-tools.md.
+[outputFormats]
+  [outputFormats.markdown]
+    mediaType = "text/markdown"
+    isPlainText = true
+    isHTML = false
+    permalinkable = true
+  [outputFormats.llms]
+    mediaType = "text/plain"
+    baseName = "llms"
+    isPlainText = true
+  [outputFormats.llmsfull]
+    mediaType = "text/plain"
+    baseName = "llms-full"
+    isPlainText = true
+  [outputFormats.llmsjson]
+    mediaType = "application/json"
+    baseName = "llms"
+    isPlainText = true
 
 
 [build]

--- a/docs/themes/geekboot/assets/scss/_modelplane.scss
+++ b/docs/themes/geekboot/assets/scss/_modelplane.scss
@@ -64,64 +64,130 @@ nav.site-nav a {
   letter-spacing: -0.02em;
 }
 
-// ── For AI agents — sidebar tools (content pages) ────────────
+// ── For AI agents — "Copy page" split control next to the page title ─────────
 
-.mp-page-ai-tools {
-  margin-top: 1.5rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--toc-mobile-menu-outline);
+.mp-page-ai {
+  display: inline-flex;
+  align-items: stretch;
 }
 
-.mp-page-ai-label {
-  font-size: 0.7rem;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  color: var(--toc-font-color);
-  margin-bottom: 0.5rem;
-}
-
-.mp-page-ai-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-
-.mp-llm-badge {
-  font-family: #{$font-family-monospace};
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  color: #{$mp-cyan};
-  background: rgba(0,220,232,0.08);
-  border: 1px solid rgba(0,220,232,0.25);
-  border-radius: 4px;
-  padding: 2px 7px;
-  text-decoration: none;
-  transition: background 150ms;
-
-  &:hover {
-    background: rgba(0,220,232,0.16);
-    color: #{$mp-cyan};
-    text-decoration: none;
-  }
-}
-[color-theme="light"] .mp-llm-badge { color: #{$aqua-700}; }
-
-.mp-copy-page-btn {
+// Shared look for the two halves of the split button.
+.mp-page-ai-copy,
+.mp-page-ai-caret {
   font-family: inherit;
-  font-size: 0.75rem;
   color: var(--toc-font-color);
   background: none;
   border: 1px solid var(--toc-mobile-menu-outline);
-  border-radius: 4px;
-  padding: 2px 8px;
   cursor: pointer;
-  transition: color 150ms, border-color 150ms;
+  transition: color 150ms, border-color 150ms, background 150ms;
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     color: #{$mp-muted-hi};
-    border-color: rgba(154,94,252,0.3);
+    border-color: rgba(154,94,252,0.45);
+  }
+}
+
+.mp-page-ai-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.78rem;
+  padding: 3px 10px;
+  border-radius: 5px 0 0 5px;
+
+  svg { opacity: 0.85; }
+}
+
+.mp-page-ai-caret {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 6px;
+  border-left: 0;
+  border-radius: 0 5px 5px 0;
+
+  &[aria-expanded="true"] {
+    color: #{$mp-purple-hi};
+    border-color: rgba(154,94,252,0.45);
+  }
+}
+
+// Position deterministically: below the control, right edge aligned. We use
+// data-bs-display="static" (Popper disabled) and place it ourselves, because
+// Bootstrap's right-alignment reads a --bs-position custom property that
+// PurgeCSS strips from the production build (it's only read by JS).
+.mp-page-ai .mp-page-ai-menu {
+  position: absolute;
+  inset: auto 0 auto auto;
+  top: calc(100% + 0.4rem);
+  transform: none;
+}
+
+.mp-page-ai-menu {
+  --bs-dropdown-min-width: 18rem;
+  padding: 0.4rem;
+  background: var(--dropdown-background);
+  border: 1px solid var(--dropdown-border-color);
+  color: var(--body-font-color);
+
+  .mp-ai-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.6rem;
+    width: 100%;
+    padding: 0.45rem 0.55rem;
+    border-radius: 0.5rem;
+    white-space: normal;
+    text-align: left;
+    cursor: pointer;
+    color: var(--body-font-color);
+
+    &:hover,
+    &:focus,
+    &:focus-visible,
+    &:active {
+      background: var(--dropdown-highlight);
+      color: var(--body-font-color);
+    }
+  }
+
+  .mp-ai-ico {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    border: 1px solid var(--dropdown-border-color);
+    border-radius: 0.45rem;
+    color: var(--body-font-color);
+  }
+
+  .mp-ai-text {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+  }
+
+  .mp-ai-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-weight: 600;
+    font-size: 0.88rem;
+    color: var(--body-font-color);
+  }
+
+  .mp-ai-desc {
+    font-size: 0.76rem;
+    line-height: 1.3;
+    color: var(--mp-muted, #{$mp-muted});
+  }
+
+  .mp-ai-ext {
+    flex: 0 0 auto;
+    color: var(--mp-muted, #{$mp-muted});
   }
 }
 

--- a/docs/themes/geekboot/layouts/_default/home.llms.txt
+++ b/docs/themes/geekboot/layouts/_default/home.llms.txt
@@ -11,5 +11,5 @@
 ## Resources
 
 - Full documentation as one file: {{ with .OutputFormats.Get "llmsfull" }}{{ .Permalink }}{{ end }}
-- Connect an AI assistant (MCP, Markdown): {{ .Site.Home.Permalink }}ai-tools/
+{{ with .Site.GetPage "/overview/ai-tools" }}- Connect an AI assistant (MCP, Markdown): {{ .Permalink }}{{ end }}
 - GitHub: https://github.com/modelplaneai/modelplane

--- a/docs/themes/geekboot/layouts/_default/home.llms.txt
+++ b/docs/themes/geekboot/layouts/_default/home.llms.txt
@@ -1,0 +1,15 @@
+{{- /* llms.txt: a concise index of the docs for LLM tools, per https://llmstxt.org. */ -}}
+# Modelplane Documentation
+
+> Modelplane is the open source control plane for AI model serving. It extends Crossplane to manage AI inference across a fleet of GPU clusters.
+
+## Documentation
+{{ range (where .Site.Pages "Kind" "in" (slice "page" "section")).ByWeight }}{{ if .RawContent }}
+- [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+{{- end }}{{ end }}
+
+## Resources
+
+- Full documentation as one file: {{ with .OutputFormats.Get "llmsfull" }}{{ .Permalink }}{{ end }}
+- Connect an AI assistant (MCP, Markdown): {{ .Site.Home.Permalink }}ai-tools/
+- GitHub: https://github.com/modelplaneai/modelplane

--- a/docs/themes/geekboot/layouts/_default/home.llmsfull.txt
+++ b/docs/themes/geekboot/layouts/_default/home.llmsfull.txt
@@ -1,0 +1,13 @@
+{{- /* llms-full.txt: every docs page concatenated as one Markdown file. */ -}}
+# Modelplane Documentation
+
+> Modelplane is the open source control plane for AI model serving. It extends Crossplane to manage AI inference across a fleet of GPU clusters.
+{{ range (where .Site.Pages "Kind" "in" (slice "page" "section")).ByWeight }}{{ if .RawContent }}
+---
+
+# {{ .Title }}
+
+Source: {{ .Permalink }}
+
+{{ .RawContent }}
+{{ end }}{{ end }}

--- a/docs/themes/geekboot/layouts/_default/home.llmsjson.json
+++ b/docs/themes/geekboot/layouts/_default/home.llmsjson.json
@@ -1,0 +1,22 @@
+{{- /* llms.json: the structured corpus the docs MCP server searches.
+       One entry per content page; the MCP server chunks by heading at load time. */ -}}
+{{- $pages := slice -}}
+{{- range (where .Site.Pages "Kind" "in" (slice "home" "page" "section")).ByWeight -}}
+  {{- if .RawContent -}}
+    {{- $md := "" -}}
+    {{- with .OutputFormats.Get "markdown" }}{{ $md = .Permalink }}{{ end -}}
+    {{- $pages = $pages | append (dict
+        "title" .Title
+        "description" (.Description | default "")
+        "url" .Permalink
+        "path" .RelPermalink
+        "markdown_url" $md
+        "content" .RawContent) -}}
+  {{- end -}}
+{{- end -}}
+{{- dict
+    "name" "Modelplane Documentation"
+    "description" "Open source control plane for AI model serving on a fleet of GPU clusters."
+    "homepage" .Site.Home.Permalink
+    "pages" $pages
+  | jsonify (dict "indent" "  ") -}}

--- a/docs/themes/geekboot/layouts/_default/list.md
+++ b/docs/themes/geekboot/layouts/_default/list.md
@@ -1,0 +1,5 @@
+{{- /* Raw-Markdown rendering of a section landing page, served at section/index.md. */ -}}
+{{- printf "# %s\n\n" .Title -}}
+{{- with .Description }}{{ printf "%s\n\n" . }}{{ end -}}
+{{- with .OutputFormats.Get "html" }}{{ printf "Source: %s\n\n" .Permalink }}{{ end -}}
+{{- .RawContent -}}

--- a/docs/themes/geekboot/layouts/_default/single.md
+++ b/docs/themes/geekboot/layouts/_default/single.md
@@ -1,0 +1,7 @@
+{{- /* Raw-Markdown rendering of a docs page, served at page/index.md.
+       Powers the "View as Markdown" action and feeds the docs MCP server.
+       Uses .RawContent so the source Markdown is preserved verbatim. */ -}}
+{{- printf "# %s\n\n" .Title -}}
+{{- with .Description }}{{ printf "%s\n\n" . }}{{ end -}}
+{{- with .OutputFormats.Get "html" }}{{ printf "Source: %s\n\n" .Permalink }}{{ end -}}
+{{- .RawContent -}}

--- a/docs/themes/geekboot/layouts/partials/ai-ext-arrow.html
+++ b/docs/themes/geekboot/layouts/partials/ai-ext-arrow.html
@@ -1,0 +1,2 @@
+{{- /* Small up-right arrow marking a menu item that leaves the page. */ -}}
+<svg class="mp-ai-ext" width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 11 11 5M6 5h5v5"/></svg>

--- a/docs/themes/geekboot/layouts/partials/single-list.html
+++ b/docs/themes/geekboot/layouts/partials/single-list.html
@@ -45,6 +45,72 @@
       <div class="bd-intro-inner">
       <div class="d-md-flex flex-md-row-reverse align-items-center justify-content-between">
         <div class="mb-3 mb-md-0 d-flex">
+          {{ $md := "" }}{{ with .OutputFormats.Get "markdown" }}{{ $md = .Permalink }}{{ end }}
+          {{ $mcp := "https://docs.modelplane.ai/mcp" }}
+          {{ $cursorURL := printf "cursor://anysphere.cursor-deeplink/mcp/install?name=modelplane-docs&config=%s" (printf "{\"url\":\"%s\"}" $mcp | base64Encode | urlquery) | safeURL }}
+          {{ $vscodeURL := printf "vscode:mcp/install?%s" (printf "{\"name\":\"modelplane-docs\",\"type\":\"http\",\"url\":\"%s\"}" $mcp | urlquery) | safeURL }}
+          <div class="mp-page-ai dropdown">
+            <button type="button" class="mp-page-ai-copy" onclick="mpCopyPage(this)">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><rect x="5.5" y="5.5" width="8" height="8" rx="1.2"/><path d="M10.5 5.5V3.2A1.2 1.2 0 0 0 9.3 2H3.2A1.2 1.2 0 0 0 2 3.2v6.1a1.2 1.2 0 0 0 1.2 1.2h2.3"/></svg>
+              <span>Copy page</span>
+            </button>
+            <button type="button" class="mp-page-ai-caret" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false" aria-label="More tools for AI agents">
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/></svg>
+            </button>
+            <ul class="dropdown-menu mp-page-ai-menu">
+              <li>
+                <button type="button" class="dropdown-item mp-ai-item" onclick="mpCopyPage(this)">
+                  <span class="mp-ai-ico"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true"><rect x="5.5" y="5.5" width="8" height="8" rx="1.4"/><path d="M10.5 5.5V3.4A1.4 1.4 0 0 0 9.1 2H3.4A1.4 1.4 0 0 0 2 3.4v5.7A1.4 1.4 0 0 0 3.4 10.5h2.1"/></svg></span>
+                  <span class="mp-ai-text"><span class="mp-ai-title">Copy page</span><span class="mp-ai-desc">Copy page as Markdown for LLMs</span></span>
+                </button>
+              </li>
+              {{ with $md }}
+              <li>
+                <a class="dropdown-item mp-ai-item" href="{{ . }}" target="_blank" rel="noopener">
+                  <span class="mp-ai-ico"><svg width="17" height="11" viewBox="0 0 208 128" fill="none" aria-hidden="true"><rect x="5" y="5" width="198" height="118" rx="16" stroke="currentColor" stroke-width="14"/><path fill="currentColor" d="M30 98V30h20l20 25 20-25h20v68H90V59L70 84 50 59v39zm125 0l-30-33h20V30h20v35h20z"/></svg></span>
+                  <span class="mp-ai-text"><span class="mp-ai-title">View as Markdown {{ partial "ai-ext-arrow.html" }}</span><span class="mp-ai-desc">View this page as plain text</span></span>
+                </a>
+              </li>
+              {{ end }}
+              <li>
+                <button type="button" class="dropdown-item mp-ai-item" onclick="mpCopyText(this, '{{ $mcp }}')">
+                  <span class="mp-ai-ico"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12 11.1 3.9a3 3 0 1 1 4.3 4.3L7.3 16.3"/><path d="M7.3 16.3 15.4 8.2a3 3 0 1 1 4.3 4.3l-8.1 8"/></svg></span>
+                  <span class="mp-ai-text"><span class="mp-ai-title">Copy MCP Server</span><span class="mp-ai-desc">Copy MCP Server URL to clipboard</span></span>
+                </button>
+              </li>
+              <li>
+                <a class="dropdown-item mp-ai-item" href="{{ $cursorURL }}">
+                  <span class="mp-ai-ico"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" aria-hidden="true"><path d="M12 2.5 3.5 7v10L12 21.5 20.5 17V7z"/><path d="M3.5 7 12 11.5 20.5 7M12 11.5V21.5"/></svg></span>
+                  <span class="mp-ai-text"><span class="mp-ai-title">Connect to Cursor {{ partial "ai-ext-arrow.html" }}</span><span class="mp-ai-desc">Install MCP Server on Cursor</span></span>
+                </a>
+              </li>
+              <li>
+                <a class="dropdown-item mp-ai-item" href="{{ $vscodeURL }}">
+                  <span class="mp-ai-ico"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" fill-rule="evenodd" aria-hidden="true"><path d="M23.15 2.587 18.21.21a1.494 1.494 0 0 0-1.705.29l-9.46 8.63-4.12-3.128a.999.999 0 0 0-1.276.057L.327 7.261A1 1 0 0 0 .326 8.74L3.899 12 .326 15.26a1 1 0 0 0 .001 1.479L1.65 17.94a.999.999 0 0 0 1.276.057l4.12-3.128 9.46 8.63a1.492 1.492 0 0 0 1.704.29l4.942-2.377A1.5 1.5 0 0 0 24 19.645V3.876a1.5 1.5 0 0 0-.85-1.29zm-5.146 14.861L10.826 12l7.178-5.448z"/></svg></span>
+                  <span class="mp-ai-text"><span class="mp-ai-title">Connect to VS Code {{ partial "ai-ext-arrow.html" }}</span><span class="mp-ai-desc">Install MCP Server on VS Code</span></span>
+                </a>
+              </li>
+            </ul>
+          </div>
+          <template id="mp-raw-md">{{ .RawContent | htmlEscape }}</template>
+          <script>
+          function mpFlash(btn, msg) {
+            var label = btn.querySelector('.mp-ai-title') || btn.querySelector('span') || btn;
+            var original = label.textContent;
+            label.textContent = msg;
+            setTimeout(function () { label.textContent = original; }, 2000);
+          }
+          function mpCopyPage(btn) {
+            var tmpl = document.getElementById('mp-raw-md');
+            if (!tmpl) return;
+            var ta = document.createElement('textarea');
+            ta.innerHTML = tmpl.innerHTML;
+            navigator.clipboard.writeText(ta.value).then(function () { mpFlash(btn, 'Copied!'); });
+          }
+          function mpCopyText(btn, text) {
+            navigator.clipboard.writeText(text).then(function () { mpFlash(btn, 'Copied!'); });
+          }
+          </script>
         </div>
         <h1 class="bd-title mb-0" id="content">{{ .Title | markdownify }}
           {{ if eq .Page.Title "Release Notes" }}
@@ -89,28 +155,6 @@
           </nav>
         {{ end }}
         {{ end }}
-
-        <div class="mp-page-ai-tools">
-          <div class="mp-page-ai-label">For AI agents and LLM tools</div>
-          <div class="mp-page-ai-row">
-            <a href="{{ "llms.txt" | relURL }}" class="mp-llm-badge" target="_blank" rel="noopener">llms.txt</a>
-            <button class="mp-copy-page-btn" onclick="mpCopyPage(this)">Copy
-                           Markdown</button>
-          </div>
-          <template id="mp-raw-md">{{ .RawContent | htmlEscape }}</template>
-          <script>
-          function mpCopyPage(btn) {
-            var tmpl = document.getElementById('mp-raw-md');
-            if (!tmpl) return;
-            var ta = document.createElement('textarea');
-            ta.innerHTML = tmpl.innerHTML;
-            navigator.clipboard.writeText(ta.value).then(function () {
-              btn.textContent = 'Copied!';
-              setTimeout(function () { btn.textContent = 'Copy Markdown'; }, 2000);
-            });
-          }
-          </script>
-        </div>
       </div>
 
       <div class="bd-content ps-lg-2 DocSearch-content">

--- a/docs/utils/vale/styles/config/vocabularies/Modelplane/accept.txt
+++ b/docs/utils/vale/styles/config/vocabularies/Modelplane/accept.txt
@@ -130,6 +130,21 @@ WekaIO
 NetApp
 minikube
 
+# AI assistants and agent tooling
+MCP
+Claude
+Cursor
+ChatGPT
+VS
+VS Code
+Markdown
+JSON
+streamable
+llms
+txt
+llms\.txt
+llms-full\.txt
+
 # ML and AI
 Qwen
 Llama

--- a/docs/vercel-build.sh
+++ b/docs/vercel-build.sh
@@ -42,6 +42,15 @@ rm -f "$installer"
 
 export PATH="/nix/var/nix/profiles/default/bin:$PATH"
 
+# The Vercel project's Root Directory is docs/, so the api/ serverless functions
+# live under the docs site rather than polluting the repo root. The build runs
+# with the working directory at docs/, but the flake that defines .#docs is at
+# the repo root, so build from there. This needs the project's "Include source
+# files outside of the Root Directory in the Build Step" setting enabled, which
+# checks out the parent into the build container.
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
 # Build the site. result is a symlink into the read-only store; dereference it
 # into a plain, writable directory Vercel can serve.
 #
@@ -62,6 +71,8 @@ else
 	export HUGO_BASEURL="/"
 	nix build .#docs --impure --print-build-logs
 fi
-rm -rf public
-cp -rL --no-preserve=mode result public
+# outputDirectory in docs/vercel.json is "public", resolved against the docs/
+# Root Directory, so the served site goes to docs/public.
+rm -rf docs/public
+cp -rL --no-preserve=mode result docs/public
 rm -f result

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "bash vercel-build.sh",
+  "outputDirectory": "public",
+  "installCommand": "true",
+  "framework": null,
+  "rewrites": [{ "source": "/mcp", "destination": "/api/mcp" }],
+  "functions": { "api/mcp.js": { "maxDuration": 15 } }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "bash docs/vercel-build.sh",
-  "outputDirectory": "public",
-  "installCommand": "true",
-  "framework": null
-}


### PR DESCRIPTION
### Description of your changes

The Modelplane docs only shipped as HTML. AI assistants and coding agents had no clean way to read a page, pull the whole set, or search it in real time, so they fell back on stale training data when answering questions about Modelplane.

This makes the docs consumable by AI tools through three layers. The Hugo build now publishes a raw-Markdown sibling of every page, an `llms.txt` index, an `llms-full.txt` concatenation, and an `llms.json` corpus. A zero-dependency MCP server at `https://docs.modelplane.ai/mcp` exposes `search_modelplane_docs` (BM25 over the corpus, chunked by heading) and `get_modelplane_doc`; it implements the streamable HTTP transport by hand because the site builds in a sandboxed Nix derivation with `installCommand` skipped, so there is nowhere to install an SDK. The corpus is fetched from the published `llms.json` once per cold start. A "Copy page" menu next to every page title and a new `/ai-tools` page surface all of this to readers.

The MCP function lives under `docs/api` to stay out of the repo root and clear of the control-plane `apis/` tree. That required setting the docs Vercel project's Root Directory to `docs/` and enabling "Include files outside the Root Directory in the Build Step" so the build can still reach the flake at the repo root; both are set on the project, and `vercel.json` moved into `docs/` to match.

Validated against the pinned Hugo (0.152.2) that CI uses: the `docs`, `docs-vale`, and `docs-htmltest` flake checks all pass, and the MCP server was exercised end to end (initialize, tools/list, search, get) against the generated corpus.

One gap worth calling out: the API reference page renders from CRD data rather than Markdown content, so it is not in the search corpus or the per-page Markdown yet. The `models/*` pages cover those CRDs in prose. A follow-up could render the generated reference into the corpus too.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] ~Added or updated tests covering any composition function changes.~ No composition function changes.
- [x] Signed off every commit with `git commit -s`.
