### PR TITLE
Enable the Filestore CSI driver addon on GKE clusters

### DIFF
--- a/functions/compose-gke-cluster/function/fn.py
+++ b/functions/compose-gke-cluster/function/fn.py
@@ -207,6 +207,16 @@ class Composer:
                         workloadIdentityConfig=clusterv1beta1.WorkloadIdentityConfig(
                             workloadPool=f"{self.xr.spec.project}.svc.id.goog",
                         ),
+                        # Enable the Filestore CSI driver addon so the
+                        # modelplane-rwx StorageClass has a provisioner. Without
+                        # it the ModelCache RWX PVC stays Pending forever (we
+                        # enable file.googleapis.com and compose the
+                        # StorageClass, but nothing runs the provisioner).
+                        addonsConfig=clusterv1beta1.AddonsConfig(
+                            gcpFilestoreCsiDriverConfig=clusterv1beta1.GcpFilestoreCsiDriverConfig(
+                                enabled=True,
+                            ),
+                        ),
                     ),
                     writeConnectionSecretToRef=clusterv1beta1.WriteConnectionSecretToRef(
                         name=_kubeconfig_secret_name(self.xr),

--- a/functions/compose-gke-cluster/tests/test_fn.py
+++ b/functions/compose-gke-cluster/tests/test_fn.py
@@ -164,6 +164,9 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                                                 "workloadIdentityConfig": {
                                                     "workloadPool": "my-gcp-project.svc.id.goog",
                                                 },
+                                                "addonsConfig": {
+                                                    "gcpFilestoreCsiDriverConfig": {"enabled": True},
+                                                },
                                             },
                                             "writeConnectionSecretToRef": {
                                                 "name": "test-cluster-kubeconfig-55b57",
@@ -548,6 +551,9 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                                                 "releaseChannel": {"channel": "REGULAR"},
                                                 "workloadIdentityConfig": {
                                                     "workloadPool": "my-gcp-project.svc.id.goog",
+                                                },
+                                                "addonsConfig": {
+                                                    "gcpFilestoreCsiDriverConfig": {"enabled": True},
                                                 },
                                             },
                                             "writeConnectionSecretToRef": {


### PR DESCRIPTION
Fixes #221

A GKE-backed `ModelCache` never hydrates: its RWX PVC stays `Pending` forever, so any `ModelDeployment` referencing it on a GKE cluster never becomes ready. EKS is unaffected.

The GKE cluster composition already enables the `file.googleapis.com` API and composes a `modelplane-rwx` StorageClass that provisions through `filestore.csi.storage.gke.io`, but it never enables the Filestore CSI driver addon on the cluster. With no provisioner running, the PVC can't bind — `kubectl describe pvc` reports `Waiting for a volume to be created ... by 'filestore.csi.storage.gke.io' ... verify that the provisioner is running and correctly registered`.

This enables the addon on the composed `Cluster`'s `forProvider` via `addonsConfig.gcpFilestoreCsiDriverConfig.enabled`, which is the GKE-native equivalent of the manual workaround proven out in the issue. The driver then runs, the StorageClass has a provisioner, and the cache PVC binds.

The addon is enabled inline on the `Cluster` MR rather than as a separate composed resource, so it's covered by the cluster's existing `Ready` condition and needs no readiness change. Setting only `gcpFilestoreCsiDriverConfig` leaves the other `addonsConfig` sub-fields unset, so it doesn't toggle GKE's other default addons. This mirrors how the composition already enables the Filestore API and StorageClass; EKS models CSI drivers differently (separate `Addon` MRs) and is left unchanged.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
