### PR TITLE
Orphan EKS and GKE in-cluster resources to unblock teardown

### DIFF
--- a/apis/eksclusters/composition.yaml
+++ b/apis/eksclusters/composition.yaml
@@ -11,6 +11,3 @@ spec:
   - functionRef:
       name: modelplane-modelplanecompose-eks-cluster
     step: compose-eks-cluster
-  - functionRef:
-      name: modelplane-modelplanecompose-usages
-    step: compose-usages

--- a/functions/compose-eks-cluster/function/fn.py
+++ b/functions/compose-eks-cluster/function/fn.py
@@ -55,6 +55,20 @@ from models.io.upbound.m.aws.iam.rolepolicyattachment import v1beta1 as rpav1bet
 # default "*" still reconciles forProvider, defeating the purpose.)
 _NODE_GROUP_MANAGEMENT = ["Observe", "Create", "Update", "Delete"]
 
+# Management policies that exclude Delete, used for resources installed on the
+# workload cluster (the RWX StorageClass Object, the autoscaler and EFA DRA
+# Helm Releases). These exist only to configure the cluster and are only ever
+# deleted because the whole EKSCluster - and the cluster itself - is being torn
+# down. Deleting them then means asking provider-helm / provider-kubernetes to
+# reach a cluster whose kubeconfig Secret has already been deleted, which wedges
+# their finalizers and hangs the composite. Orphaning them sidesteps that: the
+# in-cluster resources die with the cluster. Crossplane names composed resources
+# deterministically from the owner XR's UID and the composition resource name,
+# so if one of these MRs is ever deleted out of band the recomposed MR takes the
+# same name and provider-helm / provider-kubernetes adopt the existing release
+# or object rather than erroring.
+_ORPHAN_MANAGEMENT = ["Observe", "Create", "Update"]
+
 # System node group injected into every EKS cluster to host control-plane
 # components (Envoy Gateway, KEDA, KServe controller, etc.). Not part of
 # the user-facing API — compose-inference-cluster only passes GPU groups.
@@ -1243,6 +1257,7 @@ class Composer:
             k8sobjv1alpha1.Object(
                 metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),
                 spec=k8sobjv1alpha1.Spec(
+                    managementPolicies=_ORPHAN_MANAGEMENT,
                     providerConfigRef=k8sobjv1alpha1.ProviderConfigRef(
                         kind="ProviderConfig",
                         name=_kubeconfig_secret_name(self.xr),
@@ -1339,6 +1354,7 @@ class Composer:
             helmv1beta1.Release(
                 metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),
                 spec=helmv1beta1.Spec(
+                    managementPolicies=_ORPHAN_MANAGEMENT,
                     providerConfigRef=helmv1beta1.ProviderConfigRef(
                         kind="ProviderConfig",
                         name=_kubeconfig_secret_name(self.xr),
@@ -1384,6 +1400,7 @@ class Composer:
             helmv1beta1.Release(
                 metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),
                 spec=helmv1beta1.Spec(
+                    managementPolicies=_ORPHAN_MANAGEMENT,
                     providerConfigRef=helmv1beta1.ProviderConfigRef(
                         kind="ProviderConfig",
                         name=_kubeconfig_secret_name(self.xr),

--- a/functions/compose-eks-cluster/tests/test_fn.py
+++ b/functions/compose-eks-cluster/tests/test_fn.py
@@ -804,6 +804,7 @@ def _storage_class_object(filesystem_id: str) -> dict:
         "kind": "Object",
         "metadata": {"namespace": "modelplane-system"},
         "spec": {
+            "managementPolicies": ["Observe", "Create", "Update"],
             "providerConfigRef": {
                 "kind": "ProviderConfig",
                 "name": _KUBECONFIG_SECRET,
@@ -880,6 +881,7 @@ def _autoscaler_release() -> dict:
         "kind": "Release",
         "metadata": {"namespace": "modelplane-system"},
         "spec": {
+            "managementPolicies": ["Observe", "Create", "Update"],
             "providerConfigRef": {"kind": "ProviderConfig", "name": _KUBECONFIG_SECRET},
             "forProvider": {
                 "chart": {
@@ -906,6 +908,7 @@ def _efa_dra_driver_release() -> dict:
         "kind": "Release",
         "metadata": {"namespace": "modelplane-system"},
         "spec": {
+            "managementPolicies": ["Observe", "Create", "Update"],
             "providerConfigRef": {"kind": "ProviderConfig", "name": _KUBECONFIG_SECRET},
             "forProvider": {
                 "chart": {

--- a/functions/compose-gke-cluster/function/fn.py
+++ b/functions/compose-gke-cluster/function/fn.py
@@ -68,6 +68,18 @@ _ANNOTATION_EXTERNAL_NAME = "crossplane.io/external-name"
 # cluster's VPC (Filestore CSI defaults to the `default` VPC otherwise).
 _MANAGED_STORAGE_CLASS = "modelplane-rwx"
 
+# Management policies that exclude Delete, used for the RWX StorageClass Object
+# installed on the workload cluster. It exists only to configure the cluster and
+# is only ever deleted because the whole GKECluster - and the cluster itself - is
+# being torn down. Deleting it then means asking provider-kubernetes to reach a
+# cluster whose kubeconfig Secret has already been deleted, which wedges its
+# finalizer and hangs the composite. Orphaning it sidesteps that: the in-cluster
+# StorageClass dies with the cluster. Crossplane names composed resources
+# deterministically from the owner XR's UID and the composition resource name, so
+# if this MR is ever deleted out of band the recomposed MR takes the same name
+# and provider-kubernetes adopts the existing StorageClass rather than erroring.
+_ORPHAN_MANAGEMENT = ["Observe", "Create", "Update"]
+
 # GKE node configuration.
 _GKE_IMAGE_TYPE = "COS_CONTAINERD"
 _GKE_OAUTH_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
@@ -429,6 +441,7 @@ class Composer:
             k8sobjv1alpha1.Object(
                 metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),
                 spec=k8sobjv1alpha1.Spec(
+                    managementPolicies=_ORPHAN_MANAGEMENT,
                     providerConfigRef=k8sobjv1alpha1.ProviderConfigRef(
                         kind="ProviderConfig",
                         name=_kubeconfig_secret_name(self.xr),

--- a/functions/compose-gke-cluster/tests/test_fn.py
+++ b/functions/compose-gke-cluster/tests/test_fn.py
@@ -474,7 +474,9 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                             # StorageClass is composed against the cluster's own
                             # provider-kubernetes ProviderConfig, pinned to the
                             # observed VPC. StorageClass has no Ready condition,
-                            # so readiness is SuccessfulCreate.
+                            # so readiness is SuccessfulCreate. It's orphaned (no
+                            # Delete policy) so it dies with the cluster instead of
+                            # wedging on a deleted kubeconfig Secret during teardown.
                             "storage-class-rwx": fnv1.Resource(
                                 resource=resource.dict_to_struct(
                                     {
@@ -482,6 +484,7 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                                         "kind": "Object",
                                         "metadata": {"namespace": "modelplane-system"},
                                         "spec": {
+                                            "managementPolicies": ["Observe", "Create", "Update"],
                                             "providerConfigRef": {
                                                 "kind": "ProviderConfig",
                                                 "name": "test-cluster-kubeconfig-55b57",


### PR DESCRIPTION
### Description of your changes

Fixes #212.

Deleting an EKS- or GKE-backed `InferenceCluster` with `--cascade=foreground` could hang the composite in `Terminating` indefinitely. The cluster composites install a handful of resources on the workload cluster they provision: the RWX `StorageClass` (a provider-kubernetes `Object` on both clouds) and, on EKS, the cluster-autoscaler and EFA DRA `Release`s. Each authenticates to the workload cluster through a `ProviderConfig` backed by the kubeconfig `Secret` the cluster's own managed resource writes.

On teardown every composed resource gets a deletion timestamp at once. The kubeconfig `Secret` (and on EKS the `ClusterAuth` that refreshes it) is torn down before these leaf resources finalize, so provider-helm and provider-kubernetes can't build a client for the by-then-deleted cluster. Their `managedresource.crossplane.io` finalizers never clear and the composite wedges. The cloud resources are genuinely gone by then, so the finalizers block on a confirmation that can never arrive.

These resources exist only to configure the workload cluster and are only ever deleted because that cluster is being destroyed, so there's nothing to clean up remotely. This sets their `managementPolicies` to exclude `Delete`, orphaning them: they die with the cluster instead of trying to reach it. Crossplane names composed resources deterministically from the owner XR's UID and the composition resource name, so if one is ever deleted out of band the recomposed MR takes the same name and the provider adopts the existing release or object rather than erroring.

With the EKS workload resources orphaned, nothing in the `EKSCluster` composition references a `ProviderConfig` that needs protecting, so this drops the `compose-usages` step from it. `compose-usages` stays in the `ServingStack` composition, whose Helm/Object consumers can target a cluster that outlives them.

The original report covered the EKS autoscaler `Release` and StorageClass `Object`; [a follow-up](https://github.com/modelplaneai/modelplane/issues/212#issuecomment-4757098064) reproduced the same wedge on GKE for the StorageClass `Object`, whose edge to the base `ProviderConfig` had no protection at all (`gkeclusters` never ran `compose-usages`). Both are covered here.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
