### PR TITLE
Type-check composition functions with ty and require type annotations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,9 @@ curl -fsSL https://install.determinate.systems/nix | sh -s -- install
 ## Running checks
 
 `nix flake check` runs all of the project's checks inside the Nix sandbox:
-Python, shell, and Nix linters and formatters, plus unit tests for every
-composition function. Run `nix flake show` to see what else is available.
+Python, shell, and Nix linters and formatters, the [ty](https://docs.astral.sh/ty)
+type checker on every composition function, plus unit tests for every function.
+Run `nix flake show` to see what else is available.
 
 ```bash
 nix flake check            # or: ./nix.sh flake check

--- a/docs/utils/validate/validate_manifests.py
+++ b/docs/utils/validate/validate_manifests.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import importlib
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType
 
@@ -95,7 +96,7 @@ def _harden(module: ModuleType) -> None:
             break
 
 
-def model_for(api_version: str, kind: str):
+def model_for(api_version: str, kind: str) -> type[pydantic.BaseModel] | None:
     """Return the Pydantic model class for a Modelplane kind, or None to skip."""
     group = api_version.rsplit("/", 1)[0] if "/" in api_version else ""
     version = api_version.rsplit("/", 1)[1] if "/" in api_version else api_version
@@ -110,7 +111,7 @@ def model_for(api_version: str, kind: str):
     return getattr(mod, kind)
 
 
-def docs_from_file(path: Path):
+def docs_from_file(path: Path) -> Iterator[dict]:
     """Yield each manifest dict from a (possibly multi-document) YAML file."""
     for doc in yaml.safe_load_all(path.read_text()):
         if doc:

--- a/flake.lock
+++ b/flake.lock
@@ -95,11 +95,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1779357205,
-        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -209,7 +209,8 @@
               pkgs.docker-client
               pkgs.unstable.uv
               pkgs.python3
-              pkgs.ruff
+              pkgs.unstable.ruff
+              pkgs.unstable.ty
               pkgs.nixfmt-rfc-style
               pkgs.hugo
               pkgs.nodejs

--- a/functions/compose-eks-cluster/function/fn.py
+++ b/functions/compose-eks-cluster/function/fn.py
@@ -65,9 +65,17 @@ from models.io.upbound.m.aws.iam.rolepolicyattachment import v1beta1 as rpav1bet
 
 
 def _name(meta: metav1.ObjectMeta | None) -> str:
-    """The object's name, which is always set on resources read from the API server."""
-    assert meta is not None and meta.name is not None
+    """The object's name, always set on resources read from the API server."""
+    if meta is None or meta.name is None:
+        raise ValueError("metadata.name is unexpectedly absent")
     return meta.name
+
+
+def _namespace(meta: metav1.ObjectMeta | None) -> str:
+    """The object's namespace, always set on namespaced resources read from the API server."""
+    if meta is None or meta.namespace is None:
+        raise ValueError("metadata.namespace is unexpectedly absent")
+    return meta.namespace
 
 
 # Node group management policies that exclude LateInitialize, so the
@@ -326,7 +334,7 @@ def _cluster_name(xr: v1alpha1.EKSCluster) -> str:
     name alone would let two clusters in different namespaces collide on one AWS
     cluster. child_name folds both in and appends a hash for uniqueness.
     """
-    return resource.child_name(xr.metadata.namespace, _name(xr.metadata), "eks")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+    return resource.child_name(_namespace(xr.metadata), _name(xr.metadata), "eks")
 
 
 def _subnet_name(xr: v1alpha1.EKSCluster, az: str) -> str:
@@ -843,7 +851,7 @@ class Composer:
         must be stable and match the launchTemplate.forProvider.name set
         on the composed EC2 LaunchTemplate.
         """
-        return resource.child_name(self.xr.metadata.name, f"lt-{pool.name}")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+        return resource.child_name(_name(self.xr.metadata), f"lt-{pool.name}")
 
     def _compose_launch_template(
         self, pool: v1alpha1.NodePool, capacity_block: v1alpha1.CapacityBlock | None, *, efa: bool
@@ -973,7 +981,7 @@ class Composer:
 
     def _efa_security_group_resource_name(self) -> str:
         """Object (metadata.name) of the shared EFA security group."""
-        return resource.child_name(self.xr.metadata.name, "efa-sg")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+        return resource.child_name(_name(self.xr.metadata), "efa-sg")
 
     def _compose_efa_security_group(self) -> None:
         """Compose the EFA security group and its self-referencing rules.
@@ -994,7 +1002,7 @@ class Composer:
                 spec=sgv1beta1.Spec(
                     forProvider=sgv1beta1.ForProvider(
                         region=region,
-                        name=f"{self.xr.metadata.name}-efa",  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                        name=f"{_name(self.xr.metadata)}-efa",
                         description="EFA OS-bypass traffic between gang nodes",
                         vpcIdSelector=sgv1beta1.VpcIdSelector(matchControllerRef=True),
                     ),
@@ -1144,7 +1152,7 @@ class Composer:
                 spec=sgv1beta1.Spec(
                     forProvider=sgv1beta1.ForProvider(
                         region=region,
-                        name=f"{self.xr.metadata.name}-efs",  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                        name=f"{_name(self.xr.metadata)}-efs",
                         description="NFS access to the ModelCache EFS mount targets",
                         vpcIdSelector=sgv1beta1.VpcIdSelector(matchControllerRef=True),
                     ),
@@ -1283,7 +1291,7 @@ class Composer:
         resource.update(
             self.rsp.desired.resources["storage-class-rwx-efs"],
             k8sobjv1alpha1.Object(
-                metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                metadata=metav1.ObjectMeta(namespace=_namespace(self.xr.metadata)),
                 spec=k8sobjv1alpha1.Spec(
                     managementPolicies=_ORPHAN_MANAGEMENT,
                     providerConfigRef=k8sobjv1alpha1.ProviderConfigRef(
@@ -1380,7 +1388,7 @@ class Composer:
         resource.update(
             self.rsp.desired.resources["release-cluster-autoscaler"],
             helmv1beta1.Release(
-                metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                metadata=metav1.ObjectMeta(namespace=_namespace(self.xr.metadata)),
                 spec=helmv1beta1.Spec(
                     managementPolicies=_ORPHAN_MANAGEMENT,
                     providerConfigRef=helmv1beta1.ProviderConfigRef(
@@ -1426,7 +1434,7 @@ class Composer:
         resource.update(
             self.rsp.desired.resources["release-efa-dra-driver"],
             helmv1beta1.Release(
-                metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                metadata=metav1.ObjectMeta(namespace=_namespace(self.xr.metadata)),
                 spec=helmv1beta1.Spec(
                     managementPolicies=_ORPHAN_MANAGEMENT,
                     providerConfigRef=helmv1beta1.ProviderConfigRef(
@@ -1469,7 +1477,7 @@ class Composer:
                         source="Secret",
                         secretRef=k8spcv1alpha1.SecretRef(
                             name=kubeconfig_secret,
-                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+                            namespace=_namespace(self.xr.metadata),
                             key=_SECRET_KEY_KUBECONFIG,
                         ),
                     ),
@@ -1486,7 +1494,7 @@ class Composer:
                         source="Secret",
                         secretRef=helmpcv1beta1.SecretRef(
                             name=kubeconfig_secret,
-                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+                            namespace=_namespace(self.xr.metadata),
                             key=_SECRET_KEY_KUBECONFIG,
                         ),
                     ),

--- a/functions/compose-eks-cluster/function/fn.py
+++ b/functions/compose-eks-cluster/function/fn.py
@@ -63,6 +63,13 @@ from models.io.upbound.m.aws.iam.policy import v1beta1 as policyv1beta1
 from models.io.upbound.m.aws.iam.role import v1beta1 as rolev1beta1
 from models.io.upbound.m.aws.iam.rolepolicyattachment import v1beta1 as rpav1beta1
 
+
+def _name(meta: metav1.ObjectMeta | None) -> str:
+    """The object's name, which is always set on resources read from the API server."""
+    assert meta is not None and meta.name is not None
+    return meta.name
+
+
 # Node group management policies that exclude LateInitialize, so the
 # desiredSize we seed via initProvider is applied only at creation and then
 # left alone. The cluster autoscaler drives the ASG's desired capacity; without
@@ -301,12 +308,12 @@ _ANNOTATION_EXTERNAL_NAME = "crossplane.io/external-name"
 _MANAGED_STORAGE_CLASS = "modelplane-rwx-efs"
 
 
-def _kubeconfig_secret_name(xr):
+def _kubeconfig_secret_name(xr: v1alpha1.EKSCluster) -> str:
     """Derive the kubeconfig secret name from the XR."""
-    return resource.child_name(xr.metadata.name, "kubeconfig")
+    return resource.child_name(_name(xr.metadata), "kubeconfig")
 
 
-def _cluster_name(xr):
+def _cluster_name(xr: v1alpha1.EKSCluster) -> str:
     """The EKS cluster's name in AWS.
 
     Pinned to a deterministic, compose-time-known name (rather than left to a
@@ -319,20 +326,20 @@ def _cluster_name(xr):
     name alone would let two clusters in different namespaces collide on one AWS
     cluster. child_name folds both in and appends a hash for uniqueness.
     """
-    return resource.child_name(xr.metadata.namespace, xr.metadata.name, "eks")
+    return resource.child_name(xr.metadata.namespace, _name(xr.metadata), "eks")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
 
-def _subnet_name(xr, az):
+def _subnet_name(xr: v1alpha1.EKSCluster, az: str) -> str:
     """Derive a stable Crossplane resource name for the public subnet in az."""
-    return resource.child_name(xr.metadata.name, f"subnet-{az}")
+    return resource.child_name(_name(xr.metadata), f"subnet-{az}")
 
 
-def _private_subnet_name(xr, az):
+def _private_subnet_name(xr: v1alpha1.EKSCluster, az: str) -> str:
     """Derive a stable Crossplane resource name for the private subnet in az."""
-    return resource.child_name(xr.metadata.name, f"private-subnet-{az}")
+    return resource.child_name(_name(xr.metadata), f"private-subnet-{az}")
 
 
-def _private_cidr(public_cidr) -> str:
+def _private_cidr(public_cidr: v1alpha1.SubnetCidr) -> str:
     """Derive a private subnet CIDR from its AZ's public one.
 
     The VPC is a /16 split into /20s. The public subnets take the low /20s
@@ -347,7 +354,7 @@ def _private_cidr(public_cidr) -> str:
     return f"{'.'.join(octets)}/{mask}"
 
 
-def _az(region, index) -> str:
+def _az(region: str, index: int) -> str:
     """Derive an Availability Zone name from a region and an index.
 
     AWS conventionally names AZs as ``<region><letter>`` where the letter
@@ -379,7 +386,7 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp) -> None:
+    def __init__(self, req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.EKSCluster(**resource.struct_to_dict(req.observed.composite.resource))
@@ -425,7 +432,7 @@ class Composer:
             ),
         )
 
-        for i, cidr in enumerate(self._networking().subnetCidrs):
+        for i, cidr in enumerate(self._networking().subnetCidrs or []):
             az = _az(self.xr.spec.region, i)
             cidr_str = cidr.root if hasattr(cidr, "root") else cidr
             # Public subnet: IGW route, auto-assigned public IPs, ELB-tagged.
@@ -587,7 +594,7 @@ class Composer:
             ),
         )
 
-        for i in range(len(self._networking().subnetCidrs)):
+        for i in range(len(self._networking().subnetCidrs or [])):
             az = _az(self.xr.spec.region, i)
             resource.update(
                 self.rsp.desired.resources[f"route-table-association-{i}"],
@@ -754,7 +761,7 @@ class Composer:
             # must not also set instanceTypes in that case.
             uses_launch_template = bool(capacity_block) or efa
             if uses_launch_template:
-                self._compose_launch_template(pool, capacity_block, efa)
+                self._compose_launch_template(pool, capacity_block, efa=efa)
             if efa:
                 self._compose_efa_security_group()
 
@@ -829,7 +836,7 @@ class Composer:
                 ),
             )
 
-    def _launch_template_name(self, pool):
+    def _launch_template_name(self, pool: v1alpha1.NodePool) -> str:
         """Derive the EC2 launch template name for a Capacity Block pool.
 
         The EKS NodeGroup references the launch template by name, so it
@@ -838,7 +845,9 @@ class Composer:
         """
         return resource.child_name(self.xr.metadata.name, f"lt-{pool.name}")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
-    def _compose_launch_template(self, pool, capacity_block, efa) -> None:
+    def _compose_launch_template(
+        self, pool: v1alpha1.NodePool, capacity_block: v1alpha1.CapacityBlock | None, *, efa: bool
+    ) -> None:
         """Compose an EC2 launch template for a node group.
 
         EKS launches the node group's instances from this template. It carries
@@ -884,7 +893,7 @@ class Composer:
             ltv1beta1.LaunchTemplate(spec=ltv1beta1.Spec(forProvider=fp)),
         )
 
-    def _efa_network_interfaces(self, pool):
+    def _efa_network_interfaces(self, pool: v1alpha1.NodePool) -> list[ltv1beta1.NetworkInterface]:
         """Build the launch template's EFA network interfaces for a pool.
 
         Every network card carries an EFA interface for maximum fabric
@@ -932,7 +941,7 @@ class Composer:
             interfaces.append(ni)
         return interfaces
 
-    def _observed_efa_security_group_id(self):
+    def _observed_efa_security_group_id(self) -> str | None:
         """The composed EFA security group's ID, from its observed MR's
         external-name annotation (the sg-xxxx ID the provider sets once it
         exists). None before the group is created, so the launch template is
@@ -946,7 +955,7 @@ class Composer:
             return None
         return sg.metadata.annotations.get(_ANNOTATION_EXTERNAL_NAME)
 
-    def _observed_cluster_security_group_id(self):
+    def _observed_cluster_security_group_id(self) -> str | None:
         """The EKS-managed cluster security group ID, from the observed cluster.
 
         EKS creates this group and reports it on the cluster's status; it's
@@ -962,7 +971,7 @@ class Composer:
             return None
         return cluster.status.atProvider.vpcConfig.clusterSecurityGroupId
 
-    def _efa_security_group_resource_name(self):
+    def _efa_security_group_resource_name(self) -> str:
         """Object (metadata.name) of the shared EFA security group."""
         return resource.child_name(self.xr.metadata.name, "efa-sg")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
@@ -1068,7 +1077,7 @@ class Composer:
             ),
         )
 
-    def _subnet_refs_for_pool(self, pool):
+    def _subnet_refs_for_pool(self, pool: v1alpha1.NodePool) -> list[ngv1beta1.SubnetIdRef] | None:
         """Resolve a pool's zones to a list of private Crossplane Subnet refs.
 
         Nodes run in the private subnets (NAT egress, no public IP), so a pool
@@ -1162,7 +1171,7 @@ class Composer:
         )
 
         # One mount target per node subnet so any AZ's nodes can mount the share.
-        for i in range(len(self._networking().subnetCidrs)):
+        for i in range(len(self._networking().subnetCidrs or [])):
             az = _az(region, i)
             resource.update(
                 self.rsp.desired.resources[f"efs-mount-target-{i}"],
@@ -1501,7 +1510,7 @@ class Composer:
         )
         resource.update_status(self.rsp.desired.composite, status)
 
-    def _observed_efs_filesystem_id(self):
+    def _observed_efs_filesystem_id(self) -> str | None:
         """The composed EFS filesystem's id, from the observed FileSystem MR's
         external-name annotation (set by the provider once it exists). None on
         early reconciles before the filesystem is created."""
@@ -1546,7 +1555,7 @@ class Composer:
             "iam-attach-cluster-autoscaler",
             "pod-identity-cluster-autoscaler",
         ]
-        for i in range(len(self._networking().subnetCidrs)):
+        for i in range(len(self._networking().subnetCidrs or [])):
             managed_resources.append(f"subnet-{i}")
             managed_resources.append(f"private-subnet-{i}")
             managed_resources.append(f"route-table-association-{i}")
@@ -1579,6 +1588,6 @@ class Composer:
         self.rsp.desired.resources["provider-config-kubernetes"].ready = fnv1.READY_TRUE
         self.rsp.desired.resources["provider-config-helm"].ready = fnv1.READY_TRUE
 
-    def _networking(self):
+    def _networking(self) -> v1alpha1.Networking:
         """Return the (defaulted) networking config from the XR."""
         return self.xr.spec.networking or v1alpha1.Networking()

--- a/functions/compose-eks-cluster/function/fn.py
+++ b/functions/compose-eks-cluster/function/fn.py
@@ -332,7 +332,7 @@ def _private_subnet_name(xr, az):
     return resource.child_name(xr.metadata.name, f"private-subnet-{az}")
 
 
-def _private_cidr(public_cidr):
+def _private_cidr(public_cidr) -> str:
     """Derive a private subnet CIDR from its AZ's public one.
 
     The VPC is a /16 split into /20s. The public subnets take the low /20s
@@ -347,7 +347,7 @@ def _private_cidr(public_cidr):
     return f"{'.'.join(octets)}/{mask}"
 
 
-def _az(region, index):
+def _az(region, index) -> str:
     """Derive an Availability Zone name from a region and an index.
 
     AWS conventionally names AZs as ``<region><letter>`` where the letter
@@ -361,7 +361,7 @@ def _az(region, index):
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
@@ -379,12 +379,12 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp):
+    def __init__(self, req, rsp) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.EKSCluster(**resource.struct_to_dict(req.observed.composite.resource))
 
-    def compose(self):
+    def compose(self) -> None:
         self.compose_network()
         self.compose_iam()
         self.compose_cluster()
@@ -399,7 +399,7 @@ class Composer:
         self.write_status()
         self.mark_readiness()
 
-    def compose_network(self):
+    def compose_network(self) -> None:
         """Compose the VPC, its two subnet tiers, and internet routing.
 
         The VPC has a public and a private subnet per AZ. Public subnets route
@@ -626,7 +626,7 @@ class Composer:
                 ),
             )
 
-    def compose_iam(self):
+    def compose_iam(self) -> None:
         """Compose the cluster and node IAM roles."""
         resource.update(
             self.rsp.desired.resources["iam-role-cluster"],
@@ -687,7 +687,7 @@ class Composer:
                 ),
             )
 
-    def compose_cluster(self):
+    def compose_cluster(self) -> None:
         """Compose the EKS cluster."""
         resource.update(
             self.rsp.desired.resources["cluster"],
@@ -717,7 +717,7 @@ class Composer:
             ),
         )
 
-    def compose_cluster_auth(self):
+    def compose_cluster_auth(self) -> None:
         """Compose the ClusterAuth resource that writes a kubeconfig.
 
         ClusterAuth uses the AWS provider's own credentials to mint an
@@ -742,7 +742,7 @@ class Composer:
             ),
         )
 
-    def compose_node_groups(self):
+    def compose_node_groups(self) -> None:
         """Compose the system and user-declared GPU node groups."""
         self._compose_system_node_group()
         for pool in self.xr.spec.nodePools:
@@ -838,7 +838,7 @@ class Composer:
         """
         return resource.child_name(self.xr.metadata.name, f"lt-{pool.name}")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
-    def _compose_launch_template(self, pool, capacity_block, efa):
+    def _compose_launch_template(self, pool, capacity_block, efa) -> None:
         """Compose an EC2 launch template for a node group.
 
         EKS launches the node group's instances from this template. It carries
@@ -966,7 +966,7 @@ class Composer:
         """Object (metadata.name) of the shared EFA security group."""
         return resource.child_name(self.xr.metadata.name, "efa-sg")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
-    def _compose_efa_security_group(self):
+    def _compose_efa_security_group(self) -> None:
         """Compose the EFA security group and its self-referencing rules.
 
         EFA's OS-bypass transport requires every EFA interface to sit in a
@@ -1031,7 +1031,7 @@ class Composer:
             ),
         )
 
-    def _compose_system_node_group(self):
+    def _compose_system_node_group(self) -> None:
         """Compose the system node group for control-plane components."""
         resource.update(
             self.rsp.desired.resources[f"nodegroup-{_SYSTEM_POOL_NAME}"],
@@ -1083,7 +1083,7 @@ class Composer:
             for z in pool.zones
         ]
 
-    def compose_addons(self):
+    def compose_addons(self) -> None:
         for name in _ADDONS:
             resource.update(
                 self.rsp.desired.resources[f"addon-{name}"],
@@ -1100,7 +1100,7 @@ class Composer:
                 ),
             )
 
-    def compose_efs(self):
+    def compose_efs(self) -> None:
         """Provision EFS RWX storage for ModelCache: an Elastic-throughput
         filesystem, a mount target per node subnet, an NFS security group, and
         the EFS CSI driver. The driver's IAM role is bound through Pod Identity
@@ -1253,7 +1253,7 @@ class Composer:
             ),
         )
 
-    def compose_storage_class(self):
+    def compose_storage_class(self) -> None:
         """Compose the EFS RWX StorageClass on the workload cluster. Gated on
         the filesystem id: the StorageClass pins to it, and the id is known
         only once the FileSystem is observed. The Object is applied through the
@@ -1288,7 +1288,7 @@ class Composer:
         )
         self.rsp.desired.resources["storage-class-rwx-efs"].ready = fnv1.READY_TRUE
 
-    def compose_cluster_autoscaler(self):
+    def compose_cluster_autoscaler(self) -> None:
         """Provision the Kubernetes cluster autoscaler so GPU pools scale within
         their min/max, the way GKE's built-in autoscaler does. DRA rules out
         Karpenter and EKS Auto Mode, so we install the autoscaler ourselves: a
@@ -1399,7 +1399,7 @@ class Composer:
             ),
         )
 
-    def compose_efa_dra_driver(self):
+    def compose_efa_dra_driver(self) -> None:
         """Compose the EFA DRA driver (DRANET), only when a pool uses the EFA
         fabric. Installed as a Helm release on the cluster's own helm
         ProviderConfig, like the autoscaler, and gated the same way: until the
@@ -1449,7 +1449,7 @@ class Composer:
             ),
         )
 
-    def compose_provider_configs(self):
+    def compose_provider_configs(self) -> None:
         kubeconfig_secret = _kubeconfig_secret_name(self.xr)
         resource.update(
             self.rsp.desired.resources["provider-config-kubernetes"],
@@ -1485,7 +1485,7 @@ class Composer:
             ),
         )
 
-    def write_status(self):
+    def write_status(self) -> None:
         status = v1alpha1.Status(
             secrets=[
                 v1alpha1.Secret(
@@ -1513,7 +1513,7 @@ class Composer:
             return None
         return fs.metadata.annotations.get(_ANNOTATION_EXTERNAL_NAME)
 
-    def mark_readiness(self):
+    def mark_readiness(self) -> None:
         """Mark composed resources ready based on their observed conditions."""
         managed_resources = [
             "vpc",

--- a/functions/compose-eks-cluster/function/fn.py
+++ b/functions/compose-eks-cluster/function/fn.py
@@ -831,7 +831,7 @@ class Composer:
         must be stable and match the launchTemplate.forProvider.name set
         on the composed EC2 LaunchTemplate.
         """
-        return resource.child_name(self.xr.metadata.name, f"lt-{pool.name}")
+        return resource.child_name(self.xr.metadata.name, f"lt-{pool.name}")  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
 
     def _compose_launch_template(self, pool, capacity_block, efa):
         """Compose an EC2 launch template for a node group.
@@ -959,7 +959,7 @@ class Composer:
 
     def _efa_security_group_resource_name(self):
         """Object (metadata.name) of the shared EFA security group."""
-        return resource.child_name(self.xr.metadata.name, "efa-sg")
+        return resource.child_name(self.xr.metadata.name, "efa-sg")  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
 
     def _compose_efa_security_group(self):
         """Compose the EFA security group and its self-referencing rules.
@@ -980,7 +980,7 @@ class Composer:
                 spec=sgv1beta1.Spec(
                     forProvider=sgv1beta1.ForProvider(
                         region=region,
-                        name=f"{self.xr.metadata.name}-efa",
+                        name=f"{self.xr.metadata.name}-efa",  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                         description="EFA OS-bypass traffic between gang nodes",
                         vpcIdSelector=sgv1beta1.VpcIdSelector(matchControllerRef=True),
                     ),
@@ -1130,7 +1130,7 @@ class Composer:
                 spec=sgv1beta1.Spec(
                     forProvider=sgv1beta1.ForProvider(
                         region=region,
-                        name=f"{self.xr.metadata.name}-efs",
+                        name=f"{self.xr.metadata.name}-efs",  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                         description="NFS access to the ModelCache EFS mount targets",
                         vpcIdSelector=sgv1beta1.VpcIdSelector(matchControllerRef=True),
                     ),
@@ -1269,7 +1269,7 @@ class Composer:
         resource.update(
             self.rsp.desired.resources["storage-class-rwx-efs"],
             k8sobjv1alpha1.Object(
-                metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),
+                metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                 spec=k8sobjv1alpha1.Spec(
                     managementPolicies=_ORPHAN_MANAGEMENT,
                     providerConfigRef=k8sobjv1alpha1.ProviderConfigRef(
@@ -1366,7 +1366,7 @@ class Composer:
         resource.update(
             self.rsp.desired.resources["release-cluster-autoscaler"],
             helmv1beta1.Release(
-                metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),
+                metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                 spec=helmv1beta1.Spec(
                     managementPolicies=_ORPHAN_MANAGEMENT,
                     providerConfigRef=helmv1beta1.ProviderConfigRef(
@@ -1412,7 +1412,7 @@ class Composer:
         resource.update(
             self.rsp.desired.resources["release-efa-dra-driver"],
             helmv1beta1.Release(
-                metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),
+                metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                 spec=helmv1beta1.Spec(
                     managementPolicies=_ORPHAN_MANAGEMENT,
                     providerConfigRef=helmv1beta1.ProviderConfigRef(
@@ -1455,7 +1455,7 @@ class Composer:
                         source="Secret",
                         secretRef=k8spcv1alpha1.SecretRef(
                             name=kubeconfig_secret,
-                            namespace=self.xr.metadata.namespace,
+                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                             key=_SECRET_KEY_KUBECONFIG,
                         ),
                     ),
@@ -1472,7 +1472,7 @@ class Composer:
                         source="Secret",
                         secretRef=helmpcv1beta1.SecretRef(
                             name=kubeconfig_secret,
-                            namespace=self.xr.metadata.namespace,
+                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                             key=_SECRET_KEY_KUBECONFIG,
                         ),
                     ),

--- a/functions/compose-eks-cluster/function/fn.py
+++ b/functions/compose-eks-cluster/function/fn.py
@@ -69,12 +69,8 @@ from models.io.upbound.m.aws.iam.rolepolicyattachment import v1beta1 as rpav1bet
 # this Crossplane would keep reverting desiredSize to nodeCount and fight it.
 # (initProvider is a beta feature gated on enumerating management policies — the
 # default "*" still reconciles forProvider, defeating the purpose.)
-_NODE_GROUP_MANAGEMENT: list[Literal["Observe", "Create", "Update", "Delete", "LateInitialize", "*"]] = [
-    "Observe",
-    "Create",
-    "Update",
-    "Delete",
-]
+_ManagementPolicy = Literal["Observe", "Create", "Update", "Delete", "LateInitialize", "*"]
+_NODE_GROUP_MANAGEMENT: list[_ManagementPolicy] = ["Observe", "Create", "Update", "Delete"]
 
 # Management policies that exclude Delete, used for resources installed on the
 # workload cluster (the RWX StorageClass Object, the autoscaler and EFA DRA
@@ -88,7 +84,7 @@ _NODE_GROUP_MANAGEMENT: list[Literal["Observe", "Create", "Update", "Delete", "L
 # so if one of these MRs is ever deleted out of band the recomposed MR takes the
 # same name and provider-helm / provider-kubernetes adopt the existing release
 # or object rather than erroring.
-_ORPHAN_MANAGEMENT = ["Observe", "Create", "Update"]
+_ORPHAN_MANAGEMENT: list[_ManagementPolicy] = ["Observe", "Create", "Update"]
 
 # System node group injected into every EKS cluster to host control-plane
 # components (Envoy Gateway, KEDA, KServe controller, etc.). Not part of

--- a/functions/compose-eks-cluster/function/fn.py
+++ b/functions/compose-eks-cluster/function/fn.py
@@ -833,7 +833,7 @@ class Composer:
         must be stable and match the launchTemplate.forProvider.name set
         on the composed EC2 LaunchTemplate.
         """
-        return resource.child_name(self.xr.metadata.name, f"lt-{pool.name}")  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+        return resource.child_name(self.xr.metadata.name, f"lt-{pool.name}")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
     def _compose_launch_template(self, pool, capacity_block, efa):
         """Compose an EC2 launch template for a node group.
@@ -961,7 +961,7 @@ class Composer:
 
     def _efa_security_group_resource_name(self):
         """Object (metadata.name) of the shared EFA security group."""
-        return resource.child_name(self.xr.metadata.name, "efa-sg")  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+        return resource.child_name(self.xr.metadata.name, "efa-sg")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
     def _compose_efa_security_group(self):
         """Compose the EFA security group and its self-referencing rules.
@@ -1457,7 +1457,7 @@ class Composer:
                         source="Secret",
                         secretRef=k8spcv1alpha1.SecretRef(
                             name=kubeconfig_secret,
-                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
                             key=_SECRET_KEY_KUBECONFIG,
                         ),
                     ),
@@ -1474,7 +1474,7 @@ class Composer:
                         source="Secret",
                         secretRef=helmpcv1beta1.SecretRef(
                             name=kubeconfig_secret,
-                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
                             key=_SECRET_KEY_KUBECONFIG,
                         ),
                     ),

--- a/functions/compose-eks-cluster/function/fn.py
+++ b/functions/compose-eks-cluster/function/fn.py
@@ -28,6 +28,8 @@ authorised on the cluster. Downstream consumers only need the kubeconfig;
 no per-cluster AWS identity has to be wired into provider-kubernetes.
 """
 
+from typing import Literal
+
 import grpc
 from crossplane.function import logging, resource, response
 from crossplane.function.proto.v1 import run_function_pb2 as fnv1
@@ -67,7 +69,12 @@ from models.io.upbound.m.aws.iam.rolepolicyattachment import v1beta1 as rpav1bet
 # this Crossplane would keep reverting desiredSize to nodeCount and fight it.
 # (initProvider is a beta feature gated on enumerating management policies — the
 # default "*" still reconciles forProvider, defeating the purpose.)
-_NODE_GROUP_MANAGEMENT = ["Observe", "Create", "Update", "Delete"]
+_NODE_GROUP_MANAGEMENT: list[Literal["Observe", "Create", "Update", "Delete", "LateInitialize", "*"]] = [
+    "Observe",
+    "Create",
+    "Update",
+    "Delete",
+]
 
 # Management policies that exclude Delete, used for resources installed on the
 # workload cluster (the RWX StorageClass Object, the autoscaler and EFA DRA

--- a/functions/compose-eks-cluster/function/fn.py
+++ b/functions/compose-eks-cluster/function/fn.py
@@ -355,14 +355,16 @@ def _az(region, index):
     return f"{region}{chr(ord('a') + index)}"
 
 
-class FunctionRunner(grpcv1.FunctionRunnerService):
+class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
     def __init__(self):
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
-    async def RunFunction(self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext) -> fnv1.RunFunctionResponse:
+    async def RunFunction(
+        self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext | None
+    ) -> fnv1.RunFunctionResponse:  # ty: ignore[invalid-method-override]  # the generated grpc servicer base is untyped
         """Run the function."""
         log = self.log.bind(tag=req.meta.tag)
         log.info("Running function")

--- a/functions/compose-eks-cluster/tests/test_fn.py
+++ b/functions/compose-eks-cluster/tests/test_fn.py
@@ -16,6 +16,7 @@
 
 import dataclasses
 import unittest
+from typing import Any
 
 from crossplane.function import logging, resource
 from crossplane.function.proto.v1 import run_function_pb2 as fnv1
@@ -208,7 +209,7 @@ def _xr_efa() -> v1alpha1.EKSCluster:
 
 
 def _efa_network_interface(card: int, security_groups: list[str] | None = None) -> dict:
-    ni = {
+    ni: dict[str, Any] = {
         "networkCardIndex": card,
         "deviceIndex": 0 if card == 0 else 1,
         "interfaceType": "efa" if card == 0 else "efa-only",

--- a/functions/compose-eks-cluster/tests/test_fn.py
+++ b/functions/compose-eks-cluster/tests/test_fn.py
@@ -68,7 +68,7 @@ def _xr() -> v1alpha1.EKSCluster:
                     gpu=v1alpha1.Gpu(
                         acceleratorType="nvidia-l4",
                     ),
-                    zones=["us-west-2a", "us-west-2b"],
+                    zones=[v1alpha1.Zone("us-west-2a"), v1alpha1.Zone("us-west-2b")],
                 ),
             ],
         ),
@@ -104,7 +104,7 @@ def _xr_capacity_block() -> v1alpha1.EKSCluster:
                     capacityBlock=v1alpha1.CapacityBlock(
                         capacityReservationId=_CAPACITY_RESERVATION_ID,
                     ),
-                    zones=["us-west-2a"],
+                    zones=[v1alpha1.Zone("us-west-2a")],
                 ),
             ],
         ),
@@ -200,7 +200,7 @@ def _xr_efa() -> v1alpha1.EKSCluster:
                         acceleratorType="nvidia-h200",
                     ),
                     fabric="EFA",
-                    zones=["us-west-2a"],
+                    zones=[v1alpha1.Zone("us-west-2a")],
                 ),
             ],
         ),

--- a/functions/compose-gke-cluster/function/fn.py
+++ b/functions/compose-gke-cluster/function/fn.py
@@ -115,7 +115,7 @@ def _sa_key_secret_name(xr):
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
@@ -133,12 +133,12 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp):
+    def __init__(self, req, rsp) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.GKECluster(**resource.struct_to_dict(req.observed.composite.resource))
 
-    def compose(self):
+    def compose(self) -> None:
         self.compose_network()
         self.compose_filestore_api()
         self.compose_subnet()
@@ -151,7 +151,7 @@ class Composer:
         self.write_status()
         self.mark_readiness()
 
-    def compose_network(self):
+    def compose_network(self) -> None:
         resource.update(
             self.rsp.desired.resources["network"],
             networkv1beta1.Network(
@@ -164,7 +164,7 @@ class Composer:
             ),
         )
 
-    def compose_filestore_api(self):
+    def compose_filestore_api(self) -> None:
         """Enable file.googleapis.com so the Filestore CSI addon can provision
         RWX volumes (fresh projects have it disabled → PVCs Pending with
         SERVICE_DISABLED)."""
@@ -181,7 +181,7 @@ class Composer:
             ),
         )
 
-    def compose_subnet(self):
+    def compose_subnet(self) -> None:
         networking = self.xr.spec.networking or v1alpha1.Networking()
 
         resource.update(
@@ -210,7 +210,7 @@ class Composer:
             ),
         )
 
-    def compose_cluster(self):
+    def compose_cluster(self) -> None:
         resource.update(
             self.rsp.desired.resources["cluster"],
             clusterv1beta1.Cluster(
@@ -256,7 +256,7 @@ class Composer:
             ),
         )
 
-    def compose_node_pools(self):
+    def compose_node_pools(self) -> None:
         self._compose_system_pool()
         for pool in self.xr.spec.nodePools:
             node_config = nodepoolv1beta1.NodeConfig(
@@ -311,7 +311,7 @@ class Composer:
                 np,
             )
 
-    def _compose_system_pool(self):
+    def _compose_system_pool(self) -> None:
         """Compose the system node pool for control-plane components."""
         resource.update(
             self.rsp.desired.resources[f"nodepool-{_SYSTEM_POOL_NAME}"],
@@ -341,7 +341,7 @@ class Composer:
             ),
         )
 
-    def compose_service_account(self):
+    def compose_service_account(self) -> None:
         resource.update(
             self.rsp.desired.resources["service-account"],
             sav1beta1.ServiceAccount(
@@ -370,7 +370,7 @@ class Composer:
             ),
         )
 
-    def compose_iam_binding(self):
+    def compose_iam_binding(self) -> None:
         """Compose the IAM binding for the service account. Gated on the SA
         email being available in observed state."""
         sa_email = self.observed_sa_email()
@@ -390,7 +390,7 @@ class Composer:
             ),
         )
 
-    def compose_provider_configs(self):
+    def compose_provider_configs(self) -> None:
         resource.update(
             self.rsp.desired.resources["provider-config-kubernetes"],
             k8spcv1alpha1.ProviderConfig(
@@ -443,7 +443,7 @@ class Composer:
             ),
         )
 
-    def compose_storage_class(self):
+    def compose_storage_class(self) -> None:
         """Compose the Filestore RWX StorageClass on the workload cluster.
         Gated on the network name: Filestore CSI defaults to the `default` VPC
         → PVCs hang, so pin parameters.network to our VPC; the VPC name carries
@@ -480,7 +480,7 @@ class Composer:
         )
         self.rsp.desired.resources["storage-class-rwx"].ready = fnv1.READY_TRUE
 
-    def write_status(self):
+    def write_status(self) -> None:
         status = v1alpha1.Status(
             secrets=[
                 v1alpha1.Secret(
@@ -513,7 +513,7 @@ class Composer:
             return None
         return network.metadata.annotations.get(_ANNOTATION_EXTERNAL_NAME) or None
 
-    def mark_readiness(self):
+    def mark_readiness(self) -> None:
         """Mark composed resources as ready based on their observed conditions."""
         managed_resources = [
             "network",

--- a/functions/compose-gke-cluster/function/fn.py
+++ b/functions/compose-gke-cluster/function/fn.py
@@ -102,14 +102,28 @@ _GKE_IMAGE_TYPE = "COS_CONTAINERD"
 _GKE_OAUTH_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 
 
+def _name(meta: metav1.ObjectMeta | None) -> str:
+    """The object's name, always set on resources read from the API server."""
+    if meta is None or meta.name is None:
+        raise ValueError("metadata.name is unexpectedly absent")
+    return meta.name
+
+
+def _namespace(meta: metav1.ObjectMeta | None) -> str:
+    """The object's namespace, always set on namespaced resources read from the API server."""
+    if meta is None or meta.namespace is None:
+        raise ValueError("metadata.namespace is unexpectedly absent")
+    return meta.namespace
+
+
 def _kubeconfig_secret_name(xr: v1alpha1.GKECluster) -> str:
     """Derive the kubeconfig secret name from the XR."""
-    return resource.child_name(xr.metadata.name, "kubeconfig")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+    return resource.child_name(_name(xr.metadata), "kubeconfig")
 
 
 def _sa_key_secret_name(xr: v1alpha1.GKECluster) -> str:
     """Derive the SA key secret name from the XR."""
-    return resource.child_name(xr.metadata.name, "sa-key")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+    return resource.child_name(_name(xr.metadata), "sa-key")
 
 
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
@@ -348,7 +362,7 @@ class Composer:
                 spec=sav1beta1.Spec(
                     forProvider=sav1beta1.ForProvider(
                         project=self.xr.spec.project,
-                        displayName=f"Crossplane GKECluster {self.xr.metadata.name}",  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                        displayName=f"Crossplane GKECluster {_name(self.xr.metadata)}",
                     ),
                 ),
             ),
@@ -400,7 +414,7 @@ class Composer:
                         source="Secret",
                         secretRef=k8spcv1alpha1.SecretRef(
                             name=_kubeconfig_secret_name(self.xr),
-                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+                            namespace=_namespace(self.xr.metadata),
                             key=_SECRET_KEY_KUBECONFIG,
                         ),
                     ),
@@ -409,7 +423,7 @@ class Composer:
                         source="Secret",
                         secretRef=k8spcv1alpha1.SecretRef(
                             name=_sa_key_secret_name(self.xr),
-                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+                            namespace=_namespace(self.xr.metadata),
                             key=_SECRET_KEY_GCP_SA,
                         ),
                     ),
@@ -426,7 +440,7 @@ class Composer:
                         source="Secret",
                         secretRef=helmpcv1beta1.SecretRef(
                             name=_kubeconfig_secret_name(self.xr),
-                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+                            namespace=_namespace(self.xr.metadata),
                             key=_SECRET_KEY_KUBECONFIG,
                         ),
                     ),
@@ -435,7 +449,7 @@ class Composer:
                         source="Secret",
                         secretRef=helmpcv1beta1.SecretRef(
                             name=_sa_key_secret_name(self.xr),
-                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+                            namespace=_namespace(self.xr.metadata),
                             key=_SECRET_KEY_GCP_SA,
                         ),
                     ),
@@ -466,7 +480,7 @@ class Composer:
         resource.update(
             self.rsp.desired.resources["storage-class-rwx"],
             k8sobjv1alpha1.Object(
-                metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                metadata=metav1.ObjectMeta(namespace=_namespace(self.xr.metadata)),
                 spec=k8sobjv1alpha1.Spec(
                     managementPolicies=_ORPHAN_MANAGEMENT,
                     providerConfigRef=k8sobjv1alpha1.ProviderConfigRef(

--- a/functions/compose-gke-cluster/function/fn.py
+++ b/functions/compose-gke-cluster/function/fn.py
@@ -399,7 +399,7 @@ class Composer:
                         source="Secret",
                         secretRef=k8spcv1alpha1.SecretRef(
                             name=_kubeconfig_secret_name(self.xr),
-                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
                             key=_SECRET_KEY_KUBECONFIG,
                         ),
                     ),
@@ -408,7 +408,7 @@ class Composer:
                         source="Secret",
                         secretRef=k8spcv1alpha1.SecretRef(
                             name=_sa_key_secret_name(self.xr),
-                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
                             key=_SECRET_KEY_GCP_SA,
                         ),
                     ),
@@ -425,7 +425,7 @@ class Composer:
                         source="Secret",
                         secretRef=helmpcv1beta1.SecretRef(
                             name=_kubeconfig_secret_name(self.xr),
-                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
                             key=_SECRET_KEY_KUBECONFIG,
                         ),
                     ),
@@ -434,7 +434,7 @@ class Composer:
                         source="Secret",
                         secretRef=helmpcv1beta1.SecretRef(
                             name=_sa_key_secret_name(self.xr),
-                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
                             key=_SECRET_KEY_GCP_SA,
                         ),
                     ),

--- a/functions/compose-gke-cluster/function/fn.py
+++ b/functions/compose-gke-cluster/function/fn.py
@@ -246,7 +246,7 @@ class Composer:
                     ),
                     writeConnectionSecretToRef=clusterv1beta1.WriteConnectionSecretToRef(
                         name=_kubeconfig_secret_name(self.xr),
-                        namespace=self.xr.metadata.namespace,
+                        namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     ),
                 ),
             ),
@@ -344,7 +344,7 @@ class Composer:
                 spec=sav1beta1.Spec(
                     forProvider=sav1beta1.ForProvider(
                         project=self.xr.spec.project,
-                        displayName=f"Crossplane GKECluster {self.xr.metadata.name}",
+                        displayName=f"Crossplane GKECluster {self.xr.metadata.name}",  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     ),
                 ),
             ),
@@ -361,7 +361,7 @@ class Composer:
                     ),
                     writeConnectionSecretToRef=sakeyv1beta1.WriteConnectionSecretToRef(
                         name=_sa_key_secret_name(self.xr),
-                        namespace=self.xr.metadata.namespace,
+                        namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     ),
                 ),
             ),
@@ -397,7 +397,7 @@ class Composer:
                         source="Secret",
                         secretRef=k8spcv1alpha1.SecretRef(
                             name=_kubeconfig_secret_name(self.xr),
-                            namespace=self.xr.metadata.namespace,
+                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                             key=_SECRET_KEY_KUBECONFIG,
                         ),
                     ),
@@ -406,7 +406,7 @@ class Composer:
                         source="Secret",
                         secretRef=k8spcv1alpha1.SecretRef(
                             name=_sa_key_secret_name(self.xr),
-                            namespace=self.xr.metadata.namespace,
+                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                             key=_SECRET_KEY_GCP_SA,
                         ),
                     ),
@@ -423,7 +423,7 @@ class Composer:
                         source="Secret",
                         secretRef=helmpcv1beta1.SecretRef(
                             name=_kubeconfig_secret_name(self.xr),
-                            namespace=self.xr.metadata.namespace,
+                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                             key=_SECRET_KEY_KUBECONFIG,
                         ),
                     ),
@@ -432,7 +432,7 @@ class Composer:
                         source="Secret",
                         secretRef=helmpcv1beta1.SecretRef(
                             name=_sa_key_secret_name(self.xr),
-                            namespace=self.xr.metadata.namespace,
+                            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                             key=_SECRET_KEY_GCP_SA,
                         ),
                     ),
@@ -463,7 +463,7 @@ class Composer:
         resource.update(
             self.rsp.desired.resources["storage-class-rwx"],
             k8sobjv1alpha1.Object(
-                metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),
+                metadata=metav1.ObjectMeta(namespace=self.xr.metadata.namespace),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                 spec=k8sobjv1alpha1.Spec(
                     managementPolicies=_ORPHAN_MANAGEMENT,
                     providerConfigRef=k8sobjv1alpha1.ProviderConfigRef(

--- a/functions/compose-gke-cluster/function/fn.py
+++ b/functions/compose-gke-cluster/function/fn.py
@@ -102,14 +102,14 @@ _GKE_IMAGE_TYPE = "COS_CONTAINERD"
 _GKE_OAUTH_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 
 
-def _kubeconfig_secret_name(xr):
+def _kubeconfig_secret_name(xr: v1alpha1.GKECluster) -> str:
     """Derive the kubeconfig secret name from the XR."""
-    return resource.child_name(xr.metadata.name, "kubeconfig")
+    return resource.child_name(xr.metadata.name, "kubeconfig")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
 
-def _sa_key_secret_name(xr):
+def _sa_key_secret_name(xr: v1alpha1.GKECluster) -> str:
     """Derive the SA key secret name from the XR."""
-    return resource.child_name(xr.metadata.name, "sa-key")
+    return resource.child_name(xr.metadata.name, "sa-key")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
 
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
@@ -133,7 +133,7 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp) -> None:
+    def __init__(self, req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.GKECluster(**resource.struct_to_dict(req.observed.composite.resource))
@@ -501,7 +501,7 @@ class Composer:
         )
         resource.update_status(self.rsp.desired.composite, status)
 
-    def _observed_network_name(self):
+    def _observed_network_name(self) -> str | None:
         """The composed VPC network's GCP name, from the observed Network MR's
         external-name annotation (set by the provider once the network exists).
         None on early reconciles before the network is created."""
@@ -535,7 +535,7 @@ class Composer:
         self.rsp.desired.resources["provider-config-kubernetes"].ready = fnv1.READY_TRUE
         self.rsp.desired.resources["provider-config-helm"].ready = fnv1.READY_TRUE
 
-    def observed_sa_email(self):
+    def observed_sa_email(self) -> str | None:
         """Read the service account email from observed state."""
         observed_sa = self.req.observed.resources.get("service-account")
         if not observed_sa:

--- a/functions/compose-gke-cluster/function/fn.py
+++ b/functions/compose-gke-cluster/function/fn.py
@@ -20,6 +20,8 @@ account with container.admin IAM, and ProviderConfigs for provider-kubernetes
 and provider-helm to reach the cluster.
 """
 
+from typing import Literal
+
 import grpc
 from crossplane.function import logging, resource, response
 from crossplane.function.proto.v1 import run_function_pb2 as fnv1
@@ -92,7 +94,8 @@ _MANAGED_STORAGE_CLASS = "modelplane-rwx"
 # deterministically from the owner XR's UID and the composition resource name, so
 # if this MR is ever deleted out of band the recomposed MR takes the same name
 # and provider-kubernetes adopts the existing StorageClass rather than erroring.
-_ORPHAN_MANAGEMENT = ["Observe", "Create", "Update"]
+_ManagementPolicy = Literal["Observe", "Create", "Update", "Delete", "LateInitialize", "*"]
+_ORPHAN_MANAGEMENT: list[_ManagementPolicy] = ["Observe", "Create", "Update"]
 
 # GKE node configuration.
 _GKE_IMAGE_TYPE = "COS_CONTAINERD"

--- a/functions/compose-gke-cluster/function/fn.py
+++ b/functions/compose-gke-cluster/function/fn.py
@@ -248,7 +248,6 @@ class Composer:
                     ),
                     writeConnectionSecretToRef=clusterv1beta1.WriteConnectionSecretToRef(
                         name=_kubeconfig_secret_name(self.xr),
-                        namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     ),
                 ),
             ),
@@ -302,7 +301,7 @@ class Composer:
             )
 
             if pool.zones:
-                np.spec.forProvider.nodeLocations = pool.zones
+                np.spec.forProvider.nodeLocations = [zone.root for zone in pool.zones]
 
             resource.update(
                 self.rsp.desired.resources[f"nodepool-{pool.name}"],
@@ -363,7 +362,6 @@ class Composer:
                     ),
                     writeConnectionSecretToRef=sakeyv1beta1.WriteConnectionSecretToRef(
                         name=_sa_key_secret_name(self.xr),
-                        namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     ),
                 ),
             ),

--- a/functions/compose-gke-cluster/function/fn.py
+++ b/functions/compose-gke-cluster/function/fn.py
@@ -109,14 +109,16 @@ def _sa_key_secret_name(xr):
     return resource.child_name(xr.metadata.name, "sa-key")
 
 
-class FunctionRunner(grpcv1.FunctionRunnerService):
+class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
     def __init__(self):
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
-    async def RunFunction(self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext) -> fnv1.RunFunctionResponse:
+    async def RunFunction(
+        self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext | None
+    ) -> fnv1.RunFunctionResponse:  # ty: ignore[invalid-method-override]  # the generated grpc servicer base is untyped
         """Run the function."""
         log = self.log.bind(tag=req.meta.tag)
         log.info("Running function")

--- a/functions/compose-inference-class/function/fn.py
+++ b/functions/compose-inference-class/function/fn.py
@@ -29,7 +29,7 @@ from models.ai.modelplane.inferenceclass import v1alpha1
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 

--- a/functions/compose-inference-class/function/fn.py
+++ b/functions/compose-inference-class/function/fn.py
@@ -42,8 +42,6 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
         rsp = response.to(req)
 
-        _ = v1alpha1.InferenceClass(**resource.struct_to_dict(req.observed.composite.resource))
-
         resource.update_status(rsp.desired.composite, v1alpha1.Status())
         response.set_conditions(rsp, resource.Condition(typ="Accepted", status="True", reason="Available"))
         rsp.desired.composite.ready = fnv1.READY_TRUE

--- a/functions/compose-inference-class/function/fn.py
+++ b/functions/compose-inference-class/function/fn.py
@@ -26,14 +26,16 @@ from crossplane.function.proto.v1 import run_function_pb2_grpc as grpcv1
 from models.ai.modelplane.inferenceclass import v1alpha1
 
 
-class FunctionRunner(grpcv1.FunctionRunnerService):
+class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
     def __init__(self):
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
-    async def RunFunction(self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext) -> fnv1.RunFunctionResponse:
+    async def RunFunction(
+        self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext | None
+    ) -> fnv1.RunFunctionResponse:  # ty: ignore[invalid-method-override]  # the generated grpc servicer base is untyped
         """Run the function."""
         log = self.log.bind(tag=req.meta.tag)
         log.info("Running function")

--- a/functions/compose-inference-cluster/function/fn.py
+++ b/functions/compose-inference-cluster/function/fn.py
@@ -188,7 +188,7 @@ class Composer:
                     of=clusterusagev1beta1.Of(
                         apiVersion="modelplane.ai/v1alpha1",
                         kind="InferenceCluster",
-                        resourceRef=clusterusagev1beta1.ResourceRef(name=self.xr.metadata.name),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                        resourceRef=clusterusagev1beta1.ResourceRef(name=self.xr.metadata.name),  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
                     ),
                     reason="ModelReplicas are scheduled to this InferenceCluster",
                     replayDeletion=True,
@@ -348,7 +348,7 @@ class Composer:
             self.rsp.desired.resources[BACKEND_RESOURCE_KEY],
             ssv1alpha1.ServingStack(
                 metadata=metav1.ObjectMeta(
-                    name=resource.child_name(self.xr.metadata.name, "serving-stack"),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                    name=resource.child_name(self.xr.metadata.name, "serving-stack"),  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
                     namespace=_NAMESPACE_SYSTEM,
                 ),
                 spec=spec,
@@ -359,7 +359,7 @@ class Composer:
         """Compose a ClusterProviderConfig for provider-kubernetes so that
         ModelReplicas can create Objects on the remote cluster."""
         cpc = k8scpcv1alpha1.ClusterProviderConfig(
-            metadata=metav1.ObjectMeta(name=resource.child_name(self.xr.metadata.name, "cluster-kubeconfig")),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+            metadata=metav1.ObjectMeta(name=resource.child_name(self.xr.metadata.name, "cluster-kubeconfig")),  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
             spec=k8scpcv1alpha1.Spec(
                 credentials=k8scpcv1alpha1.Credentials(
                     source="Secret",
@@ -391,7 +391,7 @@ class Composer:
         """Write the InferenceCluster status."""
         status = v1alpha1.Status(
             providerConfigRef=v1alpha1.ProviderConfigRef(
-                name=resource.child_name(self.xr.metadata.name, "cluster-kubeconfig"),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                name=resource.child_name(self.xr.metadata.name, "cluster-kubeconfig"),  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
             ),
             namespace=_NAMESPACE_SYSTEM,
             gpuPools=gpu_pools,

--- a/functions/compose-inference-cluster/function/fn.py
+++ b/functions/compose-inference-cluster/function/fn.py
@@ -91,6 +91,13 @@ _NAMESPACE_SYSTEM = "modelplane-system"
 _IDENTITY_TYPE_GCP = "GoogleApplicationCredentials"
 
 
+def _name(meta: metav1.ObjectMeta | None) -> str:
+    """The object's name, always set on resources read from the API server."""
+    if meta is None or meta.name is None:
+        raise ValueError("metadata.name is unexpectedly absent")
+    return meta.name
+
+
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
@@ -174,7 +181,7 @@ class Composer:
             name="model-replicas",
             api_version="modelplane.ai/v1alpha1",
             kind="ModelReplica",
-            match_labels={_LABEL_CLUSTER: self.xr.metadata.name},  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+            match_labels={_LABEL_CLUSTER: _name(self.xr.metadata)},
         )
 
         replicas = request.get_required_resources(self.req, "model-replicas")
@@ -188,7 +195,7 @@ class Composer:
                     of=clusterusagev1beta1.Of(
                         apiVersion="modelplane.ai/v1alpha1",
                         kind="InferenceCluster",
-                        resourceRef=clusterusagev1beta1.ResourceRef(name=self.xr.metadata.name),  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+                        resourceRef=clusterusagev1beta1.ResourceRef(name=_name(self.xr.metadata)),
                     ),
                     reason="ModelReplicas are scheduled to this InferenceCluster",
                     replayDeletion=True,
@@ -348,7 +355,7 @@ class Composer:
             self.rsp.desired.resources[BACKEND_RESOURCE_KEY],
             ssv1alpha1.ServingStack(
                 metadata=metav1.ObjectMeta(
-                    name=resource.child_name(self.xr.metadata.name, "serving-stack"),  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+                    name=resource.child_name(_name(self.xr.metadata), "serving-stack"),
                     namespace=_NAMESPACE_SYSTEM,
                 ),
                 spec=spec,
@@ -364,7 +371,7 @@ class Composer:
         """Compose a ClusterProviderConfig for provider-kubernetes so that
         ModelReplicas can create Objects on the remote cluster."""
         cpc = k8scpcv1alpha1.ClusterProviderConfig(
-            metadata=metav1.ObjectMeta(name=resource.child_name(self.xr.metadata.name, "cluster-kubeconfig")),  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+            metadata=metav1.ObjectMeta(name=resource.child_name(_name(self.xr.metadata), "cluster-kubeconfig")),
             spec=k8scpcv1alpha1.Spec(
                 credentials=k8scpcv1alpha1.Credentials(
                     source="Secret",
@@ -396,7 +403,7 @@ class Composer:
         """Write the InferenceCluster status."""
         status = v1alpha1.Status(
             providerConfigRef=v1alpha1.ProviderConfigRef(
-                name=resource.child_name(self.xr.metadata.name, "cluster-kubeconfig"),  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+                name=resource.child_name(_name(self.xr.metadata), "cluster-kubeconfig"),
             ),
             namespace=_NAMESPACE_SYSTEM,
             gpuPools=gpu_pools,  # ty: ignore[invalid-argument-type]  # gpu_pools builds the by-alias wire form; pydantic coerces it to GpuPool
@@ -488,7 +495,7 @@ class Composer:
             self.rsp.desired.resources["gke-cluster"],
             gkev1alpha1.GKECluster(
                 metadata=metav1.ObjectMeta(
-                    name=self.xr.metadata.name,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                    name=_name(self.xr.metadata),
                     namespace=_NAMESPACE_SYSTEM,
                 ),
                 spec=gkev1alpha1.Spec(
@@ -555,7 +562,7 @@ class Composer:
             self.rsp.desired.resources["eks-cluster"],
             eksv1alpha1.EKSCluster(
                 metadata=metav1.ObjectMeta(
-                    name=self.xr.metadata.name,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                    name=_name(self.xr.metadata),
                     namespace=_NAMESPACE_SYSTEM,
                 ),
                 spec=eksv1alpha1.Spec(

--- a/functions/compose-inference-cluster/function/fn.py
+++ b/functions/compose-inference-cluster/function/fn.py
@@ -172,7 +172,7 @@ class Composer:
             name="model-replicas",
             api_version="modelplane.ai/v1alpha1",
             kind="ModelReplica",
-            match_labels={_LABEL_CLUSTER: self.xr.metadata.name},
+            match_labels={_LABEL_CLUSTER: self.xr.metadata.name},  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
         )
 
         replicas = request.get_required_resources(self.req, "model-replicas")
@@ -186,7 +186,7 @@ class Composer:
                     of=clusterusagev1beta1.Of(
                         apiVersion="modelplane.ai/v1alpha1",
                         kind="InferenceCluster",
-                        resourceRef=clusterusagev1beta1.ResourceRef(name=self.xr.metadata.name),
+                        resourceRef=clusterusagev1beta1.ResourceRef(name=self.xr.metadata.name),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     ),
                     reason="ModelReplicas are scheduled to this InferenceCluster",
                     replayDeletion=True,
@@ -346,7 +346,7 @@ class Composer:
             self.rsp.desired.resources[BACKEND_RESOURCE_KEY],
             ssv1alpha1.ServingStack(
                 metadata=metav1.ObjectMeta(
-                    name=resource.child_name(self.xr.metadata.name, "serving-stack"),
+                    name=resource.child_name(self.xr.metadata.name, "serving-stack"),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     namespace=_NAMESPACE_SYSTEM,
                 ),
                 spec=spec,
@@ -357,7 +357,7 @@ class Composer:
         """Compose a ClusterProviderConfig for provider-kubernetes so that
         ModelReplicas can create Objects on the remote cluster."""
         cpc = k8scpcv1alpha1.ClusterProviderConfig(
-            metadata=metav1.ObjectMeta(name=resource.child_name(self.xr.metadata.name, "cluster-kubeconfig")),
+            metadata=metav1.ObjectMeta(name=resource.child_name(self.xr.metadata.name, "cluster-kubeconfig")),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
             spec=k8scpcv1alpha1.Spec(
                 credentials=k8scpcv1alpha1.Credentials(
                     source="Secret",
@@ -389,7 +389,7 @@ class Composer:
         """Write the InferenceCluster status."""
         status = v1alpha1.Status(
             providerConfigRef=v1alpha1.ProviderConfigRef(
-                name=resource.child_name(self.xr.metadata.name, "cluster-kubeconfig"),
+                name=resource.child_name(self.xr.metadata.name, "cluster-kubeconfig"),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
             ),
             namespace=_NAMESPACE_SYSTEM,
             gpuPools=gpu_pools,
@@ -481,7 +481,7 @@ class Composer:
             self.rsp.desired.resources["gke-cluster"],
             gkev1alpha1.GKECluster(
                 metadata=metav1.ObjectMeta(
-                    name=self.xr.metadata.name,
+                    name=self.xr.metadata.name,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     namespace=_NAMESPACE_SYSTEM,
                 ),
                 spec=gkev1alpha1.Spec(
@@ -548,7 +548,7 @@ class Composer:
             self.rsp.desired.resources["eks-cluster"],
             eksv1alpha1.EKSCluster(
                 metadata=metav1.ObjectMeta(
-                    name=self.xr.metadata.name,
+                    name=self.xr.metadata.name,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     namespace=_NAMESPACE_SYSTEM,
                 ),
                 spec=eksv1alpha1.Spec(

--- a/functions/compose-inference-cluster/function/fn.py
+++ b/functions/compose-inference-cluster/function/fn.py
@@ -174,7 +174,7 @@ class Composer:
             name="model-replicas",
             api_version="modelplane.ai/v1alpha1",
             kind="ModelReplica",
-            match_labels={_LABEL_CLUSTER: self.xr.metadata.name},  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+            match_labels={_LABEL_CLUSTER: self.xr.metadata.name},  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
         )
 
         replicas = request.get_required_resources(self.req, "model-replicas")
@@ -475,7 +475,7 @@ class Composer:
                         acceleratorType=prov.accelerator.type,
                         acceleratorCount=prov.accelerator.count,
                     ),
-                    zones=list(pool.zones or []),
+                    zones=[gkev1alpha1.Zone(z) for z in pool.zones or []],
                 )
             )
 
@@ -531,7 +531,7 @@ class Composer:
                 gpu=eksv1alpha1.Gpu(
                     acceleratorType=prov.accelerator.type,
                 ),
-                zones=list(pool.zones or []),
+                zones=[eksv1alpha1.Zone(z) for z in pool.zones or []],
             )
             # Only set capacityBlock when the pool has one. resource.update
             # serializes with exclude_unset, so leaving it unset keeps it out

--- a/functions/compose-inference-cluster/function/fn.py
+++ b/functions/compose-inference-cluster/function/fn.py
@@ -94,7 +94,7 @@ _IDENTITY_TYPE_GCP = "GoogleApplicationCredentials"
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
@@ -112,7 +112,7 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp):
+    def __init__(self, req, rsp) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.InferenceCluster(**resource.struct_to_dict(req.observed.composite.resource))
@@ -120,7 +120,7 @@ class Composer:
         # resolve_classes().
         self.classes: dict[str, iclv1alpha1.InferenceClass] = {}
 
-    def compose(self):
+    def compose(self) -> None:
         # The replica guard runs first, before any early return. It only
         # depends on which ModelReplicas reference this cluster, not on the
         # cluster's source or whether its classes resolve. Gating it behind
@@ -147,7 +147,7 @@ class Composer:
         else:
             response.warning(self.rsp, f"unsupported cluster source: {source}")
 
-    def compose_replica_guard(self):
+    def compose_replica_guard(self) -> None:
         """Block deletion of the InferenceCluster while ModelReplicas use it.
 
         Deleting an InferenceCluster out from under running ModelReplicas
@@ -236,7 +236,7 @@ class Composer:
 
         return True
 
-    def compose_gke(self, gke):
+    def compose_gke(self, gke) -> None:
         """Compose an InferenceCluster backed by a Modelplane-provisioned
         GKE cluster. Composes the GKECluster XR, waits for it to be ready,
         then wires its secrets into the backend."""
@@ -268,7 +268,7 @@ class Composer:
         self.write_status(self.gpu_pools())
         self.derive_conditions(cluster_ready=gke_ready)
 
-    def compose_eks(self, eks):
+    def compose_eks(self, eks) -> None:
         """Compose an InferenceCluster backed by a Modelplane-provisioned
         EKS cluster. Composes the EKSCluster XR, waits for it to be ready,
         then wires its kubeconfig into the backend.
@@ -306,7 +306,7 @@ class Composer:
         self.write_status(self.gpu_pools())
         self.derive_conditions(cluster_ready=eks_ready)
 
-    def compose_existing(self, existing):
+    def compose_existing(self, existing) -> None:
         """Compose an InferenceCluster backed by a user-supplied cluster.
         No gating needed — the kubeconfig secret is provided by the user."""
         if not existing:
@@ -333,7 +333,7 @@ class Composer:
         self,
         backend_secrets: list[ssv1alpha1.Secret],
         nvidia_driver_root: str | None = None,
-    ):
+    ) -> None:
         """Compose a ServingStack XR with the given secrets.
 
         nvidia_driver_root is set for provisioned GKE clusters, where the NVIDIA
@@ -355,7 +355,7 @@ class Composer:
             ),
         )
 
-    def compose_cluster_provider_config(self, kubeconfig_name, kubeconfig_key, sa_key=None):
+    def compose_cluster_provider_config(self, kubeconfig_name, kubeconfig_key, sa_key=None) -> None:
         """Compose a ClusterProviderConfig for provider-kubernetes so that
         ModelReplicas can create Objects on the remote cluster."""
         cpc = k8scpcv1alpha1.ClusterProviderConfig(
@@ -387,7 +387,7 @@ class Composer:
         )
         self.rsp.desired.resources["cluster-provider-config-kubernetes"].ready = fnv1.READY_TRUE
 
-    def write_status(self, gpu_pools):
+    def write_status(self, gpu_pools) -> None:
         """Write the InferenceCluster status."""
         status = v1alpha1.Status(
             providerConfigRef=v1alpha1.ProviderConfigRef(
@@ -404,7 +404,7 @@ class Composer:
             status.gateway = v1alpha1.Gateway(address=gateway_address)
         resource.update_status(self.rsp.desired.composite, status)
 
-    def derive_conditions(self, cluster_ready):
+    def derive_conditions(self, cluster_ready) -> None:
         """Derive ClusterReady and BackendReady conditions."""
         backend_ready = (
             resource.get_condition(self.req.observed.resources.get(BACKEND_RESOURCE_KEY), "Ready").status == "True"
@@ -437,7 +437,7 @@ class Composer:
             ),
         )
 
-    def compose_gke_cluster(self, gke):
+    def compose_gke_cluster(self, gke) -> None:
         """Compose a GKECluster XR.
 
         Combines the cluster-level config (project, region) with the
@@ -495,7 +495,7 @@ class Composer:
             ),
         )
 
-    def compose_eks_cluster(self, eks):
+    def compose_eks_cluster(self, eks) -> None:
         """Compose an EKSCluster XR.
 
         Combines the cluster-level config (region) with GPU node pools
@@ -561,7 +561,7 @@ class Composer:
             ),
         )
 
-    def compose_eks_usage(self):
+    def compose_eks_usage(self) -> None:
         """Block EKSCluster deletion until the backend is deleted."""
         resource.update(
             self.rsp.desired.resources["usage-eks-by-backend"],
@@ -620,7 +620,7 @@ class Composer:
             return None
         return next((s for s in eks_secrets if s.type == secret_type), None)
 
-    def compose_gke_usage(self):
+    def compose_gke_usage(self) -> None:
         """Block GKECluster deletion until the backend is deleted."""
         resource.update(
             self.rsp.desired.resources["usage-gke-by-backend"],

--- a/functions/compose-inference-cluster/function/fn.py
+++ b/functions/compose-inference-cluster/function/fn.py
@@ -112,7 +112,7 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp) -> None:
+    def __init__(self, req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.InferenceCluster(**resource.struct_to_dict(req.observed.composite.resource))
@@ -236,7 +236,7 @@ class Composer:
 
         return True
 
-    def compose_gke(self, gke) -> None:
+    def compose_gke(self, gke: v1alpha1.Gke | None) -> None:
         """Compose an InferenceCluster backed by a Modelplane-provisioned
         GKE cluster. Composes the GKECluster XR, waits for it to be ready,
         then wires its secrets into the backend."""
@@ -254,7 +254,7 @@ class Composer:
         if gke_ready and kubeconfig_secret:
             self.compose_cluster_provider_config(kubeconfig_secret.name, kubeconfig_secret.key, sa_key)
 
-        backend_secrets = self.resolve_gke_backend_secrets(gke_ready, backend_exists)
+        backend_secrets = self.resolve_gke_backend_secrets(gke_ready=gke_ready, backend_exists=backend_exists)
         if backend_secrets or backend_exists:
             if backend_secrets:
                 self.compose_serving_stack(backend_secrets, nvidia_driver_root=_GKE_NVIDIA_DRIVER_ROOT)
@@ -268,7 +268,7 @@ class Composer:
         self.write_status(self.gpu_pools())
         self.derive_conditions(cluster_ready=gke_ready)
 
-    def compose_eks(self, eks) -> None:
+    def compose_eks(self, eks: v1alpha1.Eks | None) -> None:
         """Compose an InferenceCluster backed by a Modelplane-provisioned
         EKS cluster. Composes the EKSCluster XR, waits for it to be ready,
         then wires its kubeconfig into the backend.
@@ -292,7 +292,7 @@ class Composer:
         if eks_ready and kubeconfig:
             self.compose_cluster_provider_config(kubeconfig.name, kubeconfig.key)
 
-        backend_secrets = self.resolve_eks_backend_secrets(eks_ready, backend_exists)
+        backend_secrets = self.resolve_eks_backend_secrets(eks_ready=eks_ready, backend_exists=backend_exists)
         if backend_secrets or backend_exists:
             if backend_secrets:
                 self.compose_serving_stack(backend_secrets)
@@ -306,7 +306,7 @@ class Composer:
         self.write_status(self.gpu_pools())
         self.derive_conditions(cluster_ready=eks_ready)
 
-    def compose_existing(self, existing) -> None:
+    def compose_existing(self, existing: v1alpha1.Existing | None) -> None:
         """Compose an InferenceCluster backed by a user-supplied cluster.
         No gating needed — the kubeconfig secret is provided by the user."""
         if not existing:
@@ -355,7 +355,12 @@ class Composer:
             ),
         )
 
-    def compose_cluster_provider_config(self, kubeconfig_name, kubeconfig_key, sa_key=None) -> None:
+    def compose_cluster_provider_config(
+        self,
+        kubeconfig_name: str,
+        kubeconfig_key: str | None,
+        sa_key: gkev1alpha1.Secret | v1alpha1.IdentitySecretRef | None = None,
+    ) -> None:
         """Compose a ClusterProviderConfig for provider-kubernetes so that
         ModelReplicas can create Objects on the remote cluster."""
         cpc = k8scpcv1alpha1.ClusterProviderConfig(
@@ -366,7 +371,7 @@ class Composer:
                     secretRef=k8scpcv1alpha1.SecretRef(
                         namespace=_NAMESPACE_SYSTEM,
                         name=kubeconfig_name,
-                        key=kubeconfig_key,
+                        key=kubeconfig_key,  # ty: ignore[invalid-argument-type]  # XRD defaults the secret key
                     ),
                 ),
             ),
@@ -378,7 +383,7 @@ class Composer:
                 secretRef=k8scpcv1alpha1.SecretRef(
                     namespace=_NAMESPACE_SYSTEM,
                     name=sa_key.name,
-                    key=sa_key.key,
+                    key=sa_key.key,  # ty: ignore[invalid-argument-type]  # XRD defaults the secret key
                 ),
             )
         resource.update(
@@ -387,14 +392,14 @@ class Composer:
         )
         self.rsp.desired.resources["cluster-provider-config-kubernetes"].ready = fnv1.READY_TRUE
 
-    def write_status(self, gpu_pools) -> None:
+    def write_status(self, gpu_pools: list[dict[str, object]]) -> None:
         """Write the InferenceCluster status."""
         status = v1alpha1.Status(
             providerConfigRef=v1alpha1.ProviderConfigRef(
                 name=resource.child_name(self.xr.metadata.name, "cluster-kubeconfig"),  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
             ),
             namespace=_NAMESPACE_SYSTEM,
-            gpuPools=gpu_pools,
+            gpuPools=gpu_pools,  # ty: ignore[invalid-argument-type]  # gpu_pools builds the by-alias wire form; pydantic coerces it to GpuPool
         )
         cache_storage_class = self.observed_cache_storage_class()
         if cache_storage_class:
@@ -404,7 +409,7 @@ class Composer:
             status.gateway = v1alpha1.Gateway(address=gateway_address)
         resource.update_status(self.rsp.desired.composite, status)
 
-    def derive_conditions(self, cluster_ready) -> None:
+    def derive_conditions(self, *, cluster_ready: bool) -> None:
         """Derive ClusterReady and BackendReady conditions."""
         backend_ready = (
             resource.get_condition(self.req.observed.resources.get(BACKEND_RESOURCE_KEY), "Ready").status == "True"
@@ -437,7 +442,7 @@ class Composer:
             ),
         )
 
-    def compose_gke_cluster(self, gke) -> None:
+    def compose_gke_cluster(self, gke: v1alpha1.Gke) -> None:
         """Compose a GKECluster XR.
 
         Combines the cluster-level config (project, region) with the
@@ -495,7 +500,7 @@ class Composer:
             ),
         )
 
-    def compose_eks_cluster(self, eks) -> None:
+    def compose_eks_cluster(self, eks: v1alpha1.Eks) -> None:
         """Compose an EKSCluster XR.
 
         Combines the cluster-level config (region) with GPU node pools
@@ -584,7 +589,7 @@ class Composer:
         )
         self.rsp.desired.resources["usage-eks-by-backend"].ready = fnv1.READY_TRUE
 
-    def resolve_eks_backend_secrets(self, eks_ready, backend_exists) -> list[ssv1alpha1.Secret] | None:
+    def resolve_eks_backend_secrets(self, *, eks_ready: bool, backend_exists: bool) -> list[ssv1alpha1.Secret] | None:
         """Resolve secrets for the backend from EKSCluster status. Falls
         back to the observed backend's spec.secrets if EKSCluster secrets
         aren't available but the backend already exists."""
@@ -603,7 +608,7 @@ class Composer:
 
         return None
 
-    def observed_eks_secrets(self):
+    def observed_eks_secrets(self) -> list[eksv1alpha1.Secret] | None:
         """Read the EKSCluster's status.secrets from observed state."""
         eks_observed = self.req.observed.resources.get("eks-cluster")
         if not eks_observed:
@@ -613,7 +618,7 @@ class Composer:
             return None
         return observed_eks.status.secrets
 
-    def observed_eks_secret(self, secret_type):
+    def observed_eks_secret(self, secret_type: str) -> eksv1alpha1.Secret | None:
         """Read a specific secret from the observed EKSCluster status."""
         eks_secrets = self.observed_eks_secrets()
         if not eks_secrets:
@@ -643,7 +648,7 @@ class Composer:
         )
         self.rsp.desired.resources["usage-gke-by-backend"].ready = fnv1.READY_TRUE
 
-    def resolve_gke_backend_secrets(self, gke_ready, backend_exists) -> list[ssv1alpha1.Secret] | None:
+    def resolve_gke_backend_secrets(self, *, gke_ready: bool, backend_exists: bool) -> list[ssv1alpha1.Secret] | None:
         """Resolve secrets for the backend from GKECluster status. Falls
         back to the observed backend's spec.secrets if GKECluster secrets aren't
         available but the backend already exists."""
@@ -662,7 +667,7 @@ class Composer:
 
         return None
 
-    def gpu_pools(self):
+    def gpu_pools(self) -> list[dict[str, object]]:
         """Derive status.gpuPools from each node pool's class.
 
         The class declares the node's devices (DRA-style); the pool declares how
@@ -690,7 +695,7 @@ class Composer:
             )
         return gpu_pools
 
-    def observed_gke_secrets(self):
+    def observed_gke_secrets(self) -> list[gkev1alpha1.Secret] | None:
         """Read the GKECluster's status.secrets from observed state."""
         gke_observed = self.req.observed.resources.get("gke-cluster")
         if not gke_observed:
@@ -700,14 +705,14 @@ class Composer:
             return None
         return observed_gke.status.secrets
 
-    def observed_gke_secret(self, secret_type):
+    def observed_gke_secret(self, secret_type: str) -> gkev1alpha1.Secret | None:
         """Read a specific secret from the observed GKECluster status."""
         gke_secrets = self.observed_gke_secrets()
         if not gke_secrets:
             return None
         return next((s for s in gke_secrets if s.type == secret_type), None)
 
-    def observed_gateway_address(self):
+    def observed_gateway_address(self) -> str | None:
         """Read the backend's gateway address from observed state.
         Uses dict access instead of a typed model so it works for any
         backend that follows the status.gateway.address contract."""
@@ -717,7 +722,7 @@ class Composer:
         d = resource.struct_to_dict(observed.resource)
         return d.get("status", {}).get("gateway", {}).get("address")
 
-    def observed_cache_storage_class(self):
+    def observed_cache_storage_class(self) -> str | None:
         """The effective ModelCache RWX StorageClass name, relayed up so
         ModelCache can target it without reaching into the cluster XRs.
 
@@ -734,7 +739,9 @@ class Composer:
             return cluster.existing.cache.storageClassName
         return None
 
-    def _observed_cluster_cache_class(self, key, model):
+    def _observed_cluster_cache_class(
+        self, key: str, model: type[gkev1alpha1.GKECluster] | type[eksv1alpha1.EKSCluster]
+    ) -> str | None:
         """Read status.cache.storageClassName from an observed cluster XR."""
         observed = self.req.observed.resources.get(key)
         if not observed:

--- a/functions/compose-inference-cluster/function/fn.py
+++ b/functions/compose-inference-cluster/function/fn.py
@@ -91,14 +91,16 @@ _NAMESPACE_SYSTEM = "modelplane-system"
 _IDENTITY_TYPE_GCP = "GoogleApplicationCredentials"
 
 
-class FunctionRunner(grpcv1.FunctionRunnerService):
+class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
     def __init__(self):
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
-    async def RunFunction(self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext) -> fnv1.RunFunctionResponse:
+    async def RunFunction(
+        self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext | None
+    ) -> fnv1.RunFunctionResponse:  # ty: ignore[invalid-method-override]  # the generated grpc servicer base is untyped
         """Run the function."""
         log = self.log.bind(tag=req.meta.tag)
         log.info("Running function")

--- a/functions/compose-inference-gateway/function/fn.py
+++ b/functions/compose-inference-gateway/function/fn.py
@@ -180,7 +180,7 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp) -> None:
+    def __init__(self, req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.InferenceGateway(**resource.struct_to_dict(req.observed.composite.resource))
@@ -221,7 +221,7 @@ class Composer:
             if resource.get_condition(self.req.observed.resources.get(key), "Established").status == "True":
                 self.rsp.desired.resources[key].ready = fnv1.READY_TRUE
 
-    def gateway_api_crds_ready(self):
+    def gateway_api_crds_ready(self) -> bool:
         """True once every composed Gateway API CRD is Established, so Traefik
         can render its resources and watch the Gateway API types."""
         return all(
@@ -439,7 +439,7 @@ class Composer:
         if resource.get_condition(self.req.observed.resources.get("gateway"), "Accepted").status == "True":
             self.rsp.desired.resources["gateway"].ready = fnv1.READY_TRUE
 
-    def compose_pc_usage(self, release_key) -> None:
+    def compose_pc_usage(self, release_key: str) -> None:
         """Compose a Usage protecting the ProviderConfig from deletion until
         the given Helm release is gone."""
         resource.update(

--- a/functions/compose-inference-gateway/function/fn.py
+++ b/functions/compose-inference-gateway/function/fn.py
@@ -162,7 +162,7 @@ def _helm_release(
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
@@ -180,12 +180,12 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp):
+    def __init__(self, req, rsp) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.InferenceGateway(**resource.struct_to_dict(req.observed.composite.resource))
 
-    def compose(self):
+    def compose(self) -> None:
         self.compose_provider_config()
         self.compose_gateway_api_crds()
         self.compose_metallb()
@@ -195,7 +195,7 @@ class Composer:
         self.write_status()
         self.derive_conditions()
 
-    def compose_provider_config(self):
+    def compose_provider_config(self) -> None:
         """Namespaced ProviderConfig for provider-helm targeting the control
         plane using the pod's own service account (in-cluster identity).
         Namespaced (not ClusterProviderConfig) so the Usage can protect it."""
@@ -210,7 +210,7 @@ class Composer:
         )
         self.rsp.desired.resources["provider-config-helm"].ready = fnv1.READY_TRUE
 
-    def compose_gateway_api_crds(self):
+    def compose_gateway_api_crds(self) -> None:
         """Compose the Gateway API CRDs onto the control plane.
 
         These must exist before the Traefik release renders its resources and
@@ -229,7 +229,7 @@ class Composer:
             for doc in _GATEWAY_API_CRDS
         )
 
-    def compose_metallb(self):
+    def compose_metallb(self) -> None:
         """Optional MetalLB for kind/bare-metal clusters that don't have a
         cloud load balancer controller to assign Gateway addresses."""
         t = self.xr.spec.traefik
@@ -291,7 +291,7 @@ class Composer:
         )
         self.rsp.desired.resources["metallb-l2"].ready = fnv1.READY_TRUE
 
-    def compose_traefik(self):
+    def compose_traefik(self) -> None:
         """Compose Traefik Proxy. Gated on the ProviderConfig being observed
         (so provider-helm can act on the Release) and the Gateway API CRDs
         being established (so the release can render its resources and Traefik
@@ -341,7 +341,7 @@ class Composer:
         )
         self.compose_pc_usage("traefik")
 
-    def compose_gateway(self):
+    def compose_gateway(self) -> None:
         """Compose GatewayClass and Gateway. Gated on Traefik being ready."""
         traefik_ready = resource.get_condition(self.req.observed.resources.get("traefik"), "Ready").status == "True"
 
@@ -384,7 +384,7 @@ class Composer:
                 },
             )
 
-    def write_status(self):
+    def write_status(self) -> None:
         """Surface the gateway's external address. Only the address — no
         gateway-specific fields. This contract works for any routing backend."""
         status = v1alpha1.Status()
@@ -398,7 +398,7 @@ class Composer:
 
         resource.update_status(self.rsp.desired.composite, status)
 
-    def derive_conditions(self):
+    def derive_conditions(self) -> None:
         """Derive readiness for all composed resources and set custom
         conditions."""
         # MetalLB readiness.
@@ -439,7 +439,7 @@ class Composer:
         if resource.get_condition(self.req.observed.resources.get("gateway"), "Accepted").status == "True":
             self.rsp.desired.resources["gateway"].ready = fnv1.READY_TRUE
 
-    def compose_pc_usage(self, release_key):
+    def compose_pc_usage(self, release_key) -> None:
         """Compose a Usage protecting the ProviderConfig from deletion until
         the given Helm release is gone."""
         resource.update(
@@ -466,7 +466,7 @@ class Composer:
         )
         self.rsp.desired.resources[f"usage-pc-by-{release_key}"].ready = fnv1.READY_TRUE
 
-    def compose_gateway_usages(self):
+    def compose_gateway_usages(self) -> None:
         """Compose Usages so the Traefik release outlives the GatewayClass and
         Gateway it controls.
 

--- a/functions/compose-inference-gateway/function/fn.py
+++ b/functions/compose-inference-gateway/function/fn.py
@@ -159,14 +159,16 @@ def _helm_release(
     return release
 
 
-class FunctionRunner(grpcv1.FunctionRunnerService):
+class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
     def __init__(self):
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
-    async def RunFunction(self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext) -> fnv1.RunFunctionResponse:
+    async def RunFunction(
+        self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext | None
+    ) -> fnv1.RunFunctionResponse:  # ty: ignore[invalid-method-override]  # the generated grpc servicer base is untyped
         """Run the function."""
         log = self.log.bind(tag=req.meta.tag)
         log.info("Running function")

--- a/functions/compose-inference-gateway/function/fn.py
+++ b/functions/compose-inference-gateway/function/fn.py
@@ -306,7 +306,7 @@ class Composer:
             _helm_release(
                 chart=_TRAEFIK_CHART,
                 repo=_TRAEFIK_REPO,
-                version=self.xr.spec.traefik.version,
+                version=self.xr.spec.traefik.version,  # ty: ignore[unresolved-attribute]  # XRD guarantees traefik when backend is Traefik, the only backend
                 namespace=_TRAEFIK_NAMESPACE,
                 provider_config=_PC_NAME,
                 values={

--- a/functions/compose-model-cache/function/fn.py
+++ b/functions/compose-model-cache/function/fn.py
@@ -180,7 +180,7 @@ class Composer:
         # Derive each cluster's phase first (from observed state), then compose:
         # a hydrated cluster's Job is composed Observe-only so Crossplane doesn't
         # recreate it after the TTL controller cleans it.
-        per_cluster_phase = [(c.metadata.name, self.derive_cluster_phase(c.metadata.name)) for c in matched]  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+        per_cluster_phase = [(c.metadata.name, self.derive_cluster_phase(c.metadata.name)) for c in matched]  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
         phase_by_name = dict(per_cluster_phase)
         for cluster in matched:
             self.compose_cluster_resources(cluster, phase_by_name[cluster.metadata.name])  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
@@ -372,13 +372,13 @@ class Composer:
     # Namespace-qualified so same-named caches from different Modelplane
     # namespaces don't collide in the workload cluster's `default` namespace.
     def _pvc_name(self) -> str:
-        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name)  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
     def _job_name(self) -> str:
-        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name, "hydrate")  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name, "hydrate")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
     def _auth_secret_name(self) -> str:
-        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name, "auth")  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name, "auth")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
     def _pvc_key(self, cluster_name: str) -> str:
         return f"pvc-{cluster_name}"

--- a/functions/compose-model-cache/function/fn.py
+++ b/functions/compose-model-cache/function/fn.py
@@ -178,10 +178,10 @@ class Composer:
         # Derive each cluster's phase first (from observed state), then compose:
         # a hydrated cluster's Job is composed Observe-only so Crossplane doesn't
         # recreate it after the TTL controller cleans it.
-        per_cluster_phase = [(c.metadata.name, self.derive_cluster_phase(c.metadata.name)) for c in matched]
+        per_cluster_phase = [(c.metadata.name, self.derive_cluster_phase(c.metadata.name)) for c in matched]  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
         phase_by_name = dict(per_cluster_phase)
         for cluster in matched:
-            self.compose_cluster_resources(cluster, phase_by_name[cluster.metadata.name])
+            self.compose_cluster_resources(cluster, phase_by_name[cluster.metadata.name])  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
         self.mark_ready_resources(per_cluster_phase)
         self.write_status(matched, per_cluster_phase)
         self.derive_conditions(matched, per_cluster_phase)
@@ -223,7 +223,7 @@ class Composer:
                 api_version="v1",
                 kind="Secret",
                 match_name=auth.name,
-                namespace=self.xr.metadata.namespace,
+                namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
             )
 
         # get_required_resources returns [] both when unresolved AND when
@@ -284,7 +284,7 @@ class Composer:
         status, so dropping the Job doesn't regress it, and a flap that re-adds
         it is a cheap idempotent skip."""
         pc = cluster.status.providerConfigRef.name
-        name = cluster.metadata.name
+        name = cluster.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
         resource.update(
             self.rsp.desired.resources[self._pvc_key(name)],
             self._wrap_remote(pc, self._pvc_manifest(cluster), _PVC_READY_CEL),
@@ -370,13 +370,13 @@ class Composer:
     # Namespace-qualified so same-named caches from different Modelplane
     # namespaces don't collide in the workload cluster's `default` namespace.
     def _pvc_name(self) -> str:
-        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name)
+        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
 
     def _job_name(self) -> str:
-        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name, "hydrate")
+        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name, "hydrate")  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
 
     def _auth_secret_name(self) -> str:
-        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name, "auth")
+        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name, "auth")  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
 
     def _pvc_key(self, cluster_name: str) -> str:
         return f"pvc-{cluster_name}"
@@ -388,7 +388,7 @@ class Composer:
         return f"auth-{cluster_name}"
 
     def _labels(self) -> dict[str, str]:
-        return {"modelplane.ai/modelcache": self.xr.metadata.name}
+        return {"modelplane.ai/modelcache": self.xr.metadata.name}  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
 
     def _job_manifest(self) -> dict:
         env, command = _hf_hydration(self.xr.spec.huggingFace, self._auth_secret_name())
@@ -536,7 +536,7 @@ class Composer:
             )
             response.warning(
                 self.rsp,
-                f"authSecret {self.xr.metadata.namespace}/{auth.name} is missing or has no key {key!r}",
+                f"authSecret {self.xr.metadata.namespace}/{auth.name} is missing or has no key {key!r}",  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
             )
         elif any(p == PHASE_FAILED for _, p in per_cluster_phase):
             response.set_conditions(

--- a/functions/compose-model-cache/function/fn.py
+++ b/functions/compose-model-cache/function/fn.py
@@ -145,7 +145,7 @@ def _hf_hydration(hf, auth_secret_name: str | None) -> tuple[list[dict], str]:
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.log = logging.get_logger()
 
     async def RunFunction(
@@ -159,7 +159,7 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp):
+    def __init__(self, req, rsp) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.ModelCache(**resource.struct_to_dict(req.observed.composite.resource))
@@ -176,7 +176,7 @@ class Composer:
         Secret was found-but-empty or absent, not merely unresolved."""
         return self.xr.spec.huggingFace.authSecret is not None and not self.auth_data  # ty: ignore[unresolved-attribute]  # XRD guarantees huggingFace is set
 
-    def compose(self):
+    def compose(self) -> None:
         if not self.resolve_inputs():
             return
         matched = self.match_clusters()

--- a/functions/compose-model-cache/function/fn.py
+++ b/functions/compose-model-cache/function/fn.py
@@ -30,6 +30,14 @@ from crossplane.function.proto.v1 import run_function_pb2_grpc as grpcv1
 from models.ai.modelplane.inferencecluster import v1alpha1 as icv1alpha1
 from models.ai.modelplane.modelcache import v1alpha1
 from models.io.crossplane.m.kubernetes.object import v1alpha1 as k8sobjv1alpha1
+from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
+
+
+def _name(meta: metav1.ObjectMeta | None) -> str:
+    """The object's name, which is always set on resources read from the API server."""
+    assert meta is not None and meta.name is not None
+    return meta.name
+
 
 # Condition types/reasons for the ModelCache XR.
 CONDITION_TYPE_CLUSTERS_MATCHED = "ClustersMatched"
@@ -50,10 +58,11 @@ _PVC_READY_CEL = 'object.status.phase == "Bound"'
 _JOB_READY_CEL = 'object.status.conditions.exists(c, c.type == "Complete" && c.status == "True")'
 
 # Per-cluster phases reported in status.clusters[].phase.
-PHASE_PENDING = "Pending"
-PHASE_HYDRATING = "Hydrating"
-PHASE_READY = "Ready"
-PHASE_FAILED = "Failed"
+_Phase = Literal["Pending", "Hydrating", "Ready", "Failed"]
+PHASE_PENDING: _Phase = "Pending"
+PHASE_HYDRATING: _Phase = "Hydrating"
+PHASE_READY: _Phase = "Ready"
+PHASE_FAILED: _Phase = "Failed"
 
 # Namespace on the workload cluster where the PVC + Job land. Must match the
 # namespace the serving pods mount from (native.py/llmd.py `_REMOTE_NAMESPACE`,
@@ -107,7 +116,7 @@ _HYDRATED_MARKER = f"{HYDRATION_MOUNT}/.modelplane-hydrated"
 _SKIP_IF_HYDRATED = f"if [ -f {_HYDRATED_MARKER} ]; then echo 'already hydrated, skipping'; exit 0; fi; "
 
 
-def _hf_hydration(hf, auth_secret_name: str | None) -> tuple[list[dict], str]:
+def _hf_hydration(hf: v1alpha1.HuggingFace, auth_secret_name: str | None) -> tuple[list[dict], str]:
     """Return (env, shell command) for a HuggingFace source.
 
     Uses `hf download` (huggingface_hub 1.x; `huggingface-cli` is removed).
@@ -159,7 +168,7 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp) -> None:
+    def __init__(self, req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.ModelCache(**resource.struct_to_dict(req.observed.composite.resource))
@@ -183,10 +192,12 @@ class Composer:
         # Derive each cluster's phase first (from observed state), then compose:
         # a hydrated cluster's Job is composed Observe-only so Crossplane doesn't
         # recreate it after the TTL controller cleans it.
-        per_cluster_phase = [(c.metadata.name, self.derive_cluster_phase(c.metadata.name)) for c in matched]  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+        per_cluster_phase: list[tuple[str, _Phase]] = [
+            (_name(c.metadata), self.derive_cluster_phase(_name(c.metadata))) for c in matched
+        ]
         phase_by_name = dict(per_cluster_phase)
         for cluster in matched:
-            self.compose_cluster_resources(cluster, phase_by_name[cluster.metadata.name])  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+            self.compose_cluster_resources(cluster, phase_by_name[_name(cluster.metadata)])
         self.mark_ready_resources(per_cluster_phase)
         self.write_status(matched, per_cluster_phase)
         self.derive_conditions(matched, per_cluster_phase)
@@ -250,7 +261,7 @@ class Composer:
 
         return True
 
-    def _resolve_auth_data(self, auth, secret: dict | None) -> None:
+    def _resolve_auth_data(self, auth: v1alpha1.AuthSecret, secret: dict | None) -> None:
         """Read the token from the resolved control-plane authSecret into
         self.auth_data, copying its base64 `data` verbatim (re-encoding would
         corrupt it).
@@ -279,7 +290,7 @@ class Composer:
             if c.status and c.status.providerConfigRef and c.status.providerConfigRef.name and _storage_class(c)
         ]
 
-    def compose_cluster_resources(self, cluster: icv1alpha1.InferenceCluster, phase: str) -> None:
+    def compose_cluster_resources(self, cluster: icv1alpha1.InferenceCluster, phase: _Phase) -> None:
         """Compose the PVC always, and the hydration Job until the cluster is Ready.
 
         Once Ready the Job is dropped: with _JOB_MANAGEMENT (no Delete) that
@@ -292,7 +303,7 @@ class Composer:
         # is set, so this is never None here.
         assert cluster.status and cluster.status.providerConfigRef and cluster.status.providerConfigRef.name
         pc = cluster.status.providerConfigRef.name
-        name = cluster.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+        name = _name(cluster.metadata)
         resource.update(
             self.rsp.desired.resources[self._pvc_key(name)],  # ty: ignore[invalid-argument-type]  # metadata name is always set on resources read from the API server
             self._wrap_remote(pc, self._pvc_manifest(cluster), _PVC_READY_CEL),
@@ -399,7 +410,7 @@ class Composer:
         return {"modelplane.ai/modelcache": self.xr.metadata.name}  # ty: ignore[unresolved-attribute, invalid-return-type]  # metadata is always set on resources read from the API server
 
     def _job_manifest(self) -> dict:
-        env, command = _hf_hydration(self.xr.spec.huggingFace, self._auth_secret_name())
+        env, command = _hf_hydration(self.xr.spec.huggingFace, self._auth_secret_name())  # ty: ignore[invalid-argument-type]  # XRD guarantees huggingFace is set
         return {
             "apiVersion": "batch/v1",
             "kind": "Job",
@@ -431,7 +442,7 @@ class Composer:
             },
         }
 
-    def derive_cluster_phase(self, cluster_name: str) -> str:
+    def derive_cluster_phase(self, cluster_name: str) -> _Phase:
         pvc_bound = self._observed_status(self._pvc_key(cluster_name)).get("phase") == "Bound"
         job_status = self._observed_status(self._job_key(cluster_name))
         if any(c.get("type") == "Failed" and c.get("status") == "True" for c in job_status.get("conditions", [])):
@@ -469,7 +480,7 @@ class Composer:
         manifest = (obj.status.atProvider.manifest if obj.status and obj.status.atProvider else None) or {}
         return manifest.get("status", {}) or {}
 
-    def mark_ready_resources(self, per_cluster_phase) -> None:
+    def mark_ready_resources(self, per_cluster_phase: list[tuple[str, _Phase]]) -> None:
         """Mark composed Objects ready from each Object's own Ready condition.
 
         The PVC and Job carry a DeriveFromCelQuery readiness policy, so the
@@ -492,7 +503,9 @@ class Composer:
                 if observed and resource.get_condition(observed.resource, "Ready").status == "True":
                     self.rsp.desired.resources[key].ready = fnv1.READY_TRUE
 
-    def write_status(self, matched, per_cluster_phase) -> None:
+    def write_status(
+        self, matched: list[icv1alpha1.InferenceCluster], per_cluster_phase: list[tuple[str, _Phase]]
+    ) -> None:
         ready_count = sum(1 for _, p in per_cluster_phase if p == PHASE_READY)
         status = v1alpha1.Status(
             summary=v1alpha1.Summary(ready=f"{ready_count}/{len(matched)}"),
@@ -500,7 +513,9 @@ class Composer:
         )
         resource.update_status(self.rsp.desired.composite, status)
 
-    def derive_conditions(self, matched, per_cluster_phase) -> None:
+    def derive_conditions(
+        self, matched: list[icv1alpha1.InferenceCluster], per_cluster_phase: list[tuple[str, _Phase]]
+    ) -> None:
         if not matched:
             response.set_conditions(
                 self.rsp,
@@ -572,14 +587,16 @@ class Composer:
                 ),
             )
 
-    def emit_events(self, matched, per_cluster_phase) -> None:
+    def emit_events(
+        self, matched: list[icv1alpha1.InferenceCluster], per_cluster_phase: list[tuple[str, _Phase]]
+    ) -> None:
         """One-time transition events only (keep `kubectl describe` quiet)."""
         was_ready = resource.get_condition(self.req.observed.composite.resource, "Ready").status == "True"
         now_ready = bool(matched) and all(p == PHASE_READY for _, p in per_cluster_phase)
         observed_keys = self.req.observed.resources.keys()
-        first_compose = matched and all(self._pvc_key(c.metadata.name) not in observed_keys for c in matched)
+        first_compose = matched and all(self._pvc_key(_name(c.metadata)) not in observed_keys for c in matched)
         if first_compose:
-            names = ", ".join(c.metadata.name for c in matched)
+            names = ", ".join(_name(c.metadata) for c in matched)
             response.normal(
                 self.rsp,
                 f"Staging {self.xr.spec.huggingFace.repo} to {len(matched)} clusters: {names}",  # ty: ignore[unresolved-attribute]  # XRD guarantees huggingFace is set

--- a/functions/compose-model-cache/function/fn.py
+++ b/functions/compose-model-cache/function/fn.py
@@ -34,9 +34,17 @@ from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
 
 
 def _name(meta: metav1.ObjectMeta | None) -> str:
-    """The object's name, which is always set on resources read from the API server."""
-    assert meta is not None and meta.name is not None
+    """The object's name, always set on resources read from the API server."""
+    if meta is None or meta.name is None:
+        raise ValueError("metadata.name is unexpectedly absent")
     return meta.name
+
+
+def _namespace(meta: metav1.ObjectMeta | None) -> str:
+    """The object's namespace, always set on namespaced resources read from the API server."""
+    if meta is None or meta.namespace is None:
+        raise ValueError("metadata.namespace is unexpectedly absent")
+    return meta.namespace
 
 
 # Condition types/reasons for the ModelCache XR.
@@ -239,7 +247,7 @@ class Composer:
                 api_version="v1",
                 kind="Secret",
                 match_name=auth.name,
-                namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                namespace=_namespace(self.xr.metadata),
             )
 
         # get_required_resources returns [] both when unresolved AND when
@@ -305,7 +313,7 @@ class Composer:
         pc = cluster.status.providerConfigRef.name
         name = _name(cluster.metadata)
         resource.update(
-            self.rsp.desired.resources[self._pvc_key(name)],  # ty: ignore[invalid-argument-type]  # metadata name is always set on resources read from the API server
+            self.rsp.desired.resources[self._pvc_key(name)],
             self._wrap_remote(pc, self._pvc_manifest(cluster), _PVC_READY_CEL),
         )
         # The PVC (above) composes regardless of auth: it doesn't depend on the
@@ -325,11 +333,11 @@ class Composer:
             # uses default readiness (Ready once synced).
             if self.auth_data:
                 resource.update(
-                    self.rsp.desired.resources[self._auth_key(name)],  # ty: ignore[invalid-argument-type]  # metadata name is always set on resources read from the API server
+                    self.rsp.desired.resources[self._auth_key(name)],
                     self._wrap_remote(pc, self._auth_secret_manifest()),
                 )
             resource.update(
-                self.rsp.desired.resources[self._job_key(name)],  # ty: ignore[invalid-argument-type]  # metadata name is always set on resources read from the API server
+                self.rsp.desired.resources[self._job_key(name)],
                 self._wrap_remote(pc, self._job_manifest(), _JOB_READY_CEL, management_policies=_JOB_MANAGEMENT),
             )
 
@@ -389,13 +397,13 @@ class Composer:
     # Namespace-qualified so same-named caches from different Modelplane
     # namespaces don't collide in the workload cluster's `default` namespace.
     def _pvc_name(self) -> str:
-        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name)  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+        return resource.child_name("modelcache", _namespace(self.xr.metadata), _name(self.xr.metadata))
 
     def _job_name(self) -> str:
-        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name, "hydrate")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+        return resource.child_name("modelcache", _namespace(self.xr.metadata), _name(self.xr.metadata), "hydrate")
 
     def _auth_secret_name(self) -> str:
-        return resource.child_name("modelcache", self.xr.metadata.namespace, self.xr.metadata.name, "auth")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+        return resource.child_name("modelcache", _namespace(self.xr.metadata), _name(self.xr.metadata), "auth")
 
     def _pvc_key(self, cluster_name: str) -> str:
         return f"pvc-{cluster_name}"
@@ -407,7 +415,7 @@ class Composer:
         return f"auth-{cluster_name}"
 
     def _labels(self) -> dict[str, str]:
-        return {"modelplane.ai/modelcache": self.xr.metadata.name}  # ty: ignore[unresolved-attribute, invalid-return-type]  # metadata is always set on resources read from the API server
+        return {"modelplane.ai/modelcache": _name(self.xr.metadata)}
 
     def _job_manifest(self) -> dict:
         env, command = _hf_hydration(self.xr.spec.huggingFace, self._auth_secret_name())  # ty: ignore[invalid-argument-type]  # XRD guarantees huggingFace is set
@@ -561,7 +569,7 @@ class Composer:
             )
             response.warning(
                 self.rsp,
-                f"authSecret {self.xr.metadata.namespace}/{auth.name} is missing or has no key {key!r}",  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                f"authSecret {_namespace(self.xr.metadata)}/{auth.name} is missing or has no key {key!r}",
             )
         elif any(p == PHASE_FAILED for _, p in per_cluster_phase):
             response.set_conditions(

--- a/functions/compose-model-cache/function/fn.py
+++ b/functions/compose-model-cache/function/fn.py
@@ -21,6 +21,8 @@ at /mnt/models, so weights are downloaded once per cluster and read N
 times by every pod in an LWS gang.
 """
 
+from typing import Literal
+
 import grpc
 from crossplane.function import logging, request, resource, response
 from crossplane.function.proto.v1 import run_function_pb2 as fnv1
@@ -78,7 +80,8 @@ _JOB_TTL_SECONDS = 180
 # pod that pins the PVC - whereas Crossplane's delete would orphan that pod. (No
 # "all but Delete" shorthand exists, and deletionPolicy: Orphan is ignored once
 # managementPolicies is on.) Re-adding the Job after a flap is a cheap skip.
-_JOB_MANAGEMENT = ["Observe", "Create", "Update", "LateInitialize"]
+_ManagementPolicy = Literal["Observe", "Create", "Update", "Delete", "LateInitialize", "*"]
+_JOB_MANAGEMENT: list[_ManagementPolicy] = ["Observe", "Create", "Update", "LateInitialize"]
 
 
 def _storage_class(cluster: icv1alpha1.InferenceCluster) -> str | None:
@@ -171,7 +174,7 @@ class Composer:
         resolved. compose() only runs past resolve_inputs() once the auth
         requirement (if any) is resolved, so an empty auth_data here means the
         Secret was found-but-empty or absent, not merely unresolved."""
-        return self.xr.spec.huggingFace.authSecret is not None and not self.auth_data
+        return self.xr.spec.huggingFace.authSecret is not None and not self.auth_data  # ty: ignore[unresolved-attribute]  # XRD guarantees huggingFace is set
 
     def compose(self):
         if not self.resolve_inputs():
@@ -217,7 +220,7 @@ class Composer:
         # XR's own namespace on the control plane. Its token is propagated to
         # each workload cluster (compose_cluster_resources) so the hydration Job
         # finds it; without resolving it first we can't materialize it remotely.
-        auth = self.xr.spec.huggingFace.authSecret
+        auth = self.xr.spec.huggingFace.authSecret  # ty: ignore[unresolved-attribute]  # XRD guarantees huggingFace is set
         if auth:
             response.require_resources(
                 self.rsp,
@@ -285,10 +288,13 @@ class Composer:
         instead of Crossplane orphaning the pod. Readiness is latched in the XR
         status, so dropping the Job doesn't regress it, and a flap that re-adds
         it is a cheap idempotent skip."""
+        # match_clusters only returns clusters whose status.providerConfigRef.name
+        # is set, so this is never None here.
+        assert cluster.status and cluster.status.providerConfigRef and cluster.status.providerConfigRef.name
         pc = cluster.status.providerConfigRef.name
         name = cluster.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
         resource.update(
-            self.rsp.desired.resources[self._pvc_key(name)],
+            self.rsp.desired.resources[self._pvc_key(name)],  # ty: ignore[invalid-argument-type]  # metadata name is always set on resources read from the API server
             self._wrap_remote(pc, self._pvc_manifest(cluster), _PVC_READY_CEL),
         )
         # The PVC (above) composes regardless of auth: it doesn't depend on the
@@ -308,17 +314,17 @@ class Composer:
             # uses default readiness (Ready once synced).
             if self.auth_data:
                 resource.update(
-                    self.rsp.desired.resources[self._auth_key(name)],
+                    self.rsp.desired.resources[self._auth_key(name)],  # ty: ignore[invalid-argument-type]  # metadata name is always set on resources read from the API server
                     self._wrap_remote(pc, self._auth_secret_manifest()),
                 )
             resource.update(
-                self.rsp.desired.resources[self._job_key(name)],
+                self.rsp.desired.resources[self._job_key(name)],  # ty: ignore[invalid-argument-type]  # metadata name is always set on resources read from the API server
                 self._wrap_remote(pc, self._job_manifest(), _JOB_READY_CEL, management_policies=_JOB_MANAGEMENT),
             )
 
     def _pvc_manifest(self, cluster: icv1alpha1.InferenceCluster) -> dict:
         hf = self.xr.spec.huggingFace
-        size_gib = int(hf.sizeGiB)  # protobuf delivers XRD ints as float
+        size_gib = int(hf.sizeGiB)  # ty: ignore[unresolved-attribute]  # XRD guarantees huggingFace is set; protobuf delivers XRD ints as float
         return {
             "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
@@ -349,7 +355,7 @@ class Composer:
         provider_config: str,
         manifest: dict,
         cel_query: str | None = None,
-        management_policies: list[str] | None = None,
+        management_policies: list[_ManagementPolicy] | None = None,
     ) -> k8sobjv1alpha1.Object:
         spec = k8sobjv1alpha1.Spec(
             providerConfigRef=k8sobjv1alpha1.ProviderConfigRef(
@@ -390,7 +396,7 @@ class Composer:
         return f"auth-{cluster_name}"
 
     def _labels(self) -> dict[str, str]:
-        return {"modelplane.ai/modelcache": self.xr.metadata.name}  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+        return {"modelplane.ai/modelcache": self.xr.metadata.name}  # ty: ignore[unresolved-attribute, invalid-return-type]  # metadata is always set on resources read from the API server
 
     def _job_manifest(self) -> dict:
         env, command = _hf_hydration(self.xr.spec.huggingFace, self._auth_secret_name())
@@ -526,7 +532,9 @@ class Composer:
         # token rotated away after hydration is neither reported nor warned.
         ready_count = sum(1 for _, p in per_cluster_phase if p == PHASE_READY)
         if self._auth_missing() and ready_count != len(matched):
-            auth = self.xr.spec.huggingFace.authSecret
+            # _auth_missing is true only when huggingFace.authSecret is set.
+            auth = self.xr.spec.huggingFace.authSecret  # ty: ignore[unresolved-attribute]  # XRD guarantees huggingFace is set
+            assert auth is not None
             key = auth.key or "HF_TOKEN"
             response.set_conditions(
                 self.rsp,
@@ -574,7 +582,7 @@ class Composer:
             names = ", ".join(c.metadata.name for c in matched)
             response.normal(
                 self.rsp,
-                f"Staging {self.xr.spec.huggingFace.repo} to {len(matched)} clusters: {names}",
+                f"Staging {self.xr.spec.huggingFace.repo} to {len(matched)} clusters: {names}",  # ty: ignore[unresolved-attribute]  # XRD guarantees huggingFace is set
             )
         if now_ready and not was_ready:
             response.normal(self.rsp, f"Artifact staged on all {len(matched)} clusters")

--- a/functions/compose-model-cache/function/fn.py
+++ b/functions/compose-model-cache/function/fn.py
@@ -139,13 +139,15 @@ def _hf_hydration(hf, auth_secret_name: str | None) -> tuple[list[dict], str]:
     return env, command
 
 
-class FunctionRunner(grpcv1.FunctionRunnerService):
+class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
     def __init__(self):
         self.log = logging.get_logger()
 
-    async def RunFunction(self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext) -> fnv1.RunFunctionResponse:
+    async def RunFunction(
+        self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext | None
+    ) -> fnv1.RunFunctionResponse:  # ty: ignore[invalid-method-override]  # the generated grpc servicer base is untyped
         log = self.log.bind(tag=req.meta.tag)
         log.info("Running function")
         rsp = response.to(req)

--- a/functions/compose-model-cache/tests/test_fn.py
+++ b/functions/compose-model-cache/tests/test_fn.py
@@ -15,7 +15,9 @@
 """Tests for the compose-model-cache function."""
 
 import dataclasses
+import datetime
 import unittest
+from typing import Any
 
 from crossplane.function import logging, resource
 from crossplane.function.proto.v1 import run_function_pb2 as fnv1
@@ -25,6 +27,9 @@ from google.protobuf import json_format
 from google.protobuf import struct_pb2 as structpb
 from models.ai.modelplane.modelcache import v1alpha1
 from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
+
+# A fixed transition time keeps observed conditions deterministic.
+_TRANSITION_TIME = datetime.datetime(2026, 6, 8, tzinfo=datetime.UTC)
 
 
 @dataclasses.dataclass
@@ -87,14 +92,9 @@ def _observed_object(manifest_status: dict, *, ready: bool = False) -> dict:
     (read by derive_cluster_phase) and, when `ready`, the Object's own Ready
     condition (read by mark_ready_resources, populated by DeriveFromCelQuery).
     """
-    obj = {
-        "apiVersion": "kubernetes.m.crossplane.io/v1alpha1",
-        "kind": "Object",
-        "spec": {"forProvider": {"manifest": {}}},
-        "status": {"atProvider": {"manifest": {"status": manifest_status}}},
-    }
+    status: dict[str, Any] = {"atProvider": {"manifest": {"status": manifest_status}}}
     if ready:
-        obj["status"]["conditions"] = [
+        status["conditions"] = [
             {
                 "type": "Ready",
                 "status": "True",
@@ -102,7 +102,12 @@ def _observed_object(manifest_status: dict, *, ready: bool = False) -> dict:
                 "lastTransitionTime": "2026-06-08T00:00:00Z",
             },
         ]
-    return obj
+    return {
+        "apiVersion": "kubernetes.m.crossplane.io/v1alpha1",
+        "kind": "Object",
+        "spec": {"forProvider": {"manifest": {}}},
+        "status": status,
+    }
 
 
 def _auth_secret(*, data: dict[str, str] | None = None) -> dict:
@@ -578,7 +583,7 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                     type="Ready",
                     status="True",
                     reason="Available",
-                    lastTransitionTime="2026-06-08T00:00:00Z",
+                    lastTransitionTime=_TRANSITION_TIME,
                 ),
             ],
         )
@@ -725,7 +730,7 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                     type="Ready",
                     status="True",
                     reason="Available",
-                    lastTransitionTime="2026-06-08T00:00:00Z",
+                    lastTransitionTime=_TRANSITION_TIME,
                 ),
             ],
         )

--- a/functions/compose-model-cache/tests/test_fn.py
+++ b/functions/compose-model-cache/tests/test_fn.py
@@ -48,7 +48,7 @@ def setUpModule() -> None:
 # The XR used across cases: a HuggingFace ModelCache in the ml-team namespace.
 # Both the PVC and Job derive their names from
 # resource.child_name("modelcache", "ml-team", "qwen", ...).
-def _cache_xr(**hf_extra) -> v1alpha1.ModelCache:
+def _cache_xr(**hf_extra: Any) -> v1alpha1.ModelCache:
     return v1alpha1.ModelCache(
         metadata=metav1.ObjectMeta(name="qwen", namespace="ml-team"),
         spec=v1alpha1.Spec(

--- a/functions/compose-model-deployment/function/cel.py
+++ b/functions/compose-model-deployment/function/cel.py
@@ -154,7 +154,7 @@ class _DefaultMap(celtypes.MapType):
 class Program:
     """A compiled DRA CEL selector, reusable across devices."""
 
-    def __init__(self, expr: str):
+    def __init__(self, expr: str) -> None:
         env = celpy.Environment()
         # Any compile-time failure is a malformed expression - a user error.
         # celpy raises CELParseError for syntax errors, but we catch broadly so

--- a/functions/compose-model-deployment/function/cel.py
+++ b/functions/compose-model-deployment/function/cel.py
@@ -103,16 +103,25 @@ class CELCompileError(Exception):
 
 # compareTo/isGreaterThan/isLessThan are shared method names: a CEL selector
 # calls them on either a Quantity or a Semver, so dispatch on the operand type.
-def _compare_to(a, b):
-    return semver.compare_to(a, b) if isinstance(a, semver.Semver) else quantity.compare_to(a, b)
+# Both operands are always the same kind (the selector compares like to like).
+# isinstance narrows only the first operand, so cast the second to match; a
+# mixed-type comparison is a malformed selector that compilation should reject.
+def _compare_to(a: semver.Semver | quantity.Quantity, b: semver.Semver | quantity.Quantity) -> celtypes.IntType:
+    if isinstance(a, semver.Semver):
+        return semver.compare_to(a, typing.cast("semver.Semver", b))
+    return quantity.compare_to(a, typing.cast("quantity.Quantity", b))
 
 
-def _is_greater_than(a, b):
-    return semver.is_greater_than(a, b) if isinstance(a, semver.Semver) else quantity.is_greater_than(a, b)
+def _is_greater_than(a: semver.Semver | quantity.Quantity, b: semver.Semver | quantity.Quantity) -> celtypes.BoolType:
+    if isinstance(a, semver.Semver):
+        return semver.is_greater_than(a, typing.cast("semver.Semver", b))
+    return quantity.is_greater_than(a, typing.cast("quantity.Quantity", b))
 
 
-def _is_less_than(a, b):
-    return semver.is_less_than(a, b) if isinstance(a, semver.Semver) else quantity.is_less_than(a, b)
+def _is_less_than(a: semver.Semver | quantity.Quantity, b: semver.Semver | quantity.Quantity) -> celtypes.BoolType:
+    if isinstance(a, semver.Semver):
+        return semver.is_less_than(a, typing.cast("semver.Semver", b))
+    return quantity.is_less_than(a, typing.cast("quantity.Quantity", b))
 
 
 # Registered into every celpy program. celpy dispatches method-call syntax
@@ -147,7 +156,7 @@ class _DefaultMap(celtypes.MapType):
     errors, because the inner maps are plain MapTypes.
     """
 
-    def __missing__(self, key):
+    def __missing__(self, key: celtypes.MapKeyTypes) -> celtypes.MapType:
         return celtypes.MapType()
 
 
@@ -236,7 +245,8 @@ def _device_activation(device: dict) -> celtypes.MapType:
     for name, raw in device.get("attributes", {}).items():
         domain, ident = _split_qualified(name, driver)
         bucket = typing.cast(celtypes.MapType, attributes.setdefault(celtypes.StringType(domain), celtypes.MapType()))
-        bucket[celtypes.StringType(ident)] = _attribute_value(raw)
+        # celpy's MapType value type excludes the Semver extension type.
+        bucket[celtypes.StringType(ident)] = _attribute_value(raw)  # ty: ignore[invalid-assignment]
     out[celtypes.StringType("attributes")] = attributes
 
     capacity = _DefaultMap()
@@ -253,7 +263,7 @@ def _device_activation(device: dict) -> celtypes.MapType:
     return out
 
 
-def _attribute_value(entry: dict):
+def _attribute_value(entry: dict) -> semver.Semver | celtypes.Value:
     """Convert one typed attribute value object to its CEL value.
 
     A version attribute is pre-parsed to a Semver (strict), matching upstream

--- a/functions/compose-model-deployment/function/cel.py
+++ b/functions/compose-model-deployment/function/cel.py
@@ -89,6 +89,8 @@ surfaced via CELCompileError.
 
 from __future__ import annotations
 
+import typing
+
 import celpy
 from celpy import celtypes
 
@@ -160,7 +162,10 @@ class Program:
         # turns CELCompileError into an InvalidNodeSelector condition.
         try:
             ast = env.compile(expr)
-            self._prgm = env.program(ast, functions=_FUNCTIONS)
+            # celpy types extension functions as returning only its base value
+            # union, which excludes the Quantity and Semver types our functions
+            # return, so it rejects _FUNCTIONS despite celpy supporting them.
+            self._prgm = env.program(ast, functions=_FUNCTIONS)  # ty: ignore[invalid-argument-type]
         except Exception as e:
             raise CELCompileError(str(e)) from e
 
@@ -230,7 +235,7 @@ def _device_activation(device: dict) -> celtypes.MapType:
     attributes = _DefaultMap()
     for name, raw in device.get("attributes", {}).items():
         domain, ident = _split_qualified(name, driver)
-        bucket = attributes.setdefault(celtypes.StringType(domain), celtypes.MapType())
+        bucket = typing.cast(celtypes.MapType, attributes.setdefault(celtypes.StringType(domain), celtypes.MapType()))
         bucket[celtypes.StringType(ident)] = _attribute_value(raw)
     out[celtypes.StringType("attributes")] = attributes
 
@@ -240,8 +245,9 @@ def _device_activation(device: dict) -> celtypes.MapType:
         if value is None:
             continue
         domain, ident = _split_qualified(name, driver)
-        bucket = capacity.setdefault(celtypes.StringType(domain), celtypes.MapType())
-        bucket[celtypes.StringType(ident)] = quantity.quantity(value)
+        bucket = typing.cast(celtypes.MapType, capacity.setdefault(celtypes.StringType(domain), celtypes.MapType()))
+        # celpy's MapType value type excludes the Quantity extension type.
+        bucket[celtypes.StringType(ident)] = quantity.quantity(value)  # ty: ignore[invalid-assignment]
     out[celtypes.StringType("capacity")] = capacity
 
     return out

--- a/functions/compose-model-deployment/function/cel.py
+++ b/functions/compose-model-deployment/function/cel.py
@@ -268,10 +268,3 @@ def _attribute_value(entry: dict):
             return celpy.json_to_cel(entry[field])
     # No supported value: upstream returns "unsupported attribute value" error.
     raise ValueError("unsupported attribute value")
-
-
-def compile_selector(expr: str | None) -> Program | None:
-    """Compile a DRA CEL selector, or None if there is none."""
-    if not expr:
-        return None
-    return Program(expr)

--- a/functions/compose-model-deployment/function/fn.py
+++ b/functions/compose-model-deployment/function/fn.py
@@ -88,7 +88,7 @@ class Resolution(enum.Enum):
     PRESENT = "present"  # Resolved and found.
 
 
-def resolve_required(req, name: str) -> tuple[Resolution, dict | None]:
+def resolve_required(req: fnv1.RunFunctionRequest, name: str) -> tuple[Resolution, dict | None]:
     """Classify a required resource into a Resolution and its value.
 
     Returns (PRESENT, resource) when one was found, (ABSENT, None) when the
@@ -135,7 +135,7 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp) -> None:
+    def __init__(self, req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.ModelDeployment(**resource.struct_to_dict(req.observed.composite.resource))
@@ -248,7 +248,7 @@ class Composer:
 
         return True
 
-    def resolve_cache_footprint(self, ref) -> tuple[Resolution, dict[str, str] | None]:
+    def resolve_cache_footprint(self, ref: v1alpha1.ModelCacheRef) -> tuple[Resolution, dict[str, str] | None]:
         """Resolve the cluster footprint of the ModelCache named by ref.
 
         Returns a (Resolution, matchLabels) pair:
@@ -322,7 +322,7 @@ class Composer:
         # constraint beyond the deployment's own selector.
         return resolution, {}
 
-    def schedule(self):
+    def schedule(self) -> list[scheduling.Candidate]:
         """Match the deployment's engines against available clusters."""
         matched = scheduling.schedule(self.xr, self.clusters, self.all_replicas, fill=self.fill)
 
@@ -340,7 +340,7 @@ class Composer:
 
         return matched
 
-    def compose_replicas(self, matched) -> None:
+    def compose_replicas(self, matched: list[scheduling.Candidate]) -> None:
         """Compose a ModelReplica per matched cluster.
 
         Each replica mirrors the deployment's engines with the scheduler's
@@ -381,7 +381,7 @@ class Composer:
                 )
             resource.update(self.rsp.desired.resources[replica_key], replica)
 
-    def _replica_engine(self, engine, placement):
+    def _replica_engine(self, engine: v1alpha1.Engine, placement: scheduling.EnginePlacement) -> mrv1alpha1.Engine:
         """Build a ModelReplica engine from a deployment engine + placement.
 
         The engine keeps its name, copies, phase, and member templates verbatim;
@@ -428,7 +428,7 @@ class Composer:
             replica_engine.phase = engine.phase
         return replica_engine
 
-    def compose_endpoints(self, matched) -> None:
+    def compose_endpoints(self, matched: list[scheduling.Candidate]) -> None:
         """Compose one ModelEndpoint per matched replica.
 
         Endpoints are labeled with the deployment name so a ModelService
@@ -490,7 +490,7 @@ class Composer:
                 ),
             )
 
-    def write_status(self, matched) -> None:
+    def write_status(self, matched: list[scheduling.Candidate]) -> None:
         """Write deployment status: replica counts."""
         replicas_ready = sum(
             1
@@ -503,7 +503,7 @@ class Composer:
         )
         resource.update_status(self.rsp.desired.composite, status)
 
-    def derive_conditions(self, matched) -> None:
+    def derive_conditions(self, matched: list[scheduling.Candidate]) -> None:
         """Derive ReplicasScheduled and ReplicasReady. Per-resource
         readiness is marked here too."""
         self.derive_replicas_scheduled(matched)
@@ -515,7 +515,7 @@ class Composer:
         if not matched:
             self.rsp.desired.composite.ready = fnv1.READY_FALSE
 
-    def derive_replicas_scheduled(self, matched) -> None:
+    def derive_replicas_scheduled(self, matched: list[scheduling.Candidate]) -> None:
         """ReplicasScheduled: replicas placed and created."""
         any_observed = any(name.replica_key(c) in self.req.observed.resources for c in matched)
         scheduled = len(matched) > 0 and any_observed
@@ -541,7 +541,7 @@ class Composer:
             ),
         )
 
-    def derive_replicas_ready(self, matched) -> None:
+    def derive_replicas_ready(self, matched: list[scheduling.Candidate]) -> None:
         """ReplicasReady: all replicas are serving traffic."""
         replicas_ready = 0
         for c in matched:
@@ -572,7 +572,7 @@ class Composer:
             ),
         )
 
-    def mark_endpoint_readiness(self, matched) -> None:
+    def mark_endpoint_readiness(self, matched: list[scheduling.Candidate]) -> None:
         """Mark each composed ModelEndpoint Ready when observed Ready."""
         for c in matched:
             endpoint_key = name.endpoint_key(c)

--- a/functions/compose-model-deployment/function/fn.py
+++ b/functions/compose-model-deployment/function/fn.py
@@ -265,7 +265,7 @@ class Composer:
             api_version="modelplane.ai/v1alpha1",
             kind="ModelCache",
             match_name=ref.name,
-            namespace=self.xr.metadata.namespace,
+            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
         )
 
         resolution, cache_dict = resolve_required(self.req, "cache")
@@ -352,10 +352,10 @@ class Composer:
 
             replica = mrv1alpha1.ModelReplica(
                 metadata=metav1.ObjectMeta(
-                    name=name.replica(self.xr.metadata.name, cluster_info),
-                    namespace=self.xr.metadata.namespace,
+                    name=name.replica(self.xr.metadata.name, cluster_info),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     labels={
-                        _LABEL_DEPLOYMENT: self.xr.metadata.name,
+                        _LABEL_DEPLOYMENT: self.xr.metadata.name,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                         _LABEL_CLUSTER: cluster_info.name,
                         _LABEL_INDEX: str(cluster_info.index),
                     },
@@ -460,8 +460,8 @@ class Composer:
             # The replica name (== the ModelReplica and the backend's workload
             # resources) is the per-placement routing key. Must match the name
             # composed in compose_replicas so routing lands on this replica.
-            replica_name = name.replica(self.xr.metadata.name, cluster_info)
-            rewrite_path = f"/{self.xr.metadata.namespace}/{replica_name}/"
+            replica_name = name.replica(self.xr.metadata.name, cluster_info)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+            rewrite_path = f"/{self.xr.metadata.namespace}/{replica_name}/"  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
             endpoint_key = name.endpoint_key(cluster_info)
             url = f"{_GATEWAY_SCHEME}://{cluster_info.gateway_address}{rewrite_path}v1"
 
@@ -470,9 +470,9 @@ class Composer:
                 mev1alpha1.ModelEndpoint(
                     metadata=metav1.ObjectMeta(
                         name=replica_name,
-                        namespace=self.xr.metadata.namespace,
+                        namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                         labels={
-                            _LABEL_DEPLOYMENT: self.xr.metadata.name,
+                            _LABEL_DEPLOYMENT: self.xr.metadata.name,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                             _LABEL_CLUSTER: cluster_info.name,
                             _LABEL_INDEX: str(cluster_info.index),
                         },

--- a/functions/compose-model-deployment/function/fn.py
+++ b/functions/compose-model-deployment/function/fn.py
@@ -139,6 +139,10 @@ class Composer:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.ModelDeployment(**resource.struct_to_dict(req.observed.composite.resource))
+        # The deployment's name and namespace are always set on the observed
+        # composite read from the API server.
+        assert self.xr.metadata is not None and self.xr.metadata.name is not None
+        self.name: str = self.xr.metadata.name
 
         # Required resources — set by resolve_inputs.
         self.clusters = []
@@ -354,10 +358,10 @@ class Composer:
 
             replica = mrv1alpha1.ModelReplica(
                 metadata=metav1.ObjectMeta(
-                    name=name.replica(self.xr.metadata.name, cluster_info),  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+                    name=name.replica(self.name, cluster_info),
                     namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     labels={
-                        _LABEL_DEPLOYMENT: self.xr.metadata.name,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                        _LABEL_DEPLOYMENT: self.name,
                         _LABEL_CLUSTER: cluster_info.name,
                         _LABEL_INDEX: str(cluster_info.index),
                     },
@@ -462,7 +466,7 @@ class Composer:
             # The replica name (== the ModelReplica and the backend's workload
             # resources) is the per-placement routing key. Must match the name
             # composed in compose_replicas so routing lands on this replica.
-            replica_name = name.replica(self.xr.metadata.name, cluster_info)  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+            replica_name = name.replica(self.name, cluster_info)
             rewrite_path = f"/{self.xr.metadata.namespace}/{replica_name}/"  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
             endpoint_key = name.endpoint_key(cluster_info)
             url = f"{_GATEWAY_SCHEME}://{cluster_info.gateway_address}{rewrite_path}v1"
@@ -474,7 +478,7 @@ class Composer:
                         name=replica_name,
                         namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                         labels={
-                            _LABEL_DEPLOYMENT: self.xr.metadata.name,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                            _LABEL_DEPLOYMENT: self.name,
                             _LABEL_CLUSTER: cluster_info.name,
                             _LABEL_INDEX: str(cluster_info.index),
                         },

--- a/functions/compose-model-deployment/function/fn.py
+++ b/functions/compose-model-deployment/function/fn.py
@@ -354,7 +354,7 @@ class Composer:
 
             replica = mrv1alpha1.ModelReplica(
                 metadata=metav1.ObjectMeta(
-                    name=name.replica(self.xr.metadata.name, cluster_info),  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                    name=name.replica(self.xr.metadata.name, cluster_info),  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
                     namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     labels={
                         _LABEL_DEPLOYMENT: self.xr.metadata.name,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
@@ -462,7 +462,7 @@ class Composer:
             # The replica name (== the ModelReplica and the backend's workload
             # resources) is the per-placement routing key. Must match the name
             # composed in compose_replicas so routing lands on this replica.
-            replica_name = name.replica(self.xr.metadata.name, cluster_info)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+            replica_name = name.replica(self.xr.metadata.name, cluster_info)  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
             rewrite_path = f"/{self.xr.metadata.namespace}/{replica_name}/"  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
             endpoint_key = name.endpoint_key(cluster_info)
             url = f"{_GATEWAY_SCHEME}://{cluster_info.gateway_address}{rewrite_path}v1"

--- a/functions/compose-model-deployment/function/fn.py
+++ b/functions/compose-model-deployment/function/fn.py
@@ -117,7 +117,7 @@ def _inference_cluster(
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
@@ -135,7 +135,7 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp):
+    def __init__(self, req, rsp) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.ModelDeployment(**resource.struct_to_dict(req.observed.composite.resource))
@@ -154,7 +154,7 @@ class Composer:
         # the (then-unknown) cache footprint. Set by resolve_inputs.
         self.fill = True
 
-    def compose(self):
+    def compose(self) -> None:
         if not self.resolve_inputs():
             return
         try:
@@ -179,7 +179,7 @@ class Composer:
         self.write_status(matched)
         self.derive_conditions(matched)
 
-    def resolve_inputs(self):
+    def resolve_inputs(self) -> bool:
         """Declare and fetch required resources. Returns False if critical
         inputs are missing."""
         # Candidate clusters are those matching the deployment's own
@@ -340,7 +340,7 @@ class Composer:
 
         return matched
 
-    def compose_replicas(self, matched):
+    def compose_replicas(self, matched) -> None:
         """Compose a ModelReplica per matched cluster.
 
         Each replica mirrors the deployment's engines with the scheduler's
@@ -428,7 +428,7 @@ class Composer:
             replica_engine.phase = engine.phase
         return replica_engine
 
-    def compose_endpoints(self, matched):
+    def compose_endpoints(self, matched) -> None:
         """Compose one ModelEndpoint per matched replica.
 
         Endpoints are labeled with the deployment name so a ModelService
@@ -490,7 +490,7 @@ class Composer:
                 ),
             )
 
-    def write_status(self, matched):
+    def write_status(self, matched) -> None:
         """Write deployment status: replica counts."""
         replicas_ready = sum(
             1
@@ -503,7 +503,7 @@ class Composer:
         )
         resource.update_status(self.rsp.desired.composite, status)
 
-    def derive_conditions(self, matched):
+    def derive_conditions(self, matched) -> None:
         """Derive ReplicasScheduled and ReplicasReady. Per-resource
         readiness is marked here too."""
         self.derive_replicas_scheduled(matched)
@@ -515,7 +515,7 @@ class Composer:
         if not matched:
             self.rsp.desired.composite.ready = fnv1.READY_FALSE
 
-    def derive_replicas_scheduled(self, matched):
+    def derive_replicas_scheduled(self, matched) -> None:
         """ReplicasScheduled: replicas placed and created."""
         any_observed = any(name.replica_key(c) in self.req.observed.resources for c in matched)
         scheduled = len(matched) > 0 and any_observed
@@ -541,7 +541,7 @@ class Composer:
             ),
         )
 
-    def derive_replicas_ready(self, matched):
+    def derive_replicas_ready(self, matched) -> None:
         """ReplicasReady: all replicas are serving traffic."""
         replicas_ready = 0
         for c in matched:
@@ -572,7 +572,7 @@ class Composer:
             ),
         )
 
-    def mark_endpoint_readiness(self, matched):
+    def mark_endpoint_readiness(self, matched) -> None:
         """Mark each composed ModelEndpoint Ready when observed Ready."""
         for c in matched:
             endpoint_key = name.endpoint_key(c)

--- a/functions/compose-model-deployment/function/fn.py
+++ b/functions/compose-model-deployment/function/fn.py
@@ -70,6 +70,20 @@ _LABEL_INDEX = "modelplane.ai/replica-index"
 _GATEWAY_SCHEME = "http"
 
 
+def _name(meta: metav1.ObjectMeta | None) -> str:
+    """The object's name, always set on resources read from the API server."""
+    if meta is None or meta.name is None:
+        raise ValueError("metadata.name is unexpectedly absent")
+    return meta.name
+
+
+def _namespace(meta: metav1.ObjectMeta | None) -> str:
+    """The object's namespace, always set on namespaced resources read from the API server."""
+    if meta is None or meta.namespace is None:
+        raise ValueError("metadata.namespace is unexpectedly absent")
+    return meta.namespace
+
+
 # TODO(https://github.com/crossplane/function-sdk-python/issues/217): Replace
 # Resolution and resolve_required with the SDK helper once it lands upstream.
 class Resolution(enum.Enum):
@@ -139,10 +153,6 @@ class Composer:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.ModelDeployment(**resource.struct_to_dict(req.observed.composite.resource))
-        # The deployment's name and namespace are always set on the observed
-        # composite read from the API server.
-        assert self.xr.metadata is not None and self.xr.metadata.name is not None
-        self.name: str = self.xr.metadata.name
 
         # Required resources — set by resolve_inputs.
         self.clusters = []
@@ -271,7 +281,7 @@ class Composer:
             api_version="modelplane.ai/v1alpha1",
             kind="ModelCache",
             match_name=ref.name,
-            namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+            namespace=_namespace(self.xr.metadata),
         )
 
         resolution, cache_dict = resolve_required(self.req, "cache")
@@ -358,10 +368,10 @@ class Composer:
 
             replica = mrv1alpha1.ModelReplica(
                 metadata=metav1.ObjectMeta(
-                    name=name.replica(self.name, cluster_info),
-                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                    name=name.replica(_name(self.xr.metadata), cluster_info),
+                    namespace=_namespace(self.xr.metadata),
                     labels={
-                        _LABEL_DEPLOYMENT: self.name,
+                        _LABEL_DEPLOYMENT: _name(self.xr.metadata),
                         _LABEL_CLUSTER: cluster_info.name,
                         _LABEL_INDEX: str(cluster_info.index),
                     },
@@ -466,8 +476,8 @@ class Composer:
             # The replica name (== the ModelReplica and the backend's workload
             # resources) is the per-placement routing key. Must match the name
             # composed in compose_replicas so routing lands on this replica.
-            replica_name = name.replica(self.name, cluster_info)
-            rewrite_path = f"/{self.xr.metadata.namespace}/{replica_name}/"  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+            replica_name = name.replica(_name(self.xr.metadata), cluster_info)
+            rewrite_path = f"/{_namespace(self.xr.metadata)}/{replica_name}/"
             endpoint_key = name.endpoint_key(cluster_info)
             url = f"{_GATEWAY_SCHEME}://{cluster_info.gateway_address}{rewrite_path}v1"
 
@@ -476,9 +486,9 @@ class Composer:
                 mev1alpha1.ModelEndpoint(
                     metadata=metav1.ObjectMeta(
                         name=replica_name,
-                        namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                        namespace=_namespace(self.xr.metadata),
                         labels={
-                            _LABEL_DEPLOYMENT: self.name,
+                            _LABEL_DEPLOYMENT: _name(self.xr.metadata),
                             _LABEL_CLUSTER: cluster_info.name,
                             _LABEL_INDEX: str(cluster_info.index),
                         },

--- a/functions/compose-model-deployment/function/fn.py
+++ b/functions/compose-model-deployment/function/fn.py
@@ -114,14 +114,16 @@ def _inference_cluster(
     return ic
 
 
-class FunctionRunner(grpcv1.FunctionRunnerService):
+class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
     def __init__(self):
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
-    async def RunFunction(self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext) -> fnv1.RunFunctionResponse:
+    async def RunFunction(
+        self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext | None
+    ) -> fnv1.RunFunctionResponse:  # ty: ignore[invalid-method-override]  # the generated grpc servicer base is untyped
         """Run the function."""
         log = self.log.bind(tag=req.meta.tag)
         log.info("Running function")

--- a/functions/compose-model-deployment/function/name.py
+++ b/functions/compose-model-deployment/function/name.py
@@ -29,6 +29,10 @@ agree. Two kinds of identifier live here:
 """
 
 import hashlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from function import scheduling
 
 # DNS label limit and hash suffix length for opaque child names, matching
 # crossplane's resource.child_name so names stay valid 63-char DNS labels.
@@ -54,7 +58,7 @@ def opaque_name(visible: str, *discriminators: str) -> str:
     return f"{prefix}-{h}"
 
 
-def replica(deployment_name: str, candidate) -> str:
+def replica(deployment_name: str, candidate: "scheduling.Candidate") -> str:
     """The opaque, DNS-safe name for a replica's resources.
 
     Hashed from (deployment, cluster, index) so co-located replicas get distinct
@@ -65,7 +69,7 @@ def replica(deployment_name: str, candidate) -> str:
     return opaque_name(deployment_name, candidate.name, str(candidate.index))
 
 
-def replica_key(candidate) -> str:
+def replica_key(candidate: "scheduling.Candidate") -> str:
     """Function-local desired-resource handle for a replica's (cluster, index).
 
     Distinct per co-located replica so two replicas on one cluster don't share a
@@ -75,6 +79,6 @@ def replica_key(candidate) -> str:
     return f"replica-{candidate.name}-{candidate.index}"
 
 
-def endpoint_key(candidate) -> str:
+def endpoint_key(candidate: "scheduling.Candidate") -> str:
     """Function-local desired-resource handle for a replica's ModelEndpoint."""
     return f"endpoint-{candidate.name}-{candidate.index}"

--- a/functions/compose-model-deployment/function/quantity.py
+++ b/functions/compose-model-deployment/function/quantity.py
@@ -175,19 +175,19 @@ class Quantity:
     def __init__(self, value: decimal.Decimal) -> None:
         self.value = value
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, Quantity) and self.value == other.value
 
     def __hash__(self) -> int:
         return hash(self.value)
 
 
-def quantity(s) -> Quantity:
+def quantity(s: str) -> Quantity:
     """The CEL quantity(<string>) constructor."""
     return Quantity(parse(s))
 
 
-def is_quantity(s) -> celtypes.BoolType:
+def is_quantity(s: str) -> celtypes.BoolType:
     """The CEL isQuantity(<string>) predicate.
 
     Returns false for any parse failure, mirroring upstream (isQuantity is true
@@ -232,15 +232,15 @@ def as_approximate_float(a: Quantity) -> celtypes.DoubleType:
     return celtypes.DoubleType(float(a.value))
 
 
-def add(a: Quantity, b) -> Quantity:
+def add(a: Quantity, b: Quantity | int) -> Quantity:
     return Quantity(a.value + _operand(b))
 
 
-def sub(a: Quantity, b) -> Quantity:
+def sub(a: Quantity, b: Quantity | int) -> Quantity:
     return Quantity(a.value - _operand(b))
 
 
-def _operand(b) -> decimal.Decimal:
+def _operand(b: Quantity | int) -> decimal.Decimal:
     """add/sub accept a Quantity or an integer (upstream has both overloads)."""
     if isinstance(b, Quantity):
         return b.value

--- a/functions/compose-model-deployment/function/quantity.py
+++ b/functions/compose-model-deployment/function/quantity.py
@@ -172,7 +172,7 @@ class Quantity:
 
     __slots__ = ("value",)
 
-    def __init__(self, value: decimal.Decimal):
+    def __init__(self, value: decimal.Decimal) -> None:
         self.value = value
 
     def __eq__(self, other) -> bool:

--- a/functions/compose-model-deployment/function/scheduling.py
+++ b/functions/compose-model-deployment/function/scheduling.py
@@ -79,8 +79,16 @@ from dataclasses import dataclass, field
 from models.ai.modelplane.inferencecluster import v1alpha1 as icv1alpha1
 from models.ai.modelplane.modeldeployment import v1alpha1 as mdv1alpha1
 from models.ai.modelplane.modelreplica import v1alpha1 as mrv1alpha1
+from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
 
 from function import cel
+
+
+def _name(meta: metav1.ObjectMeta | None) -> str:
+    """The object's name, which is always set on resources read from the API server."""
+    assert meta is not None and meta.name is not None
+    return meta.name
+
 
 # A deployment Member and a replica Member are distinct generated classes with
 # the same shape (a deployment fans out to identically-shaped replicas).
@@ -297,7 +305,7 @@ def _cluster_ready(cluster: icv1alpha1.InferenceCluster) -> bool:
     receive routed traffic. Both must be true for the cluster to be
     schedulable for new placements.
     """
-    if not cluster.status.gateway or not cluster.status.gateway.address:
+    if not cluster.status or not cluster.status.gateway or not cluster.status.gateway.address:
         return False
     return any(c.type == "Ready" and c.status == "True" for c in cluster.status.conditions or [])
 
@@ -383,9 +391,16 @@ def _member_cost(member: _CompiledMember, resolved: list[DeviceRequest]) -> int:
     return member.nodes if resolved else 0
 
 
+def _gpu_pools(cluster: icv1alpha1.InferenceCluster) -> list[icv1alpha1.GpuPool]:
+    """The cluster's published GPU pools, empty if it has none yet."""
+    if not cluster.status:
+        return []
+    return cluster.status.gpuPools or []
+
+
 def _pool_by_name(cluster: icv1alpha1.InferenceCluster, pool_name: str) -> icv1alpha1.GpuPool | None:
     """The cluster's published pool with this name, or None."""
-    for pool in cluster.status.gpuPools or []:
+    for pool in _gpu_pools(cluster):
         if (pool.name or "") == pool_name:
             return pool
     return None
@@ -393,7 +408,7 @@ def _pool_by_name(cluster: icv1alpha1.InferenceCluster, pool_name: str) -> icv1a
 
 def _is_ours(replica: mrv1alpha1.ModelReplica, deployment: mdv1alpha1.ModelDeployment) -> bool:
     """Whether a replica belongs to this deployment."""
-    return (replica.metadata.labels or {}).get(_LABEL_DEPLOYMENT) == deployment.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+    return (replica.metadata.labels or {}).get(_LABEL_DEPLOYMENT) == _name(deployment.metadata)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
 
 
 def _replica_index(replica: mrv1alpha1.ModelReplica) -> int:
@@ -404,9 +419,11 @@ def _replica_index(replica: mrv1alpha1.ModelReplica) -> int:
     natural single-replica-per-cluster case those replicas came from.
     """
     raw = (replica.metadata.labels or {}).get(_LABEL_INDEX)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+    if raw is None:
+        return 0
     try:
         return int(raw)
-    except (TypeError, ValueError):
+    except ValueError:
         return 0
 
 
@@ -478,8 +495,8 @@ def _build_ledger(
     """
     free: dict[tuple[str, str], int] = {}
     for cluster in clusters:
-        name = cluster.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
-        for pool in cluster.status.gpuPools or []:
+        name = _name(cluster.metadata)
+        for pool in _gpu_pools(cluster):
             free[(name, pool.name or "")] = _published_count(pool.nodes)
 
     def charge(cluster_name: str, pool_name: str, nodes: int) -> None:
@@ -677,14 +694,12 @@ def _place_engines(
     (disjoint pools). Overlapping selectors across engines of one replica are the
     case that can false-reject.
     """
-    cluster_name = cluster.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+    cluster_name = _name(cluster.metadata)
     # Trial free counts for this cluster's pools, decremented as we place each
     # member so a later member sees capacity an earlier one took. Discarded
     # wholesale when any member fails to place, so partial placement never
     # leaks into the real ledger.
-    trial = {
-        (pool.name or ""): ledger.available(cluster_name, pool.name or "") for pool in cluster.status.gpuPools or []
-    }
+    trial = {(pool.name or ""): ledger.available(cluster_name, pool.name or "") for pool in _gpu_pools(cluster)}
     placements: list[EnginePlacement] = []
     for engine in engines:
         members = _place_engine(cluster, engine, trial)
@@ -726,7 +741,7 @@ def _place_engine(
     Decrements trial as it places; on failure the caller discards the whole
     trial, so partial decrements don't leak.
     """
-    pools = cluster.status.gpuPools or []
+    pools = _gpu_pools(cluster)
     # Whether each member's requests resolve a claimable device on any pool of
     # this cluster, ignoring capacity. Used to refuse a placement that would
     # strand a claim-capable member on a pool where it resolves only synthetic
@@ -802,14 +817,14 @@ def _fill(
         if choice is None:
             break
         cluster, placements = choice
-        name = cluster.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+        name = _name(cluster.metadata)
         index = _lowest_free_index(used_indices.setdefault(name, set()))
 
         placed.append(
             Candidate(
                 name=name,
                 index=index,
-                gateway_address=cluster.status.gateway.address,
+                gateway_address=_gateway_address(cluster),
                 engines=placements,
             )
         )
@@ -852,7 +867,7 @@ def _pick_cluster(
         placements = _place_engines(cluster, engines, ledger)
         if placements is None:
             continue
-        key = (load.get(cluster.metadata.name, 0), cluster.metadata.name)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+        key = (load.get(_name(cluster.metadata), 0), _name(cluster.metadata))
         if best_key is None or key < best_key:
             best_key = key
             best = (cluster, placements)
@@ -869,7 +884,9 @@ def _lowest_free_index(used: set[int]) -> int:
 
 def _gateway_address(cluster: icv1alpha1.InferenceCluster) -> str:
     """The cluster's gateway address, or empty when degraded/unset."""
-    return (cluster.status.gateway.address if cluster.status.gateway else "") or ""
+    if not cluster.status or not cluster.status.gateway:
+        return ""
+    return cluster.status.gateway.address or ""
 
 
 def _scale_down(retained: list[Candidate], desired: int) -> list[Candidate]:
@@ -920,7 +937,7 @@ def schedule(
     absence can't evict a pinned replica.
     """
     desired = int(deployment.spec.replicas)
-    clusters_by_name = {c.metadata.name: c for c in clusters}  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+    clusters_by_name = {_name(c.metadata): c for c in clusters}
 
     # Sort observed replicas by name (unique per object) so the schedule is a
     # deterministic function of state, not of the order Crossplane happened to

--- a/functions/compose-model-deployment/function/scheduling.py
+++ b/functions/compose-model-deployment/function/scheduling.py
@@ -85,9 +85,17 @@ from function import cel
 
 
 def _name(meta: metav1.ObjectMeta | None) -> str:
-    """The object's name, which is always set on resources read from the API server."""
-    assert meta is not None and meta.name is not None
+    """The object's name, always set on resources read from the API server."""
+    if meta is None or meta.name is None:
+        raise ValueError("metadata.name is unexpectedly absent")
     return meta.name
+
+
+def _labels(meta: metav1.ObjectMeta | None) -> dict[str, str]:
+    """The object's labels, empty when it has none."""
+    if meta is None or meta.labels is None:
+        return {}
+    return meta.labels
 
 
 # A deployment Member and a replica Member are distinct generated classes with
@@ -408,7 +416,7 @@ def _pool_by_name(cluster: icv1alpha1.InferenceCluster, pool_name: str) -> icv1a
 
 def _is_ours(replica: mrv1alpha1.ModelReplica, deployment: mdv1alpha1.ModelDeployment) -> bool:
     """Whether a replica belongs to this deployment."""
-    return (replica.metadata.labels or {}).get(_LABEL_DEPLOYMENT) == _name(deployment.metadata)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+    return _labels(replica.metadata).get(_LABEL_DEPLOYMENT) == _name(deployment.metadata)
 
 
 def _replica_index(replica: mrv1alpha1.ModelReplica) -> int:
@@ -418,7 +426,7 @@ def _replica_index(replica: mrv1alpha1.ModelReplica) -> int:
     label existed (or with a malformed value) is treated as index 0; that's the
     natural single-replica-per-cluster case those replicas came from.
     """
-    raw = (replica.metadata.labels or {}).get(_LABEL_INDEX)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+    raw = _labels(replica.metadata).get(_LABEL_INDEX)
     if raw is None:
         return 0
     try:

--- a/functions/compose-model-deployment/function/scheduling.py
+++ b/functions/compose-model-deployment/function/scheduling.py
@@ -393,7 +393,7 @@ def _pool_by_name(cluster: icv1alpha1.InferenceCluster, pool_name: str) -> icv1a
 
 def _is_ours(replica: mrv1alpha1.ModelReplica, deployment: mdv1alpha1.ModelDeployment) -> bool:
     """Whether a replica belongs to this deployment."""
-    return (replica.metadata.labels or {}).get(_LABEL_DEPLOYMENT) == deployment.metadata.name
+    return (replica.metadata.labels or {}).get(_LABEL_DEPLOYMENT) == deployment.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
 
 
 def _replica_index(replica: mrv1alpha1.ModelReplica) -> int:
@@ -403,7 +403,7 @@ def _replica_index(replica: mrv1alpha1.ModelReplica) -> int:
     label existed (or with a malformed value) is treated as index 0; that's the
     natural single-replica-per-cluster case those replicas came from.
     """
-    raw = (replica.metadata.labels or {}).get(_LABEL_INDEX)
+    raw = (replica.metadata.labels or {}).get(_LABEL_INDEX)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
     try:
         return int(raw)
     except (TypeError, ValueError):
@@ -478,7 +478,7 @@ def _build_ledger(
     """
     free: dict[tuple[str, str], int] = {}
     for cluster in clusters:
-        name = cluster.metadata.name
+        name = cluster.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
         for pool in cluster.status.gpuPools or []:
             free[(name, pool.name or "")] = _published_count(pool.nodes)
 
@@ -677,7 +677,7 @@ def _place_engines(
     (disjoint pools). Overlapping selectors across engines of one replica are the
     case that can false-reject.
     """
-    cluster_name = cluster.metadata.name
+    cluster_name = cluster.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
     # Trial free counts for this cluster's pools, decremented as we place each
     # member so a later member sees capacity an earlier one took. Discarded
     # wholesale when any member fails to place, so partial placement never
@@ -802,7 +802,7 @@ def _fill(
         if choice is None:
             break
         cluster, placements = choice
-        name = cluster.metadata.name
+        name = cluster.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
         index = _lowest_free_index(used_indices.setdefault(name, set()))
 
         placed.append(
@@ -852,7 +852,7 @@ def _pick_cluster(
         placements = _place_engines(cluster, engines, ledger)
         if placements is None:
             continue
-        key = (load.get(cluster.metadata.name, 0), cluster.metadata.name)
+        key = (load.get(cluster.metadata.name, 0), cluster.metadata.name)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
         if best_key is None or key < best_key:
             best_key = key
             best = (cluster, placements)
@@ -920,7 +920,7 @@ def schedule(
     absence can't evict a pinned replica.
     """
     desired = int(deployment.spec.replicas)
-    clusters_by_name = {c.metadata.name: c for c in clusters}
+    clusters_by_name = {c.metadata.name: c for c in clusters}  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
 
     # Sort observed replicas by name (unique per object) so the schedule is a
     # deterministic function of state, not of the order Crossplane happened to

--- a/functions/compose-model-deployment/function/semver.py
+++ b/functions/compose-model-deployment/function/semver.py
@@ -39,7 +39,7 @@ _ALPHANUM = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-0123456789
 _SEMVER_PARTS = 3
 
 
-def _cmp(a, b) -> int:
+def _cmp[T: (int, str)](a: T, b: T) -> int:
     # Three-way compare: -1, 0, or +1, like Go's cmp/blang's Compare. Python has
     # no built-in spaceship operator; (a > b) - (a < b) evaluates the two bools
     # to 0/1 and subtracts, yielding -1/0/+1 without branching.
@@ -157,7 +157,7 @@ class Semver:
     # Equality and hashing are defined together (an object that defines __eq__
     # without __hash__ becomes unhashable) so a Semver can be a dict key / set
     # member, and so == agrees with precedence comparison.
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         # Equal iff precedence-equal. Note this means build metadata doesn't
         # affect equality, consistent with it being ignored for ordering.
         return isinstance(other, Semver) and self.compare(other) == 0
@@ -252,14 +252,14 @@ def _normalize_and_parse(s: str) -> Semver:
     return parse(".".join(parts))
 
 
-def semver(s, normalize=None) -> Semver:
+def semver(s: str, normalize: celtypes.BoolType | None = None) -> Semver:
     """The CEL semver(<string>[, <bool>]) constructor."""
     if normalize is not None and bool(normalize):
         return _normalize_and_parse(s)
     return parse(s)
 
 
-def is_semver(s, normalize=None) -> celtypes.BoolType:
+def is_semver(s: str, normalize: celtypes.BoolType | None = None) -> celtypes.BoolType:
     """The CEL isSemver(<string>[, <bool>]) predicate.
 
     Returns false for any parse failure, mirroring upstream (isSemver is true

--- a/functions/compose-model-deployment/function/semver.py
+++ b/functions/compose-model-deployment/function/semver.py
@@ -76,7 +76,7 @@ class _PRVersion:
     # attribute-access savings are worth the rigidity.
     __slots__ = ("is_num", "num", "string")
 
-    def __init__(self, s: str):
+    def __init__(self, s: str) -> None:
         # An empty identifier (e.g. from "1.0.0-" or "1.0.0-a..b") is invalid.
         if s == "":
             raise ValueError("prerelease is empty")
@@ -124,7 +124,7 @@ class Semver:
     # a release version with no prerelease.
     __slots__ = ("major", "minor", "patch", "pre")
 
-    def __init__(self, major: int, minor: int, patch: int, pre: list[_PRVersion]):
+    def __init__(self, major: int, minor: int, patch: int, pre: list[_PRVersion]) -> None:
         self.major = major
         self.minor = minor
         self.patch = patch

--- a/functions/compose-model-deployment/tests/test_cel.py
+++ b/functions/compose-model-deployment/tests/test_cel.py
@@ -26,7 +26,12 @@ import unittest
 from function import cel
 
 
-def _device(driver="gpu.nvidia.com", attributes=None, capacity=None, **extra) -> dict:
+def _device(
+    driver: str = "gpu.nvidia.com",
+    attributes: dict | None = None,
+    capacity: dict | None = None,
+    **extra: object,
+) -> dict:
     """A pool device in the raw dict shape cel.Program.matches expects."""
     return {
         "driver": driver,

--- a/functions/compose-model-deployment/tests/test_cel.py
+++ b/functions/compose-model-deployment/tests/test_cel.py
@@ -307,18 +307,14 @@ class TestMatches(unittest.TestCase):
         ]
         for case in cases:
             with self.subTest(case.name):
-                got = cel.compile_selector(case.expr).matches(case.device)
+                got = cel.Program(case.expr).matches(case.device)
                 self.assertEqual(case.want, got, f"{case.name}: -want, +got")
 
 
 class TestCompile(unittest.TestCase):
-    def test_compile_selector_none(self) -> None:
-        self.assertIsNone(cel.compile_selector(None))
-        self.assertIsNone(cel.compile_selector(""))
-
     def test_invalid_expression_raises(self) -> None:
         with self.assertRaises(cel.CELCompileError):
-            cel.compile_selector("not ) valid (")
+            cel.Program("not ) valid (")
 
 
 if __name__ == "__main__":

--- a/functions/compose-model-deployment/tests/test_fn.py
+++ b/functions/compose-model-deployment/tests/test_fn.py
@@ -17,6 +17,7 @@
 import dataclasses
 import datetime
 import unittest
+from typing import Any
 
 from crossplane.function import logging, resource
 from crossplane.function.proto.v1 import run_function_pb2 as fnv1
@@ -97,7 +98,7 @@ def _replica_engines(*, args: bool = True) -> list:
     args toggles the engine container's --model arg, matching the fixture
     deployment a want is built from.
     """
-    container = {"name": "engine", "image": "vllm/vllm-openai:latest"}
+    container: dict[str, Any] = {"name": "engine", "image": "vllm/vllm-openai:latest"}
     if args:
         container["args"] = ["--model=Qwen/Qwen3-0.6B"]
     return [

--- a/functions/compose-model-deployment/tests/test_fn.py
+++ b/functions/compose-model-deployment/tests/test_fn.py
@@ -15,6 +15,7 @@
 """Tests for the compose-model-deployment function."""
 
 import dataclasses
+import datetime
 import unittest
 
 from crossplane.function import logging, resource
@@ -32,6 +33,9 @@ from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
 # The selector used on the deployment's single GPU request, echoed verbatim
 # into each resolved device request.
 _GPU_CEL = 'device.driver == "gpu.nvidia.com"'
+
+# A fixed transition time keeps observed conditions deterministic.
+_TRANSITION_TIME = datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC)
 
 # The resolved DRA device requests the scheduler stamps onto each ModelReplica
 # member, derived from the deployment's nodeSelector matched against the
@@ -156,7 +160,7 @@ def _cluster(name: str, *, ready: bool = True, address: str | None = "10.0.0.1",
                     type="Ready",
                     status="True" if ready else "False",
                     reason="Available" if ready else "Unavailable",
-                    lastTransitionTime="2025-01-01T00:00:00Z",
+                    lastTransitionTime=_TRANSITION_TIME,
                 )
             ],
             gateway=icv1alpha1.Gateway(address=address) if address else None,

--- a/functions/compose-model-deployment/tests/test_fn.py
+++ b/functions/compose-model-deployment/tests/test_fn.py
@@ -284,7 +284,7 @@ def _req(
     observed: dict | None = None,
     cache: dict | None = None,
     cache_resolved_empty: bool = False,
-):
+) -> fnv1.RunFunctionRequest:
     """Build a RunFunctionRequest with the standard required_resources.
 
     clusters and replicas populate the "clusters" and "all-replicas" required

--- a/functions/compose-model-deployment/tests/test_quantity.py
+++ b/functions/compose-model-deployment/tests/test_quantity.py
@@ -44,7 +44,7 @@ from function import cel, quantity
 
 def _eval(expr: str) -> bool:
     """Compile and evaluate a deviceless boolean CEL expression."""
-    return cel.compile_selector(expr).matches({})
+    return cel.Program(expr).matches({})
 
 
 @dataclasses.dataclass

--- a/functions/compose-model-deployment/tests/test_scheduling.py
+++ b/functions/compose-model-deployment/tests/test_scheduling.py
@@ -66,7 +66,7 @@ def _request(name: str = "gpu", count: int = 1, cel_exprs: list[str] | None = No
     )
 
 
-def _template():
+def _template() -> mdv1alpha1.Template:
     return mdv1alpha1.Template(
         spec=mdv1alpha1.Spec(
             containers=[mdv1alpha1.Container(name="engine", image="vllm/vllm-openai:latest")],
@@ -115,7 +115,7 @@ def _deployment(
     count: int = 1,
     requests: list[mdv1alpha1.Device] | None = None,
     engines: list[mdv1alpha1.Engine] | None = None,
-):
+) -> mdv1alpha1.ModelDeployment:
     """Construct a ModelDeployment.
 
     The single-engine helpers map a node shape onto one engine: pipeline sets the
@@ -365,7 +365,14 @@ def _placement(
 # degraded/unplaced cluster carries no gateway. Cases that need a specific pool,
 # request, or engine layout pass `engines` explicitly.
 def _cand(
-    name: str, *, index: int = 0, pool: str = "default", device_requests=None, pipeline: int = 1, engines=None, **kwargs
+    name: str,
+    *,
+    index: int = 0,
+    pool: str = "default",
+    device_requests: list[scheduling.DeviceRequest] | None = None,
+    pipeline: int = 1,
+    engines: list[scheduling.EnginePlacement] | None = None,
+    **kwargs: str,
 ) -> scheduling.Candidate:
     if engines is None:
         engines = [_placement(pool=pool, device_requests=device_requests, pipeline=pipeline)]

--- a/functions/compose-model-deployment/tests/test_scheduling.py
+++ b/functions/compose-model-deployment/tests/test_scheduling.py
@@ -24,6 +24,7 @@ expressed as a device request's count, not derived from topology.
 """
 
 import dataclasses
+import datetime
 import unittest
 
 from function import cel, scheduling
@@ -31,6 +32,9 @@ from models.ai.modelplane.inferencecluster import v1alpha1 as icv1alpha1
 from models.ai.modelplane.modeldeployment import v1alpha1 as mdv1alpha1
 from models.ai.modelplane.modelreplica import v1alpha1 as mrv1alpha1
 from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
+
+# A fixed transition time keeps observed conditions deterministic.
+_TRANSITION_TIME = datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC)
 
 # A GPU memory selector reused across cases.
 _MEM_141 = 'device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("141Gi")) >= 0'
@@ -192,7 +196,7 @@ def _cluster(
             type="Ready",
             status=status,
             reason=reason,
-            lastTransitionTime="2025-01-01T00:00:00Z",
+            lastTransitionTime=_TRANSITION_TIME,
         )
     ]
 
@@ -315,6 +319,7 @@ def _collision_replica(
     the tiebreak the scheduler sorts on.
     """
     r = _replica_with_pool("my-model", cluster_name, pool=pool, index=index)
+    assert r.metadata is not None
     r.metadata.name = object_name
     return r
 

--- a/functions/compose-model-deployment/tests/test_semver.py
+++ b/functions/compose-model-deployment/tests/test_semver.py
@@ -36,7 +36,7 @@ from function import cel, semver
 
 def _eval(expr: str) -> bool:
     """Compile and evaluate a deviceless boolean CEL expression."""
-    return cel.compile_selector(expr).matches({})
+    return cel.Program(expr).matches({})
 
 
 @dataclasses.dataclass

--- a/functions/compose-model-endpoint/function/fn.py
+++ b/functions/compose-model-endpoint/function/fn.py
@@ -57,7 +57,7 @@ def _address_type(host: str) -> str:
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
@@ -75,12 +75,12 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp):
+    def __init__(self, req, rsp) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.ModelEndpoint(**resource.struct_to_dict(req.observed.composite.resource))
 
-    def compose(self):
+    def compose(self) -> None:
         host, port = self.parse_url()
         if host is None:
             return
@@ -109,7 +109,7 @@ class Composer:
         port = parsed.port or (443 if parsed.scheme == "https" else 80)
         return parsed.hostname, port
 
-    def compose_backend(self, host: str, port: int, address_type: str):
+    def compose_backend(self, host: str, port: int, address_type: str) -> None:
         """Compose a selectorless Service and EndpointSlice for the endpoint.
 
         The Service has no selector (Kubernetes will not auto-populate
@@ -166,7 +166,7 @@ class Composer:
                 },
             )
 
-    def write_status(self):
+    def write_status(self) -> None:
         """Surface the composed Service's name in status, but only once the
         EndpointSlice is observed too. ModelService treats backendName as
         routable, so we must not advertise it until the backing endpoint
@@ -183,7 +183,7 @@ class Composer:
 
         resource.update_status(self.rsp.desired.composite, status)
 
-    def derive_conditions(self):
+    def derive_conditions(self) -> None:
         """RoutingReady: both the Service and the EndpointSlice have been
         observed on the control plane."""
         svc_exists = SERVICE_RESOURCE_KEY in self.req.observed.resources

--- a/functions/compose-model-endpoint/function/fn.py
+++ b/functions/compose-model-endpoint/function/fn.py
@@ -75,23 +75,24 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp) -> None:
+    def __init__(self, req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.ModelEndpoint(**resource.struct_to_dict(req.observed.composite.resource))
 
     def compose(self) -> None:
-        host, port = self.parse_url()
-        if host is None:
+        parsed = self.parse_url()
+        if parsed is None:
             return
+        host, port = parsed
 
         self.compose_backend(host, port, _address_type(host))
         self.write_status()
         self.derive_conditions()
 
-    def parse_url(self):
-        """Parse spec.url into (host, port). Returns (None, None) and
-        marks the XR not-ready if the URL is invalid."""
+    def parse_url(self) -> tuple[str, int] | None:
+        """Parse spec.url into (host, port), or None (marking the XR not-ready)
+        if the URL is invalid."""
         parsed = urllib.parse.urlparse(self.xr.spec.url)
         if not parsed.hostname:
             response.set_conditions(
@@ -104,7 +105,7 @@ class Composer:
                 ),
             )
             response.warning(self.rsp, f"Invalid spec.url: {self.xr.spec.url}")
-            return None, None
+            return None
 
         port = parsed.port or (443 if parsed.scheme == "https" else 80)
         return parsed.hostname, port

--- a/functions/compose-model-endpoint/function/fn.py
+++ b/functions/compose-model-endpoint/function/fn.py
@@ -120,7 +120,7 @@ class Composer:
         Traefik's Gateway API provider explicitly rejects them. See
         https://github.com/traefik/traefik/blob/fa49e2bcad7ffd8a80accdf1fae1ae480913d93d/pkg/provider/kubernetes/gateway/kubernetes.go#L890.
         """
-        ns = self.xr.metadata.namespace
+        ns = self.xr.metadata.namespace  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
 
         resource.update(
             self.rsp.desired.resources[SERVICE_RESOURCE_KEY],

--- a/functions/compose-model-endpoint/function/fn.py
+++ b/functions/compose-model-endpoint/function/fn.py
@@ -102,20 +102,26 @@ class Composer:
         """Parse spec.url into (host, port), or None (marking the XR not-ready)
         if the URL is invalid."""
         parsed = urllib.parse.urlparse(self.xr.spec.url)
-        if not parsed.hostname:
+        try:
+            # .port parses lazily and raises on a non-integer port, e.g.
+            # https://host:abc.
+            port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        except ValueError:
+            port = None
+
+        if not parsed.hostname or port is None:
             response.set_conditions(
                 self.rsp,
                 resource.Condition(
                     typ=CONDITION_TYPE_ROUTING_READY,
                     status="False",
                     reason=CONDITION_REASON_INVALID_URL,
-                    message=f"spec.url has no host: {self.xr.spec.url}",
+                    message=f"Invalid spec.url: {self.xr.spec.url}",
                 ),
             )
             response.warning(self.rsp, f"Invalid spec.url: {self.xr.spec.url}")
             return None
 
-        port = parsed.port or (443 if parsed.scheme == "https" else 80)
         return parsed.hostname, port
 
     def compose_backend(self, host: str, port: int, address_type: str) -> None:

--- a/functions/compose-model-endpoint/function/fn.py
+++ b/functions/compose-model-endpoint/function/fn.py
@@ -33,6 +33,7 @@ from crossplane.function import logging, resource, response
 from crossplane.function.proto.v1 import run_function_pb2 as fnv1
 from crossplane.function.proto.v1 import run_function_pb2_grpc as grpcv1
 from models.ai.modelplane.modelendpoint import v1alpha1
+from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
 
 SERVICE_RESOURCE_KEY = "service"
 ENDPOINTSLICE_RESOURCE_KEY = "endpointslice"
@@ -43,6 +44,13 @@ CONDITION_TYPE_ROUTING_READY = "RoutingReady"
 CONDITION_REASON_BACKEND_CONFIGURED = "BackendConfigured"
 CONDITION_REASON_WAITING_FOR_BACKEND = "WaitingForBackend"
 CONDITION_REASON_INVALID_URL = "InvalidURL"
+
+
+def _namespace(meta: metav1.ObjectMeta | None) -> str:
+    """The object's namespace, always set on namespaced resources read from the API server."""
+    if meta is None or meta.namespace is None:
+        raise ValueError("metadata.namespace is unexpectedly absent")
+    return meta.namespace
 
 
 def _address_type(host: str) -> str:
@@ -123,7 +131,7 @@ class Composer:
         Traefik's Gateway API provider explicitly rejects them. See
         https://github.com/traefik/traefik/blob/fa49e2bcad7ffd8a80accdf1fae1ae480913d93d/pkg/provider/kubernetes/gateway/kubernetes.go#L890.
         """
-        ns = self.xr.metadata.namespace  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+        ns = _namespace(self.xr.metadata)
 
         resource.update(
             self.rsp.desired.resources[SERVICE_RESOURCE_KEY],

--- a/functions/compose-model-endpoint/function/fn.py
+++ b/functions/compose-model-endpoint/function/fn.py
@@ -54,14 +54,16 @@ def _address_type(host: str) -> str:
     return "IPv6" if isinstance(addr, ipaddress.IPv6Address) else "IPv4"
 
 
-class FunctionRunner(grpcv1.FunctionRunnerService):
+class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
     def __init__(self):
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
-    async def RunFunction(self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext) -> fnv1.RunFunctionResponse:
+    async def RunFunction(
+        self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext | None
+    ) -> fnv1.RunFunctionResponse:  # ty: ignore[invalid-method-override]  # the generated grpc servicer base is untyped
         """Run the function."""
         log = self.log.bind(tag=req.meta.tag)
         log.info("Running function")

--- a/functions/compose-model-endpoint/tests/test_fn.py
+++ b/functions/compose-model-endpoint/tests/test_fn.py
@@ -388,11 +388,42 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                             type="RoutingReady",
                             status=fnv1.STATUS_CONDITION_FALSE,
                             reason="InvalidURL",
-                            message="spec.url has no host: not-a-url",
+                            message="Invalid spec.url: not-a-url",
                         ),
                     ],
                     results=[
                         fnv1.Result(severity=fnv1.SEVERITY_WARNING, message="Invalid spec.url: not-a-url"),
+                    ],
+                    context=structpb.Struct(),
+                ),
+            ),
+            Case(
+                name="URL with a non-integer port produces a warning and no service",
+                req=fnv1.RunFunctionRequest(
+                    observed=fnv1.State(
+                        composite=fnv1.Resource(
+                            resource=resource.dict_to_struct(
+                                v1alpha1.ModelEndpoint(
+                                    metadata=metav1.ObjectMeta(name="test-endpoint", namespace="ml-team"),
+                                    spec=v1alpha1.Spec(url="https://host:abc"),
+                                ).model_dump(exclude_none=True, mode="json")
+                            ),
+                        ),
+                    ),
+                ),
+                want=fnv1.RunFunctionResponse(
+                    meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
+                    desired=fnv1.State(),
+                    conditions=[
+                        fnv1.Condition(
+                            type="RoutingReady",
+                            status=fnv1.STATUS_CONDITION_FALSE,
+                            reason="InvalidURL",
+                            message="Invalid spec.url: https://host:abc",
+                        ),
+                    ],
+                    results=[
+                        fnv1.Result(severity=fnv1.SEVERITY_WARNING, message="Invalid spec.url: https://host:abc"),
                     ],
                     context=structpb.Struct(),
                 ),

--- a/functions/compose-model-replica/function/backends/base.py
+++ b/functions/compose-model-replica/function/backends/base.py
@@ -65,7 +65,7 @@ def cache_mounts(replica: v1alpha1.ModelReplica) -> tuple[list[dict], list[dict]
     ref = replica.spec.modelCacheRef
     if not ref:
         return [], []
-    pvc = cache_pvc_name(replica.metadata.namespace, ref.name)
+    pvc = cache_pvc_name(replica.metadata.namespace, ref.name)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
     # Mounted read-write (NOT readOnly): engines write into the model dir
     # (tokenizer/compile/lock artifacts), and a readOnly mount hard-fails them.
     # The PVC is ReadWriteMany, so every pod in the gang shares one read-write
@@ -265,7 +265,7 @@ def serving_resources(replica: v1alpha1.ModelReplica, provider_config: str) -> d
     /<ns>/<service>/ prefix to this replica's /<ns>/<replica>/, which the route
     strips to /.
     """
-    name = replica.metadata.name
+    name = replica.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
     service = {
         "apiVersion": "v1",
         "kind": "Service",
@@ -280,7 +280,7 @@ def serving_resources(replica: v1alpha1.ModelReplica, provider_config: str) -> d
             "parentRefs": [{"name": "inference-gateway", "namespace": "modelplane-system"}],
             "rules": [
                 {
-                    "matches": [{"path": {"type": "PathPrefix", "value": f"/{replica.metadata.namespace}/{name}/"}}],
+                    "matches": [{"path": {"type": "PathPrefix", "value": f"/{replica.metadata.namespace}/{name}/"}}],  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     "timeouts": {"request": REQUEST_TIMEOUT},
                     "filters": [
                         {
@@ -305,7 +305,7 @@ def serving_label(replica: v1alpha1.ModelReplica) -> str:
     The replica name, so the shared Service selects every engine's leader and
     Standalone pods.
     """
-    return replica.metadata.name
+    return replica.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
 
 
 def engine_container(member):
@@ -356,7 +356,7 @@ def engine_name(replica: v1alpha1.ModelReplica, engine) -> str:
     LWS shared the serving Service's name, that headless Service would never be
     created, gang DNS would never resolve, and the gang could never form.
     """
-    return resource.child_name(replica.metadata.name, engine.name)
+    return resource.child_name(replica.metadata.name, engine.name)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
 
 
 def claim_template_name(replica: v1alpha1.ModelReplica, engine, member) -> str:
@@ -370,7 +370,7 @@ def claim_template_name(replica: v1alpha1.ModelReplica, engine, member) -> str:
     engine's members may claim different devices, so each claiming member gets
     its own.
     """
-    return resource.child_name(replica.metadata.name, engine.name, member_role(member), _POD_CLAIM_NAME)
+    return resource.child_name(replica.metadata.name, engine.name, member_role(member), _POD_CLAIM_NAME)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
 
 
 def engine_resources() -> dict:

--- a/functions/compose-model-replica/function/backends/base.py
+++ b/functions/compose-model-replica/function/backends/base.py
@@ -24,6 +24,21 @@ from typing import Protocol
 from crossplane.function import resource
 from models.ai.modelplane.modelreplica import v1alpha1
 from models.io.crossplane.m.kubernetes.object import v1alpha1 as k8sobjv1alpha1
+from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
+
+
+def _name(meta: metav1.ObjectMeta | None) -> str:
+    """The object's name, always set on resources read from the API server."""
+    if meta is None or meta.name is None:
+        raise ValueError("metadata.name is unexpectedly absent")
+    return meta.name
+
+
+def _namespace(meta: metav1.ObjectMeta | None) -> str:
+    """The object's namespace, always set on namespaced resources read from the API server."""
+    if meta is None or meta.namespace is None:
+        raise ValueError("metadata.namespace is unexpectedly absent")
+    return meta.namespace
 
 
 class Backend(Protocol):
@@ -75,7 +90,7 @@ def cache_mounts(replica: v1alpha1.ModelReplica) -> tuple[list[dict], list[dict]
     ref = replica.spec.modelCacheRef
     if not ref:
         return [], []
-    pvc = cache_pvc_name(replica.metadata.namespace, ref.name)  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+    pvc = cache_pvc_name(_namespace(replica.metadata), ref.name)
     # Mounted read-write (NOT readOnly): engines write into the model dir
     # (tokenizer/compile/lock artifacts), and a readOnly mount hard-fails them.
     # The PVC is ReadWriteMany, so every pod in the gang shares one read-write
@@ -275,7 +290,7 @@ def serving_resources(replica: v1alpha1.ModelReplica, provider_config: str) -> d
     /<ns>/<service>/ prefix to this replica's /<ns>/<replica>/, which the route
     strips to /.
     """
-    name = replica.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+    name = _name(replica.metadata)
     service = {
         "apiVersion": "v1",
         "kind": "Service",
@@ -290,7 +305,7 @@ def serving_resources(replica: v1alpha1.ModelReplica, provider_config: str) -> d
             "parentRefs": [{"name": "inference-gateway", "namespace": "modelplane-system"}],
             "rules": [
                 {
-                    "matches": [{"path": {"type": "PathPrefix", "value": f"/{replica.metadata.namespace}/{name}/"}}],  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                    "matches": [{"path": {"type": "PathPrefix", "value": f"/{_namespace(replica.metadata)}/{name}/"}}],
                     "timeouts": {"request": REQUEST_TIMEOUT},
                     "filters": [
                         {
@@ -315,7 +330,7 @@ def serving_label(replica: v1alpha1.ModelReplica) -> str:
     The replica name, so the shared Service selects every engine's leader and
     Standalone pods.
     """
-    return replica.metadata.name  # ty: ignore[unresolved-attribute, invalid-return-type]  # metadata is always set on resources read from the API server
+    return _name(replica.metadata)
 
 
 def engine_container(member: v1alpha1.Member) -> v1alpha1.Container:
@@ -370,7 +385,7 @@ def engine_name(replica: v1alpha1.ModelReplica, engine: v1alpha1.Engine) -> str:
     LWS shared the serving Service's name, that headless Service would never be
     created, gang DNS would never resolve, and the gang could never form.
     """
-    return resource.child_name(replica.metadata.name, engine.name)  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+    return resource.child_name(_name(replica.metadata), engine.name)
 
 
 def claim_template_name(replica: v1alpha1.ModelReplica, engine: v1alpha1.Engine, member: v1alpha1.Member) -> str:
@@ -384,7 +399,7 @@ def claim_template_name(replica: v1alpha1.ModelReplica, engine: v1alpha1.Engine,
     engine's members may claim different devices, so each claiming member gets
     its own.
     """
-    return resource.child_name(replica.metadata.name, engine.name, member_role(member), _POD_CLAIM_NAME)  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+    return resource.child_name(_name(replica.metadata), engine.name, member_role(member), _POD_CLAIM_NAME)
 
 
 def engine_resources() -> dict:

--- a/functions/compose-model-replica/function/backends/base.py
+++ b/functions/compose-model-replica/function/backends/base.py
@@ -32,7 +32,7 @@ class Backend(Protocol):
     def build(
         self,
         replica: v1alpha1.ModelReplica,
-        engine,
+        engine: v1alpha1.Engine,
         provider_config: str,
         serving_label: str,
     ) -> dict[str, k8sobjv1alpha1.Object]: ...
@@ -86,7 +86,7 @@ def cache_mounts(replica: v1alpha1.ModelReplica) -> tuple[list[dict], list[dict]
     )
 
 
-def apply_cache_args(args: list[str], replica: v1alpha1.ModelReplica, engine) -> list[str]:
+def apply_cache_args(args: list[str], replica: v1alpha1.ModelReplica, engine: v1alpha1.Container) -> list[str]:
     """Inject --model=<mount> for the turnkey vLLM path only.
 
     KServe used to inject this; nothing does now, and without it vLLM silently
@@ -170,12 +170,12 @@ _CLAIM_KEY = "resource-claim"
 REQUEST_TIMEOUT = "0s"
 
 
-def workload_key(engine) -> str:
+def workload_key(engine: v1alpha1.Engine) -> str:
     """Response key for an engine's workload (Deployment or LeaderWorkerSet)."""
     return f"{_WORKLOAD_KEY}-{engine.name}"
 
 
-def member_role(member) -> str:
+def member_role(member: v1alpha1.Member) -> str:
     """A member's role, lowercased, defaulting to standalone.
 
     The discriminator for a member's claim key and ResourceClaimTemplate name.
@@ -186,7 +186,7 @@ def member_role(member) -> str:
     return (member.role or ROLE_STANDALONE).lower()
 
 
-def claim_key(engine, member) -> str:
+def claim_key(engine: v1alpha1.Engine, member: v1alpha1.Member) -> str:
     """Response key for a member's ResourceClaimTemplate.
 
     One per member that claims devices: a member's pods all claim the same
@@ -318,7 +318,7 @@ def serving_label(replica: v1alpha1.ModelReplica) -> str:
     return replica.metadata.name  # ty: ignore[unresolved-attribute, invalid-return-type]  # metadata is always set on resources read from the API server
 
 
-def engine_container(member):
+def engine_container(member: v1alpha1.Member) -> v1alpha1.Container:
     """Return a member's container named 'engine'. The XRD's CEL validation
     guarantees exactly one exists per member, so this always succeeds.
 
@@ -327,10 +327,14 @@ def engine_container(member):
     multi-container support is tracked in #108 — it needs design for the LWS
     gang (which containers run on the leader vs the workers).
     """
+    # An engine member carries its container in template.spec. The XRD types
+    # spec as optional but a member with no spec defines no pod to serve, so
+    # reaching here without one is a malformed replica.
+    assert member.template.spec is not None
     return next(c for c in member.template.spec.containers if c.name == "engine")
 
 
-def engine_member(engine, role: str):
+def engine_member(engine: v1alpha1.Engine, role: str) -> v1alpha1.Member | None:
     """The engine's member with this role, or None.
 
     An engine has at most one member of each role (a single Standalone, or one
@@ -339,7 +343,7 @@ def engine_member(engine, role: str):
     return next((m for m in engine.members if (m.role or ROLE_STANDALONE) == role), None)
 
 
-def select_backend(engine) -> str:
+def select_backend(engine: v1alpha1.Engine) -> str:
     """Pick the serving path for an engine from its member roles.
 
     A single Standalone member is a self-contained pod, served natively as a
@@ -351,7 +355,7 @@ def select_backend(engine) -> str:
     return LLMD
 
 
-def engine_name(replica: v1alpha1.ModelReplica, engine) -> str:
+def engine_name(replica: v1alpha1.ModelReplica, engine: v1alpha1.Engine) -> str:
     """The base name for an engine's composed workload and claim resources.
 
     Every engine's resources are qualified by the engine name: per-replica so
@@ -369,7 +373,7 @@ def engine_name(replica: v1alpha1.ModelReplica, engine) -> str:
     return resource.child_name(replica.metadata.name, engine.name)  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
 
-def claim_template_name(replica: v1alpha1.ModelReplica, engine, member) -> str:
+def claim_template_name(replica: v1alpha1.ModelReplica, engine: v1alpha1.Engine, member: v1alpha1.Member) -> str:
     """ResourceClaimTemplate name for a member.
 
     Per-replica, per-engine, per-member-role: derived from the same parts as
@@ -418,7 +422,7 @@ _GPU_TOLERATION = {"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoS
 _LABEL_POOL = "modelplane.ai/pool"
 
 
-def place_pod(pod_spec: dict, replica: v1alpha1.ModelReplica, engine, member) -> None:
+def place_pod(pod_spec: dict, replica: v1alpha1.ModelReplica, engine: v1alpha1.Engine, member: v1alpha1.Member) -> None:
     """Constrain a member's serving pod to the placement the scheduler chose.
 
     Pins the pod to its member's scheduled node pool, wires it to claim its
@@ -451,7 +455,7 @@ def place_pod(pod_spec: dict, replica: v1alpha1.ModelReplica, engine, member) ->
 
 
 def resource_claim_template(
-    replica: v1alpha1.ModelReplica, engine, member, provider_config: str
+    replica: v1alpha1.ModelReplica, engine: v1alpha1.Engine, member: v1alpha1.Member, provider_config: str
 ) -> k8sobjv1alpha1.Object:
     """Compose a DRA ResourceClaimTemplate Object for a member.
 
@@ -461,6 +465,10 @@ def resource_claim_template(
     with device requests; a claimless member composes no template. One template
     serves every pod of the member, and DRA stamps a fresh claim per pod.
     """
+    # Callers (the backends) gate this on `if member.deviceRequests`, so it's
+    # only reached for a member that claims devices; a claimless member composes
+    # no template.
+    assert member.deviceRequests is not None
     device_requests = []
     for r in member.deviceRequests:
         exactly: dict = {"deviceClassName": r.deviceClassName, "count": int(r.count or 1)}

--- a/functions/compose-model-replica/function/backends/base.py
+++ b/functions/compose-model-replica/function/backends/base.py
@@ -65,7 +65,7 @@ def cache_mounts(replica: v1alpha1.ModelReplica) -> tuple[list[dict], list[dict]
     ref = replica.spec.modelCacheRef
     if not ref:
         return [], []
-    pvc = cache_pvc_name(replica.metadata.namespace, ref.name)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+    pvc = cache_pvc_name(replica.metadata.namespace, ref.name)  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
     # Mounted read-write (NOT readOnly): engines write into the model dir
     # (tokenizer/compile/lock artifacts), and a readOnly mount hard-fails them.
     # The PVC is ReadWriteMany, so every pod in the gang shares one read-write
@@ -356,7 +356,7 @@ def engine_name(replica: v1alpha1.ModelReplica, engine) -> str:
     LWS shared the serving Service's name, that headless Service would never be
     created, gang DNS would never resolve, and the gang could never form.
     """
-    return resource.child_name(replica.metadata.name, engine.name)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+    return resource.child_name(replica.metadata.name, engine.name)  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
 
 def claim_template_name(replica: v1alpha1.ModelReplica, engine, member) -> str:
@@ -370,7 +370,7 @@ def claim_template_name(replica: v1alpha1.ModelReplica, engine, member) -> str:
     engine's members may claim different devices, so each claiming member gets
     its own.
     """
-    return resource.child_name(replica.metadata.name, engine.name, member_role(member), _POD_CLAIM_NAME)  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+    return resource.child_name(replica.metadata.name, engine.name, member_role(member), _POD_CLAIM_NAME)  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
 
 def engine_resources() -> dict:

--- a/functions/compose-model-replica/function/backends/base.py
+++ b/functions/compose-model-replica/function/backends/base.py
@@ -15,18 +15,28 @@
 """Backend dispatch for compose-model-replica.
 
 A backend turns a ModelReplica + its InferenceCluster into the cluster-level
-serving resources. Backends return provider-kubernetes Objects and/or
-provider-helm Releases; the dispatcher (fn.py) applies them to the response.
+serving resources. Backends return provider-kubernetes Objects; the dispatcher
+(fn.py) applies them to the response.
 """
+
+from typing import Protocol
 
 from crossplane.function import resource
 from models.ai.modelplane.modelreplica import v1alpha1
-from models.io.crossplane.m.helm.release import v1beta1 as helmv1beta1
 from models.io.crossplane.m.kubernetes.object import v1alpha1 as k8sobjv1alpha1
 
-# A composed resource is either a provider-kubernetes Object or a
-# provider-helm Release. fn.py writes these into the response by key.
-ComposedResource = k8sobjv1alpha1.Object | helmv1beta1.Release
+
+class Backend(Protocol):
+    """Composes a replica engine's cluster-level serving resources."""
+
+    def build(
+        self,
+        replica: v1alpha1.ModelReplica,
+        engine,
+        provider_config: str,
+        serving_label: str,
+    ) -> dict[str, k8sobjv1alpha1.Object]: ...
+
 
 # Backend identifiers.
 NATIVE = "native"
@@ -305,7 +315,7 @@ def serving_label(replica: v1alpha1.ModelReplica) -> str:
     The replica name, so the shared Service selects every engine's leader and
     Standalone pods.
     """
-    return replica.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+    return replica.metadata.name  # ty: ignore[unresolved-attribute, invalid-return-type]  # metadata is always set on resources read from the API server
 
 
 def engine_container(member):

--- a/functions/compose-model-replica/function/backends/dynamo.py
+++ b/functions/compose-model-replica/function/backends/dynamo.py
@@ -27,7 +27,7 @@ class DynamoBackend:
     def build(
         self,
         replica: v1alpha1.ModelReplica,
-        engine,
+        engine: v1alpha1.Engine,
         provider_config: str,
         serving_label: str,
     ) -> dict[str, k8sobjv1alpha1.Object]:

--- a/functions/compose-model-replica/function/backends/dynamo.py
+++ b/functions/compose-model-replica/function/backends/dynamo.py
@@ -20,8 +20,7 @@ Object reconciled by the Dynamo operator installed by ServingStack.
 """
 
 from models.ai.modelplane.modelreplica import v1alpha1
-
-from function.backends import base
+from models.io.crossplane.m.kubernetes.object import v1alpha1 as k8sobjv1alpha1
 
 
 class DynamoBackend:
@@ -31,5 +30,5 @@ class DynamoBackend:
         engine,
         provider_config: str,
         serving_label: str,
-    ) -> dict[str, base.ComposedResource]:
+    ) -> dict[str, k8sobjv1alpha1.Object]:
         raise NotImplementedError("the Dynamo backend is not implemented in v0.1")

--- a/functions/compose-model-replica/function/backends/llmd.py
+++ b/functions/compose-model-replica/function/backends/llmd.py
@@ -53,12 +53,17 @@ class LLMDBackend:
     def build(
         self,
         replica: v1alpha1.ModelReplica,
-        engine,
+        engine: v1alpha1.Engine,
         provider_config: str,
         serving_label: str,
     ) -> dict[str, k8sobjv1alpha1.Object]:
         leader = base.engine_member(engine, base.ROLE_LEADER)
         worker = base.engine_member(engine, base.ROLE_WORKER)
+        # select_backend dispatches the llm-d backend for a non-Standalone
+        # engine, and the XRD requires such an engine to carry exactly one
+        # Leader and one Worker member, so both are always present here.
+        assert leader is not None
+        assert worker is not None
         name = base.engine_name(replica, engine)
 
         # Gang size: the leader plus the worker's nodes (one follower pod each).
@@ -66,7 +71,7 @@ class LLMDBackend:
 
         cache_volumes, cache_volume_mounts = base.cache_mounts(replica)
 
-        def container(member, *, serving: bool) -> dict:
+        def container(member: v1alpha1.Member, *, serving: bool) -> dict:
             engine_container = base.engine_container(member)
             args = list(engine_container.args or [])
             # The turnkey cache --model injection is for the serving engine (the
@@ -109,7 +114,7 @@ class LLMDBackend:
                 }
             return c
 
-        def pod_spec(member, c: dict) -> dict:
+        def pod_spec(member: v1alpha1.Member, c: dict) -> dict:
             spec = {
                 "containers": [c],
                 "volumes": [{"name": "dshm", "emptyDir": {"medium": "Memory"}}, *cache_volumes],
@@ -118,6 +123,9 @@ class LLMDBackend:
             # claims devices, claims GPUs via the member's DRA template (one
             # fresh claim per pod).
             base.place_pod(spec, replica, engine, member)
+            # The XRD types template.spec as optional, but a member with no spec
+            # defines no pod to serve, so reaching here without one is malformed.
+            assert member.template.spec is not None
             secrets = member.template.spec.imagePullSecrets
             if secrets:
                 spec["imagePullSecrets"] = [s.model_dump(exclude_none=True) for s in secrets]

--- a/functions/compose-model-replica/function/backends/native.py
+++ b/functions/compose-model-replica/function/backends/native.py
@@ -33,11 +33,14 @@ class NativeBackend:
     def build(
         self,
         replica: v1alpha1.ModelReplica,
-        engine,
+        engine: v1alpha1.Engine,
         provider_config: str,
         serving_label: str,
     ) -> dict[str, k8sobjv1alpha1.Object]:
         member = base.engine_member(engine, base.ROLE_STANDALONE)
+        # select_backend dispatches the native backend only for an engine with a
+        # Standalone member, so it's always present here.
+        assert member is not None
         engine_container = base.engine_container(member)
         name = base.engine_name(replica, engine)
         # The pod carries two labels: the shared serving label the replica's one
@@ -87,6 +90,9 @@ class NativeBackend:
         # Pin to the member's scheduled pool and claim GPUs via DRA.
         base.place_pod(pod_spec, replica, engine, member)
         tmpl = member.template
+        # The XRD types template.spec as optional, but a member with no spec
+        # defines no pod to serve, so reaching here without one is malformed.
+        assert tmpl.spec is not None
         if tmpl.spec.imagePullSecrets:
             pod_spec["imagePullSecrets"] = [s.model_dump(exclude_none=True) for s in tmpl.spec.imagePullSecrets]
 

--- a/functions/compose-model-replica/function/fn.py
+++ b/functions/compose-model-replica/function/fn.py
@@ -77,7 +77,7 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp) -> None:
+    def __init__(self, req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.ModelReplica(**resource.struct_to_dict(req.observed.composite.resource))

--- a/functions/compose-model-replica/function/fn.py
+++ b/functions/compose-model-replica/function/fn.py
@@ -59,7 +59,7 @@ _BACKENDS = {
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
@@ -77,19 +77,19 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp):
+    def __init__(self, req, rsp) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.ModelReplica(**resource.struct_to_dict(req.observed.composite.resource))
         self.ic = None
 
-    def compose(self):
+    def compose(self) -> None:
         if not self.resolve_inputs():
             return
         self.compose_model_serving()
         self.derive_conditions()
 
-    def resolve_inputs(self):
+    def resolve_inputs(self) -> bool:
         """Declare and fetch the referenced InferenceCluster."""
         response.require_resources(
             self.rsp,
@@ -136,7 +136,7 @@ class Composer:
 
         return True
 
-    def compose_model_serving(self):
+    def compose_model_serving(self) -> None:
         """Compose each engine's workload, then the replica's routing surface.
 
         Every engine composes to a Deployment or LeaderWorkerSet (with its
@@ -158,7 +158,7 @@ class Composer:
         for key, obj in composed.items():
             resource.update(self.rsp.desired.resources[key], obj)
 
-    def derive_conditions(self):
+    def derive_conditions(self) -> None:
         """Derive ModelAccepted and ModelReady across all of the replica's engines.
 
         A replica is accepted when every engine's workload has been created on the

--- a/functions/compose-model-replica/function/fn.py
+++ b/functions/compose-model-replica/function/fn.py
@@ -56,18 +56,6 @@ _BACKENDS = {
 }
 
 
-def _inference_cluster(
-    ic: icv1alpha1.InferenceCluster,
-) -> icv1alpha1.InferenceCluster:
-    """Return a copy with status fields defaulted."""
-    ic = ic.model_copy(deep=True)
-    ic.status = ic.status or icv1alpha1.Status()
-    ic.status.providerConfigRef = ic.status.providerConfigRef or icv1alpha1.ProviderConfigRef()
-    ic.status.gateway = ic.status.gateway or icv1alpha1.Gateway()
-    ic.status.gpuPools = ic.status.gpuPools or []
-    return ic
-
-
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
@@ -128,9 +116,9 @@ class Composer:
             response.normal(self.rsp, "Waiting for cluster to be resolved")
             return False
 
-        self.ic = _inference_cluster(icv1alpha1.InferenceCluster.model_validate(ic_dict))
+        self.ic = icv1alpha1.InferenceCluster.model_validate(ic_dict)
 
-        if not self.ic.status.providerConfigRef.name:
+        if not (self.ic.status and self.ic.status.providerConfigRef and self.ic.status.providerConfigRef.name):
             response.set_conditions(
                 self.rsp,
                 resource.Condition(
@@ -157,6 +145,9 @@ class Composer:
         surface serving.mode selects: a Service (Unified) or an InferencePool +
         endpoint picker (PrefillDecode).
         """
+        # resolve_inputs runs first and returns False unless the cluster's
+        # status.providerConfigRef.name is set, so it's present here.
+        assert self.ic and self.ic.status and self.ic.status.providerConfigRef and self.ic.status.providerConfigRef.name
         pc = self.ic.status.providerConfigRef.name
         label = base.serving_label(self.xr)
         composed: dict[str, k8sobjv1alpha1.Object] = {}

--- a/functions/compose-model-replica/function/fn.py
+++ b/functions/compose-model-replica/function/fn.py
@@ -68,14 +68,16 @@ def _inference_cluster(
     return ic
 
 
-class FunctionRunner(grpcv1.FunctionRunnerService):
+class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
     def __init__(self):
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
-    async def RunFunction(self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext) -> fnv1.RunFunctionResponse:
+    async def RunFunction(
+        self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext | None
+    ) -> fnv1.RunFunctionResponse:  # ty: ignore[invalid-method-override]  # the generated grpc servicer base is untyped
         """Run the function."""
         log = self.log.bind(tag=req.meta.tag)
         log.info("Running function")

--- a/functions/compose-model-replica/function/routing.py
+++ b/functions/compose-model-replica/function/routing.py
@@ -32,8 +32,17 @@ user's; this layer injects none.
 
 from models.ai.modelplane.modelreplica import v1alpha1
 from models.io.crossplane.m.kubernetes.object import v1alpha1 as k8sobjv1alpha1
+from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
 
 from function.backends import base
+
+
+def _namespace(meta: metav1.ObjectMeta | None) -> str:
+    """The object's namespace, always set on namespaced resources read from the API server."""
+    if meta is None or meta.namespace is None:
+        raise ValueError("metadata.namespace is unexpectedly absent")
+    return meta.namespace
+
 
 _EPP_IMAGE = "ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0"
 _SIDECAR_IMAGE = "ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0"
@@ -371,7 +380,7 @@ def _http_route(replica: v1alpha1.ModelReplica, name: str) -> dict:
             "parentRefs": [{"name": "inference-gateway", "namespace": "modelplane-system"}],
             "rules": [
                 {
-                    "matches": [{"path": {"type": "PathPrefix", "value": f"/{replica.metadata.namespace}/{name}/"}}],  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                    "matches": [{"path": {"type": "PathPrefix", "value": f"/{_namespace(replica.metadata)}/{name}/"}}],
                     "timeouts": {"request": base.REQUEST_TIMEOUT},
                     "filters": [
                         {

--- a/functions/compose-model-replica/function/routing.py
+++ b/functions/compose-model-replica/function/routing.py
@@ -217,7 +217,7 @@ def _disaggregated(
     current tag. Engine images are the user's (#137), so Modelplane can't bundle
     this; it is a deployment prerequisite, not something the composition provides.
     """
-    name = replica.metadata.name
+    name = replica.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
     prefill = next(e for e in replica.spec.engines if e.phase == "Prefill")
     decode = next(e for e in replica.spec.engines if e.phase == "Decode")
 
@@ -368,7 +368,7 @@ def _http_route(replica: v1alpha1.ModelReplica, name: str) -> dict:
             "parentRefs": [{"name": "inference-gateway", "namespace": "modelplane-system"}],
             "rules": [
                 {
-                    "matches": [{"path": {"type": "PathPrefix", "value": f"/{replica.metadata.namespace}/{name}/"}}],
+                    "matches": [{"path": {"type": "PathPrefix", "value": f"/{replica.metadata.namespace}/{name}/"}}],  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     "timeouts": {"request": base.REQUEST_TIMEOUT},
                     "filters": [
                         {

--- a/functions/compose-model-replica/function/routing.py
+++ b/functions/compose-model-replica/function/routing.py
@@ -217,7 +217,10 @@ def _disaggregated(
     current tag. Engine images are the user's (#137), so Modelplane can't bundle
     this; it is a deployment prerequisite, not something the composition provides.
     """
-    name = replica.metadata.name  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+    assert (
+        replica.metadata is not None and replica.metadata.name is not None
+    )  # set on resources read from the API server
+    name = replica.metadata.name
     prefill = next(e for e in replica.spec.engines if e.phase == "Prefill")
     decode = next(e for e in replica.spec.engines if e.phase == "Decode")
 

--- a/functions/compose-model-replica/tests/test_backends.py
+++ b/functions/compose-model-replica/tests/test_backends.py
@@ -374,7 +374,7 @@ _CASES = [
 
 
 class TestBackendManifests(unittest.TestCase):
-    def test_manifests(self):
+    def test_manifests(self) -> None:
         for case in _CASES:
             with self.subTest(case.name):
                 replica = _replica(engines=[case.engine])
@@ -382,7 +382,7 @@ class TestBackendManifests(unittest.TestCase):
                 got = {key: obj.spec.forProvider.manifest for key, obj in out.items()}
                 self.assertEqual(case.want, got, "-want, +got")
 
-    def test_serving_resources(self):
+    def test_serving_resources(self) -> None:
         # The shared Service + HTTPRoute front a replica regardless of how many
         # engines it has, named after the replica.
         replica = _replica()
@@ -390,7 +390,7 @@ class TestBackendManifests(unittest.TestCase):
         got = {key: obj.spec.forProvider.manifest for key, obj in out.items()}
         self.assertEqual({"model-service": _service("r"), "model-route": _route("r")}, got)
 
-    def test_leader_address_injected_into_gang_engines(self):
+    def test_leader_address_injected_into_gang_engines(self) -> None:
         # Every engine container in a multi-node gang gets
         # MODELPLANE_LEADER_ADDRESS, aliasing LWS_LEADER_ADDRESS, ahead of the
         # user's own env so commands can reference $(MODELPLANE_LEADER_ADDRESS).
@@ -402,7 +402,7 @@ class TestBackendManifests(unittest.TestCase):
             env = tmpl[role]["spec"]["containers"][0]["env"]
             self.assertEqual(env[0], _LEADER_ENV)
 
-    def test_user_env_preserved_after_leader_address(self):
+    def test_user_env_preserved_after_leader_address(self) -> None:
         engine = _gang_engine(
             leader_command=_LEADER_CMD,
             worker_command=_WORKER_CMD,
@@ -414,7 +414,7 @@ class TestBackendManifests(unittest.TestCase):
         env = leader["spec"]["containers"][0]["env"]
         self.assertEqual(env, [_LEADER_ENV, {"name": "HF_TOKEN", "value": "x"}])
 
-    def test_fieldref_env_passes_through(self):
+    def test_fieldref_env_passes_through(self) -> None:
         # A pod-field env (e.g. VLLM_HOST_IP from status.podIP, which multi-NIC
         # RDMA nodes need so the engine binds the right interface — #141) survives
         # model_dump into the composed manifest alongside the injected leader env.
@@ -438,7 +438,7 @@ class TestBackendManifests(unittest.TestCase):
     def _names(out):
         return {o.spec.forProvider.manifest["metadata"]["name"] for o in out.values()}
 
-    def test_co_located_replicas_get_distinct_names(self):
+    def test_co_located_replicas_get_distinct_names(self) -> None:
         # Two replicas of one deployment on the same cluster must produce
         # distinct resource names on the remote cluster.
         a = _replica("dep-clusterA")
@@ -447,7 +447,7 @@ class TestBackendManifests(unittest.TestCase):
         out_b = native.NativeBackend().build(b, b.spec.engines[0], _PC, base.serving_label(b))
         self.assertEqual(self._names(out_a) & self._names(out_b), set())
 
-    def test_lws_name_differs_from_serving_service_name(self):
+    def test_lws_name_differs_from_serving_service_name(self) -> None:
         # Regression: LWS's controller creates a headless Service named after
         # the LWS for gang pod DNS - but only if no Service of that name
         # exists. When the LWS shared the serving Service's name (the replica
@@ -462,7 +462,7 @@ class TestBackendManifests(unittest.TestCase):
         service_name = serving["model-service"].spec.forProvider.manifest["metadata"]["name"]
         self.assertNotEqual(lws_name, service_name)
 
-    def test_multi_engine_qualifies_workload_names(self):
+    def test_multi_engine_qualifies_workload_names(self) -> None:
         # A replica with two engines names each engine's workload distinctly so
         # they don't collide on the remote cluster.
         engines = [_standalone_engine("prefill"), _standalone_engine("decode")]
@@ -473,7 +473,7 @@ class TestBackendManifests(unittest.TestCase):
             names |= self._names(out)
         self.assertEqual(len(names), 4)  # 2 deployments + 2 claim templates
 
-    def test_workload_readiness_policies(self):
+    def test_workload_readiness_policies(self) -> None:
         # The workload reports readiness from its Available condition via a CEL
         # query; the claim templates are ready on create.
         for name, backend, engine in (
@@ -493,7 +493,7 @@ class TestBackendManifests(unittest.TestCase):
                         assert readiness is not None
                         self.assertEqual(readiness.policy, "SuccessfulCreate")
 
-    def test_serving_readiness_policies(self):
+    def test_serving_readiness_policies(self) -> None:
         replica = _replica()
         out = base.serving_resources(replica, _PC)
         service_readiness = out["model-service"].spec.readiness
@@ -502,7 +502,7 @@ class TestBackendManifests(unittest.TestCase):
         self.assertEqual(service_readiness.policy, "SuccessfulCreate")
         self.assertEqual(route_readiness.policy, "SuccessfulCreate")
 
-    def test_multiple_device_requests_single_container_claim(self):
+    def test_multiple_device_requests_single_container_claim(self) -> None:
         # resources.claims is a list-map keyed on name alone, so N device
         # requests must NOT produce N container claims all named "devices". The
         # container references the whole pod claim once; the template carries all
@@ -526,7 +526,7 @@ class TestBackendManifests(unittest.TestCase):
         assert claim_readiness is not None
         self.assertEqual(claim_readiness.policy, "SuccessfulCreate")
 
-    def test_claimless_leader_gets_no_claim(self):
+    def test_claimless_leader_gets_no_claim(self) -> None:
         # A coordinator-only leader (e.g. a vLLM DP head running
         # --data-parallel-size-local=0) carries no deviceRequests. Its pod must
         # get no resourceClaims, its container no resources.claims, and no
@@ -556,7 +556,7 @@ class TestBackendManifests(unittest.TestCase):
         self.assertEqual(worker["resourceClaims"], _claims("worker"))
         self.assertEqual(worker["containers"][0]["resources"], {"claims": [{"name": "devices"}]})
 
-    def test_members_pin_to_their_own_pools(self):
+    def test_members_pin_to_their_own_pools(self) -> None:
         # The scheduler may split a gang across pools when no single pool
         # satisfies every member. Each member's pods must pin to that member's
         # pool, not a shared engine-wide one.
@@ -569,18 +569,18 @@ class TestBackendManifests(unittest.TestCase):
 
 
 class TestBackendSelection(unittest.TestCase):
-    def test_standalone_engine_is_native(self):
+    def test_standalone_engine_is_native(self) -> None:
         self.assertEqual(base.select_backend(_standalone_engine()), base.NATIVE)
 
-    def test_leader_worker_engine_is_llmd(self):
+    def test_leader_worker_engine_is_llmd(self) -> None:
         self.assertEqual(base.select_backend(_gang_engine()), base.LLMD)
 
 
 class TestDynamoStub(unittest.TestCase):
-    def test_not_selected_in_v01(self):
+    def test_not_selected_in_v01(self) -> None:
         self.assertNotEqual(base.select_backend(_gang_engine()), base.DYNAMO)
 
-    def test_build_raises(self):
+    def test_build_raises(self) -> None:
         engine = _gang_engine()
         replica = _replica(engines=[engine])
         with self.assertRaises(NotImplementedError):
@@ -600,11 +600,11 @@ class TestCacheMounts(unittest.TestCase):
     def _engine(replica):
         return replica.spec.engines[0].members[0].template.spec.containers[0]
 
-    def test_no_cache_no_mounts(self):
+    def test_no_cache_no_mounts(self) -> None:
         volumes, mounts = base.cache_mounts(self._replica())
         self.assertEqual((volumes, mounts), ([], []))
 
-    def test_cache_adds_volume_and_mount(self):
+    def test_cache_adds_volume_and_mount(self) -> None:
         volumes, mounts = base.cache_mounts(self._replica(cache="qwen"))
         self.assertEqual(
             volumes,
@@ -612,22 +612,22 @@ class TestCacheMounts(unittest.TestCase):
         )
         self.assertEqual(mounts, [{"name": "model-cache", "mountPath": "/mnt/models"}])
 
-    def test_apply_cache_injects_model_when_absent(self):
+    def test_apply_cache_injects_model_when_absent(self) -> None:
         r = self._replica(cache="qwen")
         args = base.apply_cache_args(["--trust-remote-code"], r, self._engine(r))
         self.assertIn("--model=/mnt/models", args)
 
-    def test_apply_cache_respects_user_model(self):
+    def test_apply_cache_respects_user_model(self) -> None:
         r = self._replica(cache="qwen", args=["--model=/mnt/models"])
         args = base.apply_cache_args(["--model=/mnt/models"], r, self._engine(r))
         self.assertEqual(args.count("--model=/mnt/models"), 1)
 
-    def test_apply_cache_noop_without_cache(self):
+    def test_apply_cache_noop_without_cache(self) -> None:
         r = self._replica()
         args = base.apply_cache_args(["--trust-remote-code"], r, self._engine(r))
         self.assertEqual(args, ["--trust-remote-code"])
 
-    def test_apply_cache_skips_when_engine_has_command(self):
+    def test_apply_cache_skips_when_engine_has_command(self) -> None:
         # Non-vLLM engine (e.g. SGLang) owns its args via a command and uses
         # --model-path, not --model: we must not inject --model.
         r = self._replica(cache="qwen", args=["--model-path=/mnt/models"], command=["/bin/sh", "-c", "..."])
@@ -648,7 +648,7 @@ class TestNativeBackendCache(unittest.TestCase):
             ),
         )
 
-    def test_mounts_pvc_and_injects_model(self):
+    def test_mounts_pvc_and_injects_model(self) -> None:
         replica = self._replica()
         out = native.NativeBackend().build(replica, replica.spec.engines[0], _PC, base.serving_label(replica))
         dep = out["model-serving-main"].spec.forProvider.manifest
@@ -677,7 +677,7 @@ class TestLLMDBackendCache(unittest.TestCase):
             ),
         )
 
-    def test_both_lws_templates_mount_cache(self):
+    def test_both_lws_templates_mount_cache(self) -> None:
         replica = self._replica(leader_args=[], worker_command=["/bin/sh", "-c", "join"])
         lws = (
             llmd.LLMDBackend()
@@ -693,7 +693,7 @@ class TestLLMDBackendCache(unittest.TestCase):
                 pod["containers"][0]["volumeMounts"],
             )
 
-    def test_injects_model_into_leader_args_for_vllm(self):
+    def test_injects_model_into_leader_args_for_vllm(self) -> None:
         # The leader has no command and no --model arg, so the cache --model is
         # injected into its args.
         replica = self._replica(leader_args=[], worker_command=["/bin/sh", "-c", "join"])
@@ -705,7 +705,7 @@ class TestLLMDBackendCache(unittest.TestCase):
         leader_args = lws["spec"]["leaderWorkerTemplate"]["leaderTemplate"]["spec"]["containers"][0]["args"]
         self.assertIn("--model=/mnt/models", leader_args)
 
-    def test_command_engine_mounts_cache_without_injecting_model(self):
+    def test_command_engine_mounts_cache_without_injecting_model(self) -> None:
         # A member with its own command keeps it verbatim and gets no injected
         # --model (it points at the cache with its own flag).
         leader_cmd = [
@@ -747,7 +747,7 @@ class TestDisaggregated(unittest.TestCase):
     def _serving_pod(self, out, engine_name):
         return out[f"model-serving-{engine_name}"].spec.forProvider.manifest["spec"]["template"]
 
-    def test_replaces_unified_service_with_pool_and_epp(self):
+    def test_replaces_unified_service_with_pool_and_epp(self) -> None:
         out = self._apply()
         self.assertNotIn(base.SERVICE_KEY, out)  # unified Service gone
         self.assertIn("inference-pool", out)
@@ -757,7 +757,7 @@ class TestDisaggregated(unittest.TestCase):
         self.assertEqual(pool["kind"], "InferencePool")
         self.assertEqual(pool["spec"]["endpointPickerRef"]["name"], "r-epp")
 
-    def test_injects_nixl_plumbing(self):
+    def test_injects_nixl_plumbing(self) -> None:
         """Both disagg engines get the NIXL plumbing the schema can't express:
         a Memory /dev/shm and VLLM_NIXL_SIDE_CHANNEL_HOST = pod IP."""
         out = self._apply()
@@ -774,7 +774,7 @@ class TestDisaggregated(unittest.TestCase):
             self.assertEqual(host["valueFrom"]["fieldRef"]["fieldPath"], "status.podIP")
             self.assertIn("VLLM_NIXL_SIDE_CHANNEL_PORT", [e["name"] for e in engine["env"]])
 
-    def test_epp_config_arms_the_pd_decider(self):
+    def test_epp_config_arms_the_pd_decider(self) -> None:
         """PrefillDecode silently serves decode-only unless the PD decider is armed.
 
         Selective prefix-based-pd-decider needs all of: nonCachedTokens > 0 (0 =
@@ -791,7 +791,7 @@ class TestDisaggregated(unittest.TestCase):
         self.assertNotIn("nonCachedTokens: 0", cfg)
         self.assertNotIn("prepareDataPlugins", cfg)
 
-    def test_epp_role_watches_inferenceobjectives(self):
+    def test_epp_role_watches_inferenceobjectives(self) -> None:
         """The picker watches InferenceObjectives (GIE x-k8s.io group); the Role must allow it."""
         rules = self._apply()["epp-role"].spec.forProvider.manifest["rules"]
         self.assertTrue(
@@ -802,7 +802,7 @@ class TestDisaggregated(unittest.TestCase):
             f"EPP Role missing inferenceobjectives watch: {rules}",
         )
 
-    def test_decode_port_follows_user_arg(self):
+    def test_decode_port_follows_user_arg(self) -> None:
         """The sidecar and the decode container port track the user's --port, not a hardcoded one."""
         prefill = _standalone_engine(name="prefill")
         prefill.phase = "Prefill"
@@ -821,14 +821,14 @@ class TestDisaggregated(unittest.TestCase):
         self.assertIn("--vllm-port=9000", sidecar["args"])
         self.assertEqual(sidecar["ports"][0]["containerPort"], 8000)
 
-    def test_engines_role_labeled(self):
+    def test_engines_role_labeled(self) -> None:
         out = self._apply()
         self.assertEqual(self._serving_pod(out, "prefill")["metadata"]["labels"]["llm-d.ai/role"], "prefill")
         decode_labels = self._serving_pod(out, "decode")["metadata"]["labels"]
         self.assertEqual(decode_labels["llm-d.ai/role"], "decode")
         self.assertEqual(decode_labels["app"], "r")
 
-    def test_decode_gets_sidecar_and_moves_engine_port(self):
+    def test_decode_gets_sidecar_and_moves_engine_port(self) -> None:
         out = self._apply()
         containers = self._serving_pod(out, "decode")["spec"]["containers"]
         names = [c["name"] for c in containers]
@@ -841,11 +841,11 @@ class TestDisaggregated(unittest.TestCase):
         self.assertEqual(sidecar["readinessProbe"]["timeoutSeconds"], 5)
         self.assertIn("--secure-proxy=false", sidecar["args"])
 
-    def test_prefill_has_no_sidecar(self):
+    def test_prefill_has_no_sidecar(self) -> None:
         containers = self._serving_pod(self._apply(), "prefill")["spec"]["containers"]
         self.assertEqual([c["name"] for c in containers], ["engine"])
 
-    def test_route_targets_inference_pool(self):
+    def test_route_targets_inference_pool(self) -> None:
         route = self._apply()[base.ROUTE_KEY].spec.forProvider.manifest
         rule = route["spec"]["rules"][0]
         ref = rule["backendRefs"][0]
@@ -854,7 +854,7 @@ class TestDisaggregated(unittest.TestCase):
         # Disable the request timeout so long token streams aren't severed.
         self.assertEqual(rule["timeouts"]["request"], "0s")
 
-    def test_selects_engines_by_phase_not_name(self):
+    def test_selects_engines_by_phase_not_name(self) -> None:
         """Roles come from each engine's phase, not its name."""
         decode = _standalone_engine(name="alpha")
         decode.phase = "Decode"
@@ -879,7 +879,7 @@ class TestUnifiedRouting(unittest.TestCase):
     """With no serving block (or mode Unified), routing.apply adds a plain
     Service + HTTPRoute and no InferencePool."""
 
-    def test_adds_service_and_route(self):
+    def test_adds_service_and_route(self) -> None:
         engine = _standalone_engine(name="main")
         replica = _replica(engines=[engine])
         composed = native.NativeBackend().build(replica, engine, _PC, base.serving_label(replica))
@@ -893,21 +893,21 @@ class TestKvBlockSize(unittest.TestCase):
     """The EPP prefix-cache producer's blockSizeTokens is derived best-effort
     from the engine flags (#179) so it matches the engine's KV block size."""
 
-    def test_defaults_to_16_when_absent(self):
+    def test_defaults_to_16_when_absent(self) -> None:
         self.assertEqual(routing._kv_block_size([]), 16)
         self.assertEqual(routing._kv_block_size(["--model=/mnt/models"]), 16)
 
-    def test_reads_vllm_block_size(self):
+    def test_reads_vllm_block_size(self) -> None:
         self.assertEqual(routing._kv_block_size(["--block-size", "32"]), 32)
         self.assertEqual(routing._kv_block_size(["--model=/m", "--block-size=8"]), 8)
 
-    def test_reads_sglang_page_size(self):
+    def test_reads_sglang_page_size(self) -> None:
         self.assertEqual(routing._kv_block_size(["--page-size=64"]), 64)
 
-    def test_non_integer_falls_back_to_default(self):
+    def test_non_integer_falls_back_to_default(self) -> None:
         self.assertEqual(routing._kv_block_size(["--block-size", "auto"]), 16)
 
-    def test_rendered_config_uses_block_size(self):
+    def test_rendered_config_uses_block_size(self) -> None:
         cfg = routing._epp_config_yaml(32)
         self.assertIn("blockSizeTokens: 32", cfg)
         self.assertNotIn("BLOCK_SIZE_TOKENS", cfg)

--- a/functions/compose-model-replica/tests/test_backends.py
+++ b/functions/compose-model-replica/tests/test_backends.py
@@ -307,7 +307,7 @@ def _lws(leader_container, worker_container):
 
 
 def _engine(*, serving, args=None, command=None, env=None):
-    c = {
+    c: dict[str, Any] = {
         "name": "engine",
         "image": "vllm/vllm-openai:latest",
         "resources": {"claims": [{"name": "devices"}]},

--- a/functions/compose-model-replica/tests/test_backends.py
+++ b/functions/compose-model-replica/tests/test_backends.py
@@ -31,6 +31,7 @@ from function import routing
 from function.backends import base, dynamo, llmd, native
 from models.ai.modelplane.inferencecluster import v1alpha1 as icv1alpha1
 from models.ai.modelplane.modelreplica import v1alpha1
+from models.io.crossplane.m.kubernetes.object import v1alpha1 as k8sobjv1alpha1
 from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
 
 _SERVING = "modelplane.ai/serving"
@@ -42,7 +43,7 @@ _LEADER_ENV = {"name": "MODELPLANE_LEADER_ADDRESS", "value": "$(LWS_LEADER_ADDRE
 _GPU_CEL = 'device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("80Gi")) >= 0'
 
 
-def _gpu_request(count):
+def _gpu_request(count: int) -> v1alpha1.DeviceRequest:
     return v1alpha1.DeviceRequest(
         name="gpu",
         deviceClassName="gpu.nvidia.com",
@@ -52,13 +53,13 @@ def _gpu_request(count):
 
 
 def _standalone_engine(
-    name="main",
+    name: str = "main",
     *,
-    copies=1,
-    args=None,
-    command=None,
-    device_requests=None,
-):
+    copies: int = 1,
+    args: list[str] | None = None,
+    command: list[str] | None = None,
+    device_requests: list[v1alpha1.DeviceRequest] | None = None,
+) -> v1alpha1.Engine:
     """A single Standalone-member engine."""
     container = v1alpha1.Container(
         name="engine",
@@ -82,17 +83,17 @@ def _standalone_engine(
 
 
 def _gang_engine(
-    name="main",
+    name: str = "main",
     *,
-    copies=1,
-    nodes=1,
-    leader_args=None,
-    leader_command=None,
-    worker_args=None,
-    worker_command=None,
-    leader_device_requests=None,
-    leader_pool="frontier",
-):
+    copies: int = 1,
+    nodes: int = 1,
+    leader_args: list[str] | None = None,
+    leader_command: list[str] | None = None,
+    worker_args: list[str] | None = None,
+    worker_command: list[str] | None = None,
+    leader_device_requests: list[v1alpha1.DeviceRequest] | None = None,
+    leader_pool: str = "frontier",
+) -> v1alpha1.Engine:
     """A Leader + Worker engine.
 
     The members carry their own pool pins and device requests, defaulting to a
@@ -101,7 +102,14 @@ def _gang_engine(
     pool.
     """
 
-    def member(role, nodes, args, command, device_requests, pool):
+    def member(
+        role: str,
+        nodes: int | None,
+        args: list[str] | None,
+        command: list[str] | None,
+        device_requests: list[v1alpha1.DeviceRequest],
+        pool: str,
+    ) -> v1alpha1.Member:
         container = v1alpha1.Container(name="engine", image="vllm/vllm-openai:latest")
         if args is not None:
             container.args = args
@@ -129,7 +137,9 @@ def _gang_engine(
     )
 
 
-def _replica(name="r", *, namespace="ml-team", engines=None):
+def _replica(
+    name: str = "r", *, namespace: str = "ml-team", engines: list[v1alpha1.Engine] | None = None
+) -> v1alpha1.ModelReplica:
     if engines is None:
         engines = [_standalone_engine()]
     return v1alpha1.ModelReplica(
@@ -144,7 +154,7 @@ def _replica(name="r", *, namespace="ml-team", engines=None):
 _WORKLOAD_NAME = resource.child_name("r", "main")
 
 
-def _claim_template(count, *, replica="r", engine="main", role="standalone"):
+def _claim_template(count: int, *, replica: str = "r", engine: str = "main", role: str = "standalone") -> dict:
     """The ResourceClaimTemplate manifest a member's device requests produce."""
     return {
         "apiVersion": "resource.k8s.io/v1",
@@ -182,7 +192,7 @@ _CLUSTER = icv1alpha1.InferenceCluster(
 _PC = "cluster-a-pc"
 
 
-def _route(name):
+def _route(name: str) -> dict:
     """The replica's HTTPRoute — replica-named, prefix-stripped."""
     return {
         "apiVersion": "gateway.networking.k8s.io/v1",
@@ -207,7 +217,7 @@ def _route(name):
     }
 
 
-def _service(name):
+def _service(name: str) -> dict:
     return {
         "apiVersion": "v1",
         "kind": "Service",
@@ -260,7 +270,7 @@ _NATIVE_WANT = {
 }
 
 
-def _claims(role):
+def _claims(role: str) -> list[dict]:
     """The pod-level claim referencing a member's ResourceClaimTemplate."""
     return [
         {
@@ -270,7 +280,7 @@ def _claims(role):
     ]
 
 
-def _lws(leader_container, worker_container):
+def _lws(leader_container: dict, worker_container: dict) -> dict:
     node_selector = {"modelplane.ai/pool": "frontier"}
 
     tolerations = [{"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"}]
@@ -306,7 +316,9 @@ def _lws(leader_container, worker_container):
     }
 
 
-def _engine(*, serving, args=None, command=None, env=None):
+def _engine(
+    *, serving: bool, args: list[str] | None = None, command: list[str] | None = None, env: list[dict] | None = None
+) -> dict[str, Any]:
     c: dict[str, Any] = {
         "name": "engine",
         "image": "vllm/vllm-openai:latest",
@@ -353,7 +365,7 @@ _LLMD_WANT = {
 class Case:
     name: str
     backend: base.Backend
-    engine: v1alpha1.Worker
+    engine: v1alpha1.Engine
     want: dict
 
 
@@ -407,7 +419,9 @@ class TestBackendManifests(unittest.TestCase):
             leader_command=_LEADER_CMD,
             worker_command=_WORKER_CMD,
         )
-        engine.members[0].template.spec.containers[0].env = [v1alpha1.EnvItem(name="HF_TOKEN", value="x")]
+        spec = engine.members[0].template.spec
+        assert spec is not None
+        spec.containers[0].env = [v1alpha1.EnvItem(name="HF_TOKEN", value="x")]
         replica = _replica(engines=[engine])
         out = llmd.LLMDBackend().build(replica, engine, _PC, base.serving_label(replica))
         leader = out["model-serving-main"].spec.forProvider.manifest["spec"]["leaderWorkerTemplate"]["leaderTemplate"]
@@ -419,7 +433,9 @@ class TestBackendManifests(unittest.TestCase):
         # RDMA nodes need so the engine binds the right interface — #141) survives
         # model_dump into the composed manifest alongside the injected leader env.
         engine = _gang_engine(leader_command=_LEADER_CMD, worker_command=_WORKER_CMD)
-        engine.members[0].template.spec.containers[0].env = [
+        spec = engine.members[0].template.spec
+        assert spec is not None
+        spec.containers[0].env = [
             v1alpha1.EnvItem(
                 name="VLLM_HOST_IP",
                 valueFrom=v1alpha1.ValueFrom(fieldRef=v1alpha1.FieldRef(fieldPath="status.podIP")),
@@ -435,7 +451,7 @@ class TestBackendManifests(unittest.TestCase):
         )
 
     @staticmethod
-    def _names(out):
+    def _names(out: dict[str, k8sobjv1alpha1.Object]) -> set[str]:
         return {o.spec.forProvider.manifest["metadata"]["name"] for o in out.values()}
 
     def test_co_located_replicas_get_distinct_names(self) -> None:
@@ -588,7 +604,9 @@ class TestDynamoStub(unittest.TestCase):
 
 
 class TestCacheMounts(unittest.TestCase):
-    def _replica(self, *, cache=None, args=None, command=None):
+    def _replica(
+        self, *, cache: str | None = None, args: list[str] | None = None, command: list[str] | None = None
+    ) -> v1alpha1.ModelReplica:
         engine = _standalone_engine(args=args or [], command=command)
         modelcache = v1alpha1.ModelCacheRef(name=cache) if cache else None
         return v1alpha1.ModelReplica(
@@ -597,8 +615,10 @@ class TestCacheMounts(unittest.TestCase):
         )
 
     @staticmethod
-    def _engine(replica):
-        return replica.spec.engines[0].members[0].template.spec.containers[0]
+    def _engine(replica: v1alpha1.ModelReplica) -> v1alpha1.Container:
+        spec = replica.spec.engines[0].members[0].template.spec
+        assert spec is not None
+        return spec.containers[0]
 
     def test_no_cache_no_mounts(self) -> None:
         volumes, mounts = base.cache_mounts(self._replica())
@@ -637,7 +657,7 @@ class TestCacheMounts(unittest.TestCase):
 
 
 class TestNativeBackendCache(unittest.TestCase):
-    def _replica(self):
+    def _replica(self) -> v1alpha1.ModelReplica:
         engine = _standalone_engine(args=[])
         return v1alpha1.ModelReplica(
             metadata=metav1.ObjectMeta(name="r", namespace="ml-team"),
@@ -661,7 +681,14 @@ class TestNativeBackendCache(unittest.TestCase):
 
 
 class TestLLMDBackendCache(unittest.TestCase):
-    def _replica(self, *, leader_command=None, worker_command=None, leader_args=None, worker_args=None):
+    def _replica(
+        self,
+        *,
+        leader_command: list[str] | None = None,
+        worker_command: list[str] | None = None,
+        leader_args: list[str] | None = None,
+        worker_args: list[str] | None = None,
+    ) -> v1alpha1.ModelReplica:
         engine = _gang_engine(
             leader_command=leader_command,
             worker_command=worker_command,
@@ -732,7 +759,7 @@ class TestDisaggregated(unittest.TestCase):
     picker over two engines, role-labels them, and sidecars decode — no unified
     Service. Mirrors how fn.py composes engines then calls routing.apply."""
 
-    def _apply(self):
+    def _apply(self) -> dict[str, k8sobjv1alpha1.Object]:
         prefill = _standalone_engine(name="prefill")
         prefill.phase = "Prefill"
         decode = _standalone_engine(name="decode")
@@ -744,7 +771,7 @@ class TestDisaggregated(unittest.TestCase):
             composed.update(native.NativeBackend().build(replica, engine, _PC, base.serving_label(replica)))
         return routing.apply(composed, replica, _PC)
 
-    def _serving_pod(self, out, engine_name):
+    def _serving_pod(self, out: dict[str, k8sobjv1alpha1.Object], engine_name: str) -> dict:
         return out[f"model-serving-{engine_name}"].spec.forProvider.manifest["spec"]["template"]
 
     def test_replaces_unified_service_with_pool_and_epp(self) -> None:

--- a/functions/compose-model-replica/tests/test_backends.py
+++ b/functions/compose-model-replica/tests/test_backends.py
@@ -24,6 +24,7 @@ Dynamo stub are dispatch/behaviour tests below the table.
 
 import dataclasses
 import unittest
+from typing import Any
 
 from crossplane.function import resource
 from function import routing
@@ -106,7 +107,7 @@ def _gang_engine(
             container.args = args
         if command is not None:
             container.command = command
-        kwargs = {
+        kwargs: dict[str, Any] = {
             "role": role,
             "nodePoolName": pool,
             "template": v1alpha1.Template(spec=v1alpha1.Spec(containers=[container])),
@@ -351,7 +352,7 @@ _LLMD_WANT = {
 @dataclasses.dataclass
 class Case:
     name: str
-    backend: object
+    backend: base.Backend
     engine: v1alpha1.Worker
     want: dict
 
@@ -483,17 +484,23 @@ class TestBackendManifests(unittest.TestCase):
                 replica = _replica(engines=[engine])
                 out = backend.build(replica, engine, _PC, base.serving_label(replica))
                 serving = out["model-serving-main"].spec.readiness
+                assert serving is not None
                 self.assertEqual(serving.policy, "DeriveFromCelQuery")
                 self.assertEqual(serving.celQuery, base.AVAILABLE_CEL)
                 for key, obj in out.items():
                     if key.startswith("resource-claim"):
-                        self.assertEqual(obj.spec.readiness.policy, "SuccessfulCreate")
+                        readiness = obj.spec.readiness
+                        assert readiness is not None
+                        self.assertEqual(readiness.policy, "SuccessfulCreate")
 
     def test_serving_readiness_policies(self):
         replica = _replica()
         out = base.serving_resources(replica, _PC)
-        self.assertEqual(out["model-service"].spec.readiness.policy, "SuccessfulCreate")
-        self.assertEqual(out["model-route"].spec.readiness.policy, "SuccessfulCreate")
+        service_readiness = out["model-service"].spec.readiness
+        route_readiness = out["model-route"].spec.readiness
+        assert service_readiness is not None and route_readiness is not None
+        self.assertEqual(service_readiness.policy, "SuccessfulCreate")
+        self.assertEqual(route_readiness.policy, "SuccessfulCreate")
 
     def test_multiple_device_requests_single_container_claim(self):
         # resources.claims is a list-map keyed on name alone, so N device
@@ -515,7 +522,9 @@ class TestBackendManifests(unittest.TestCase):
         template = out["resource-claim-main-standalone"].spec.forProvider.manifest
         template_requests = template["spec"]["spec"]["devices"]["requests"]
         self.assertEqual([r["name"] for r in template_requests], ["gpu", "nic"])
-        self.assertEqual(out["resource-claim-main-standalone"].spec.readiness.policy, "SuccessfulCreate")
+        claim_readiness = out["resource-claim-main-standalone"].spec.readiness
+        assert claim_readiness is not None
+        self.assertEqual(claim_readiness.policy, "SuccessfulCreate")
 
     def test_claimless_leader_gets_no_claim(self):
         # A coordinator-only leader (e.g. a vLLM DP head running
@@ -761,7 +770,7 @@ class TestDisaggregated(unittest.TestCase):
             engine = next(c for c in pod["containers"] if c["name"] == "engine")
             self.assertIn("/dev/shm", [m["mountPath"] for m in engine["volumeMounts"]])
             host = next((e for e in engine["env"] if e["name"] == "VLLM_NIXL_SIDE_CHANNEL_HOST"), None)
-            self.assertIsNotNone(host, f"{role} missing VLLM_NIXL_SIDE_CHANNEL_HOST")
+            assert host is not None, f"{role} missing VLLM_NIXL_SIDE_CHANNEL_HOST"
             self.assertEqual(host["valueFrom"]["fieldRef"]["fieldPath"], "status.podIP")
             self.assertIn("VLLM_NIXL_SIDE_CHANNEL_PORT", [e["name"] for e in engine["env"]])
 

--- a/functions/compose-model-service/function/fn.py
+++ b/functions/compose-model-service/function/fn.py
@@ -105,7 +105,7 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp) -> None:
+    def __init__(self, req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.ModelService(**resource.struct_to_dict(req.observed.composite.resource))

--- a/functions/compose-model-service/function/fn.py
+++ b/functions/compose-model-service/function/fn.py
@@ -154,7 +154,7 @@ class Composer:
         for i in range(len(self.xr.spec.endpoints)):
             for d in request.get_required_resources(self.req, f"endpoints-{i}") or []:
                 ep = mev1alpha1.ModelEndpoint.model_validate(d)
-                key = f"{ep.metadata.namespace}/{ep.metadata.name}"
+                key = f"{ep.metadata.namespace}/{ep.metadata.name}"  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                 if key in seen_names:
                     continue
                 seen_names.add(key)
@@ -200,7 +200,7 @@ class Composer:
         correctly per-backend. This is a Gateway API Extended feature
         supported by Traefik Proxy.
         """
-        match_prefix = f"/{self.xr.metadata.namespace}/{self.xr.metadata.name}/"
+        match_prefix = f"/{self.xr.metadata.namespace}/{self.xr.metadata.name}/"  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
         match = {"path": {"type": "PathPrefix", "value": match_prefix}}
 
         backend_refs = []
@@ -238,7 +238,7 @@ class Composer:
             {
                 "apiVersion": "gateway.networking.k8s.io/v1",
                 "kind": "HTTPRoute",
-                "metadata": {"namespace": self.xr.metadata.namespace},
+                "metadata": {"namespace": self.xr.metadata.namespace},  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                 "spec": {
                     "parentRefs": [{"name": _GATEWAY_NAME, "namespace": _NAMESPACE_SYSTEM}],
                     "rules": [rule],
@@ -250,7 +250,7 @@ class Composer:
         status = v1alpha1.Status()
         gateway_ip = self.gateway.status.address if self.gateway else None
         if gateway_ip:
-            status.address = f"{_GATEWAY_SCHEME}://{gateway_ip}/{self.xr.metadata.namespace}/{self.xr.metadata.name}"
+            status.address = f"{_GATEWAY_SCHEME}://{gateway_ip}/{self.xr.metadata.namespace}/{self.xr.metadata.name}"  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
         resource.update_status(self.rsp.desired.composite, status)
 
     def derive_conditions(self):

--- a/functions/compose-model-service/function/fn.py
+++ b/functions/compose-model-service/function/fn.py
@@ -37,6 +37,7 @@ from crossplane.function.proto.v1 import run_function_pb2_grpc as grpcv1
 from models.ai.modelplane.inferencegateway import v1alpha1 as igwv1alpha1
 from models.ai.modelplane.modelendpoint import v1alpha1 as mev1alpha1
 from models.ai.modelplane.modelservice import v1alpha1
+from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
 
 CONDITION_TYPE_ENDPOINTS_RESOLVED = "EndpointsResolved"
 CONDITION_REASON_RESOLVED = "Resolved"
@@ -53,6 +54,20 @@ _NAMESPACE_SYSTEM = "modelplane-system"
 
 # Scheme for user-facing service URLs.
 _GATEWAY_SCHEME = "http"
+
+
+def _name(meta: metav1.ObjectMeta | None) -> str:
+    """The object's name, always set on resources read from the API server."""
+    if meta is None or meta.name is None:
+        raise ValueError("metadata.name is unexpectedly absent")
+    return meta.name
+
+
+def _namespace(meta: metav1.ObjectMeta | None) -> str:
+    """The object's namespace, always set on namespaced resources read from the API server."""
+    if meta is None or meta.namespace is None:
+        raise ValueError("metadata.namespace is unexpectedly absent")
+    return meta.namespace
 
 
 def _port_from_url(url: str) -> int:
@@ -147,7 +162,7 @@ class Composer:
         for i in range(len(self.xr.spec.endpoints)):
             for d in request.get_required_resources(self.req, f"endpoints-{i}") or []:
                 ep = mev1alpha1.ModelEndpoint.model_validate(d)
-                key = f"{ep.metadata.namespace}/{ep.metadata.name}"  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                key = f"{_namespace(ep.metadata)}/{_name(ep.metadata)}"
                 if key in seen_names:
                     continue
                 seen_names.add(key)
@@ -193,7 +208,7 @@ class Composer:
         correctly per-backend. This is a Gateway API Extended feature
         supported by Traefik Proxy.
         """
-        match_prefix = f"/{self.xr.metadata.namespace}/{self.xr.metadata.name}/"  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+        match_prefix = f"/{_namespace(self.xr.metadata)}/{_name(self.xr.metadata)}/"
         match = {"path": {"type": "PathPrefix", "value": match_prefix}}
 
         backend_refs = []
@@ -231,7 +246,7 @@ class Composer:
             {
                 "apiVersion": "gateway.networking.k8s.io/v1",
                 "kind": "HTTPRoute",
-                "metadata": {"namespace": self.xr.metadata.namespace},  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                "metadata": {"namespace": _namespace(self.xr.metadata)},
                 "spec": {
                     "parentRefs": [{"name": _GATEWAY_NAME, "namespace": _NAMESPACE_SYSTEM}],
                     "rules": [rule],
@@ -243,7 +258,9 @@ class Composer:
         status = v1alpha1.Status()
         gateway_ip = self.gateway.status.address if self.gateway and self.gateway.status else None
         if gateway_ip:
-            status.address = f"{_GATEWAY_SCHEME}://{gateway_ip}/{self.xr.metadata.namespace}/{self.xr.metadata.name}"  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+            status.address = (
+                f"{_GATEWAY_SCHEME}://{gateway_ip}/{_namespace(self.xr.metadata)}/{_name(self.xr.metadata)}"
+            )
         resource.update_status(self.rsp.desired.composite, status)
 
     def derive_conditions(self) -> None:

--- a/functions/compose-model-service/function/fn.py
+++ b/functions/compose-model-service/function/fn.py
@@ -55,15 +55,6 @@ _NAMESPACE_SYSTEM = "modelplane-system"
 _GATEWAY_SCHEME = "http"
 
 
-def _inference_gateway(
-    gw: igwv1alpha1.InferenceGateway,
-) -> igwv1alpha1.InferenceGateway:
-    """Return a copy with status fields defaulted."""
-    gw = gw.model_copy(deep=True)
-    gw.status = gw.status or igwv1alpha1.Status()
-    return gw
-
-
 def _port_from_url(url: str) -> int:
     """Parse the backend port from a ModelEndpoint URL.
 
@@ -149,7 +140,7 @@ class Composer:
             )
 
         gw_dict = request.get_required_resource(self.req, "inference-gateway")
-        self.gateway = _inference_gateway(igwv1alpha1.InferenceGateway.model_validate(gw_dict)) if gw_dict else None
+        self.gateway = igwv1alpha1.InferenceGateway.model_validate(gw_dict) if gw_dict else None
 
         # Gather matched endpoints from every selector entry.
         seen_names: set[str] = set()
@@ -250,7 +241,7 @@ class Composer:
 
     def write_status(self):
         status = v1alpha1.Status()
-        gateway_ip = self.gateway.status.address if self.gateway else None
+        gateway_ip = self.gateway.status.address if self.gateway and self.gateway.status else None
         if gateway_ip:
             status.address = f"{_GATEWAY_SCHEME}://{gateway_ip}/{self.xr.metadata.namespace}/{self.xr.metadata.name}"  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
         resource.update_status(self.rsp.desired.composite, status)

--- a/functions/compose-model-service/function/fn.py
+++ b/functions/compose-model-service/function/fn.py
@@ -87,7 +87,7 @@ def _has_parent_condition(req: fnv1.RunFunctionRequest, name: str, cond: str) ->
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
@@ -105,14 +105,14 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp):
+    def __init__(self, req, rsp) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.ModelService(**resource.struct_to_dict(req.observed.composite.resource))
         self.gateway = None
         self.endpoints: list[mev1alpha1.ModelEndpoint] = []
 
-    def compose(self):
+    def compose(self) -> None:
         if not self.resolve_inputs():
             return
         self.compose_httproute()
@@ -183,7 +183,7 @@ class Composer:
         )
         return True
 
-    def compose_httproute(self):
+    def compose_httproute(self) -> None:
         """Compose an HTTPRoute that load-balances across matched endpoints.
 
         A single rule matches the service prefix and fans out to all
@@ -239,14 +239,14 @@ class Composer:
             },
         )
 
-    def write_status(self):
+    def write_status(self) -> None:
         status = v1alpha1.Status()
         gateway_ip = self.gateway.status.address if self.gateway and self.gateway.status else None
         if gateway_ip:
             status.address = f"{_GATEWAY_SCHEME}://{gateway_ip}/{self.xr.metadata.namespace}/{self.xr.metadata.name}"  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
         resource.update_status(self.rsp.desired.composite, status)
 
-    def derive_conditions(self):
+    def derive_conditions(self) -> None:
         """RoutingReady: HTTPRoute is composed and Accepted with backends."""
         if "httproute" not in self.rsp.desired.resources:
             response.set_conditions(

--- a/functions/compose-model-service/function/fn.py
+++ b/functions/compose-model-service/function/fn.py
@@ -93,14 +93,16 @@ def _has_parent_condition(req: fnv1.RunFunctionRequest, name: str, cond: str) ->
     return False
 
 
-class FunctionRunner(grpcv1.FunctionRunnerService):
+class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
     def __init__(self):
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
-    async def RunFunction(self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext) -> fnv1.RunFunctionResponse:
+    async def RunFunction(
+        self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext | None
+    ) -> fnv1.RunFunctionResponse:  # ty: ignore[invalid-method-override]  # the generated grpc servicer base is untyped
         """Run the function."""
         log = self.log.bind(tag=req.meta.tag)
         log.info("Running function")

--- a/functions/compose-serving-stack/function/fn.py
+++ b/functions/compose-serving-stack/function/fn.py
@@ -315,7 +315,7 @@ class Composer:
                 source="Secret",
                 secretRef=k8spcv1alpha1.SecretRef(
                     name=kubeconfig_secret.name,
-                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
                     key=kubeconfig_secret.key,
                 ),
             ),
@@ -325,7 +325,7 @@ class Composer:
                 source="Secret",
                 secretRef=helmpcv1beta1.SecretRef(
                     name=kubeconfig_secret.name,
-                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
                     key=kubeconfig_secret.key,
                 ),
             ),
@@ -341,7 +341,7 @@ class Composer:
                 source="Secret",
                 secretRef=k8spcv1alpha1.SecretRef(
                     name=gcp_secret.name,
-                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
                     key=gcp_secret.key,
                 ),
             )
@@ -350,7 +350,7 @@ class Composer:
                 source="Secret",
                 secretRef=helmpcv1beta1.SecretRef(
                     name=gcp_secret.name,
-                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
+                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
                     key=gcp_secret.key,
                 ),
             )

--- a/functions/compose-serving-stack/function/fn.py
+++ b/functions/compose-serving-stack/function/fn.py
@@ -251,9 +251,9 @@ def _prometheus_release(version: str, provider_config: str) -> helmv1beta1.Relea
     )
 
 
-def _pc_name(xr):
+def _pc_name(xr: v1alpha1.ServingStack) -> str:
     """Derive the ProviderConfig name from the XR."""
-    return resource.child_name(xr.metadata.name, "cluster")
+    return resource.child_name(xr.metadata.name, "cluster")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
 
 
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
@@ -277,7 +277,7 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp) -> None:
+    def __init__(self, req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.ServingStack(**resource.struct_to_dict(req.observed.composite.resource))
@@ -827,7 +827,7 @@ class Composer:
             ):
                 self.rsp.desired.resources[r].ready = fnv1.READY_TRUE
 
-    def provider_configs_observed(self):
+    def provider_configs_observed(self) -> bool:
         """Check if both ProviderConfigs have been persisted by Crossplane from
         a previous reconcile. Resources targeting the remote cluster are gated
         on this to avoid transient 'ProviderConfig not found' errors on first

--- a/functions/compose-serving-stack/function/fn.py
+++ b/functions/compose-serving-stack/function/fn.py
@@ -313,7 +313,7 @@ class Composer:
                 source="Secret",
                 secretRef=k8spcv1alpha1.SecretRef(
                     name=kubeconfig_secret.name,
-                    namespace=self.xr.metadata.namespace,
+                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     key=kubeconfig_secret.key,
                 ),
             ),
@@ -323,7 +323,7 @@ class Composer:
                 source="Secret",
                 secretRef=helmpcv1beta1.SecretRef(
                     name=kubeconfig_secret.name,
-                    namespace=self.xr.metadata.namespace,
+                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     key=kubeconfig_secret.key,
                 ),
             ),
@@ -339,7 +339,7 @@ class Composer:
                 source="Secret",
                 secretRef=k8spcv1alpha1.SecretRef(
                     name=gcp_secret.name,
-                    namespace=self.xr.metadata.namespace,
+                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     key=gcp_secret.key,
                 ),
             )
@@ -348,7 +348,7 @@ class Composer:
                 source="Secret",
                 secretRef=helmpcv1beta1.SecretRef(
                     name=gcp_secret.name,
-                    namespace=self.xr.metadata.namespace,
+                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute]  # metadata is always set on resources read from the API server
                     key=gcp_secret.key,
                 ),
             )

--- a/functions/compose-serving-stack/function/fn.py
+++ b/functions/compose-serving-stack/function/fn.py
@@ -259,7 +259,7 @@ def _pc_name(xr):
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
@@ -277,12 +277,12 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 
 
 class Composer:
-    def __init__(self, req, rsp):
+    def __init__(self, req, rsp) -> None:
         self.req = req
         self.rsp = rsp
         self.xr = v1alpha1.ServingStack(**resource.struct_to_dict(req.observed.composite.resource))
 
-    def compose(self):
+    def compose(self) -> None:
         self.compose_provider_configs()
         self.compose_usages()
         self.compose_cert_manager()
@@ -297,7 +297,7 @@ class Composer:
         self.write_status()
         self.mark_readiness()
 
-    def compose_provider_configs(self):
+    def compose_provider_configs(self) -> None:
         """Build ProviderConfigs from the XR's secrets.
 
         The XRD requires a Kubeconfig secret, so one is always present.
@@ -371,7 +371,7 @@ class Composer:
             ),
         )
 
-    def compose_usages(self):
+    def compose_usages(self) -> None:
         """Compose Usages ordering the Envoy Gateway teardown.
 
         The Envoy Gateway controller must outlive the Gateway and GatewayClass
@@ -441,7 +441,7 @@ class Composer:
         )
         self.rsp.desired.resources["usage-envoy-gw-by-gateway-class"].ready = fnv1.READY_TRUE
 
-    def compose_cert_manager(self):
+    def compose_cert_manager(self) -> None:
         """Compose cert-manager. Gated on ProviderConfigs being observed."""
         pc_observed = self.provider_configs_observed()
         if not (pc_observed or "cert-manager" in self.req.observed.resources):
@@ -460,7 +460,7 @@ class Composer:
             ),
         )
 
-    def compose_envoy_gateway(self):
+    def compose_envoy_gateway(self) -> None:
         """Compose Envoy Gateway. Gated on ProviderConfigs being observed.
 
         The extensionManager block points Envoy Gateway at the Envoy AI Gateway
@@ -519,7 +519,7 @@ class Composer:
             ),
         )
 
-    def compose_ai_gateway(self):
+    def compose_ai_gateway(self) -> None:
         """Compose the Envoy AI Gateway CRDs and controller. Gated on the same
         ProviderConfigs as Envoy Gateway.
 
@@ -551,7 +551,7 @@ class Composer:
             ),
         )
 
-    def compose_gaie_crds(self):
+    def compose_gaie_crds(self) -> None:
         """Compose the Gateway API Inference Extension (GAIE) CRDs as
         provider-kubernetes Objects on the remote cluster. Gated on the same
         ProviderConfigs as Envoy Gateway.
@@ -568,7 +568,7 @@ class Composer:
             if resource.get_condition(self.req.observed.resources.get(key), "Ready").status == "True":
                 self.rsp.desired.resources[key].ready = fnv1.READY_TRUE
 
-    def compose_prometheus(self):
+    def compose_prometheus(self) -> None:
         """Compose the kube-prometheus-stack. Gated on ProviderConfigs being
         observed. Provides cluster observability (metrics scraping)."""
         pc_observed = self.provider_configs_observed()
@@ -581,7 +581,7 @@ class Composer:
             _prometheus_release(v.prometheus, _pc_name(self.xr)),  # ty: ignore[invalid-argument-type]  # XRD defaults this version and forbids null
         )
 
-    def compose_leader_worker_set(self):
+    def compose_leader_worker_set(self) -> None:
         """Compose LeaderWorkerSet. Gated on ProviderConfigs being observed."""
         pc_observed = self.provider_configs_observed()
         if not (pc_observed or "leader-worker-set" in self.req.observed.resources):
@@ -599,7 +599,7 @@ class Composer:
             ),
         )
 
-    def compose_node_feature_discovery(self):
+    def compose_node_feature_discovery(self) -> None:
         """Compose Node Feature Discovery. Gated on ProviderConfigs being
         observed. NFD labels GPU nodes (e.g. feature.node.kubernetes.io/pci-10de
         for NVIDIA) so the DRA driver can target its kubelet plugin to them."""
@@ -619,7 +619,7 @@ class Composer:
             ),
         )
 
-    def compose_dra_driver(self):
+    def compose_dra_driver(self) -> None:
         """Compose the NVIDIA DRA driver. Gated on ProviderConfigs being
         observed. The driver publishes each GPU node's devices as DRA
         ResourceSlices and registers the gpu.nvidia.com DeviceClass that
@@ -695,7 +695,7 @@ class Composer:
             ),
         )
 
-    def compose_gateway(self):
+    def compose_gateway(self) -> None:
         """Compose the GatewayClass and Gateway on the remote cluster. Gated on
         ProviderConfigs being observed."""
         pc_observed = self.provider_configs_observed()
@@ -770,7 +770,7 @@ class Composer:
                 ),
             )
 
-    def write_status(self):
+    def write_status(self) -> None:
         """Extract the gateway address from the observed Gateway Object and
         write it to the XR's status."""
         gateway_address = None
@@ -792,7 +792,7 @@ class Composer:
             status.gateway = v1alpha1.GatewayModel(address=gateway_address)
         resource.update_status(self.rsp.desired.composite, status)
 
-    def mark_readiness(self):
+    def mark_readiness(self) -> None:
         """Mark composed resources as ready. Resources that don't need external
         readiness tracking are always marked ready. Others are marked ready when
         their observed condition is True."""

--- a/functions/compose-serving-stack/function/fn.py
+++ b/functions/compose-serving-stack/function/fn.py
@@ -102,6 +102,20 @@ _GAIE_CRDS = [
 ]
 
 
+def _name(meta: metav1.ObjectMeta | None) -> str:
+    """The object's name, always set on resources read from the API server."""
+    if meta is None or meta.name is None:
+        raise ValueError("metadata.name is unexpectedly absent")
+    return meta.name
+
+
+def _namespace(meta: metav1.ObjectMeta | None) -> str:
+    """The object's namespace, always set on namespaced resources read from the API server."""
+    if meta is None or meta.namespace is None:
+        raise ValueError("metadata.namespace is unexpectedly absent")
+    return meta.namespace
+
+
 def _gaie_crd_key(doc: dict) -> str:
     """Stable composed-resource key for a GAIE CRD."""
     return f"gaie-crd-{doc['metadata']['name']}"
@@ -253,7 +267,7 @@ def _prometheus_release(version: str, provider_config: str) -> helmv1beta1.Relea
 
 def _pc_name(xr: v1alpha1.ServingStack) -> str:
     """Derive the ProviderConfig name from the XR."""
-    return resource.child_name(xr.metadata.name, "cluster")  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+    return resource.child_name(_name(xr.metadata), "cluster")
 
 
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
@@ -315,7 +329,7 @@ class Composer:
                 source="Secret",
                 secretRef=k8spcv1alpha1.SecretRef(
                     name=kubeconfig_secret.name,
-                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+                    namespace=_namespace(self.xr.metadata),
                     key=kubeconfig_secret.key,
                 ),
             ),
@@ -325,7 +339,7 @@ class Composer:
                 source="Secret",
                 secretRef=helmpcv1beta1.SecretRef(
                     name=kubeconfig_secret.name,
-                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+                    namespace=_namespace(self.xr.metadata),
                     key=kubeconfig_secret.key,
                 ),
             ),
@@ -341,7 +355,7 @@ class Composer:
                 source="Secret",
                 secretRef=k8spcv1alpha1.SecretRef(
                     name=gcp_secret.name,
-                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+                    namespace=_namespace(self.xr.metadata),
                     key=gcp_secret.key,
                 ),
             )
@@ -350,7 +364,7 @@ class Composer:
                 source="Secret",
                 secretRef=helmpcv1beta1.SecretRef(
                     name=gcp_secret.name,
-                    namespace=self.xr.metadata.namespace,  # ty: ignore[unresolved-attribute, invalid-argument-type]  # metadata is always set on resources read from the API server
+                    namespace=_namespace(self.xr.metadata),
                     key=gcp_secret.key,
                 ),
             )

--- a/functions/compose-serving-stack/function/fn.py
+++ b/functions/compose-serving-stack/function/fn.py
@@ -256,14 +256,16 @@ def _pc_name(xr):
     return resource.child_name(xr.metadata.name, "cluster")
 
 
-class FunctionRunner(grpcv1.FunctionRunnerService):
+class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
     def __init__(self):
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
-    async def RunFunction(self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext) -> fnv1.RunFunctionResponse:
+    async def RunFunction(
+        self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext | None
+    ) -> fnv1.RunFunctionResponse:  # ty: ignore[invalid-method-override]  # the generated grpc servicer base is untyped
         """Run the function."""
         log = self.log.bind(tag=req.meta.tag)
         log.info("Running function")

--- a/functions/compose-serving-stack/function/fn.py
+++ b/functions/compose-serving-stack/function/fn.py
@@ -453,7 +453,7 @@ class Composer:
             _helm_release(
                 chart="cert-manager",
                 repo="https://charts.jetstack.io",
-                version=v.certManager,
+                version=v.certManager,  # ty: ignore[invalid-argument-type]  # XRD defaults this version and forbids null
                 namespace="cert-manager",
                 provider_config=_pc_name(self.xr),
                 values={"crds": {"enabled": True, "keep": False}},
@@ -479,7 +479,7 @@ class Composer:
             _helm_release(
                 chart="gateway-helm",
                 repo="oci://docker.io/envoyproxy",
-                version=v.envoyGateway,
+                version=v.envoyGateway,  # ty: ignore[invalid-argument-type]  # XRD defaults this version and forbids null
                 namespace="envoy-gateway-system",
                 provider_config=_pc_name(self.xr),
                 labels={_LABEL_RESOURCE: "envoy-gateway"},
@@ -578,7 +578,7 @@ class Composer:
         v = self.xr.spec.versions or v1alpha1.Versions()
         resource.update(
             self.rsp.desired.resources["prometheus"],
-            _prometheus_release(v.prometheus, _pc_name(self.xr)),
+            _prometheus_release(v.prometheus, _pc_name(self.xr)),  # ty: ignore[invalid-argument-type]  # XRD defaults this version and forbids null
         )
 
     def compose_leader_worker_set(self):
@@ -593,7 +593,7 @@ class Composer:
             _helm_release(
                 chart="lws",
                 repo="oci://registry.k8s.io/lws/charts",
-                version=v.leaderWorkerSet,
+                version=v.leaderWorkerSet,  # ty: ignore[invalid-argument-type]  # XRD defaults this version and forbids null
                 namespace="lws-system",
                 provider_config=_pc_name(self.xr),
             ),
@@ -613,7 +613,7 @@ class Composer:
             _helm_release(
                 chart="node-feature-discovery",
                 repo="oci://registry.k8s.io/nfd/charts",
-                version=v.nodeFeatureDiscovery,
+                version=v.nodeFeatureDiscovery,  # ty: ignore[invalid-argument-type]  # XRD defaults this version and forbids null
                 namespace="node-feature-discovery",
                 provider_config=_pc_name(self.xr),
             ),
@@ -650,7 +650,7 @@ class Composer:
             _helm_release(
                 chart="dra-driver-nvidia-gpu",
                 repo="oci://registry.k8s.io/dra-driver-nvidia/charts",
-                version=v.nvidiaDraDriver,
+                version=v.nvidiaDraDriver,  # ty: ignore[invalid-argument-type]  # XRD defaults this version and forbids null
                 namespace=_DRA_DRIVER_NAMESPACE,
                 provider_config=_pc_name(self.xr),
                 values=dra_values,

--- a/functions/compose-usages/function/fn.py
+++ b/functions/compose-usages/function/fn.py
@@ -63,7 +63,7 @@ def _api_group(api_version: str) -> str:
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
@@ -82,11 +82,11 @@ class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
 class Composer:
     """Composes ProviderConfig-protecting Usages from desired resources."""
 
-    def __init__(self, req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
+    def __init__(self, req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse) -> None:
         self.req = req
         self.rsp = rsp
 
-    def compose(self):
+    def compose(self) -> None:
         """Compose one Usage per ProviderConfig-referencing consumer.
 
         Iterates the desired resources copied from the request and, for each

--- a/functions/compose-usages/function/fn.py
+++ b/functions/compose-usages/function/fn.py
@@ -60,14 +60,16 @@ def _api_group(api_version: str) -> str:
     return api_version.split("/", 1)[0]
 
 
-class FunctionRunner(grpcv1.FunctionRunnerService):
+class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
     def __init__(self):
         """Create a new FunctionRunner."""
         self.log = logging.get_logger()
 
-    async def RunFunction(self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext) -> fnv1.RunFunctionResponse:
+    async def RunFunction(
+        self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext | None
+    ) -> fnv1.RunFunctionResponse:  # ty: ignore[invalid-method-override]  # the generated grpc servicer base is untyped
         """Run the function."""
         log = self.log.bind(tag=req.meta.tag)
         log.info("Running function")

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -14,7 +14,7 @@
         name = "modelplane-fix";
         runtimeInputs = [
           pkgs.findutils
-          pkgs.ruff
+          pkgs.unstable.ruff
           pkgs.statix
           pkgs.deadnix
           pkgs.nixfmt-rfc-style

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -40,6 +40,37 @@ let
       mkdir -p $out
       touch $out/.tests-passed
     '';
+
+  # Type-check each function with ty. Each function exports its own 'function'
+  # module, so checking all functions at once would let ty resolve one
+  # function's `function.fn` import to another's package. We check each in
+  # isolation against a venv that provides its dependencies, plus the protobuf
+  # type stubs ty needs to resolve the SDK's generated Struct and Duration.
+  #
+  # Unlike mkFunctionTest, which runs the function module from the venv, ty
+  # checks the source, so we copy function/ and tests/ from the tree. We also
+  # copy pyproject.toml: the sandbox has no parent tree for ty to discover the
+  # [tool.ty] config in, where the target Python version is set.
+  mkFunctionTypeCheck =
+    name:
+    let
+      venv = pythonSet.mkVirtualEnv "${name}-ty-env" {
+        ${name} = [ ];
+        types-protobuf = [ ];
+      };
+    in
+    pkgs.runCommand "modelplane-ty-${name}"
+      {
+        nativeBuildInputs = [ pkgs.unstable.ty ];
+      }
+      ''
+        cp -r ${self}/functions/${name}/function function
+        cp -r ${self}/functions/${name}/tests tests
+        cp ${self}/pyproject.toml pyproject.toml
+        ty check function tests --python ${venv}
+        mkdir -p $out
+        touch $out/.ty-passed
+      '';
 in
 {
   # Verify the docs site builds. The build is the check.
@@ -74,7 +105,7 @@ in
   python =
     pkgs.runCommand "modelplane-python-checks"
       {
-        nativeBuildInputs = [ pkgs.ruff ];
+        nativeBuildInputs = [ pkgs.unstable.ruff ];
       }
       ''
         cp -r ${self} src
@@ -177,5 +208,11 @@ in
   map (name: {
     name = "test-${name}";
     value = mkFunctionTest name;
+  }) functionNames
+)
+// builtins.listToAttrs (
+  map (name: {
+    name = "ty-${name}";
+    value = mkFunctionTypeCheck name;
   }) functionNames
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,18 @@ select = [
     "FBT",    # flake8-boolean-trap (no boolean positional args)
     "TID",    # flake8-tidy-imports (no relative imports)
     "BLE",    # flake8-blind-except (no bare except Exception)
+    "ANN",    # flake8-annotations (require type annotations)
     "RUF",    # ruff-specific rules (incl. unused/malformed noqa)
 ]
 
 [tool.ruff.lint.pylint]
 # Builder functions like helm_release use named parameters for clarity.
 max-args = 8
+
+[tool.ruff.lint.flake8-annotations]
+# Variadic **kwargs spread into a Pydantic model constructor are inherently
+# dynamic; allow Any for *args/**kwargs while still flagging it elsewhere.
+allow-star-arg-any = true
 
 [tool.ruff.lint.per-file-ignores]
 # Generated models are not under our control.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ members = ["functions/*", "schemas/python"]
 [dependency-groups]
 dev = [
   "crossplane-function-sdk-python>=0.14.0",
+  # Type stubs for the dynamically generated protobuf modules, so ty can
+  # resolve the Struct and Duration types the functions and tests use.
+  "types-protobuf>=4.24",
 ]
 
 [tool.ruff]
@@ -63,3 +66,11 @@ max-args = 8
 # main.py is the click CLI entrypoint: boolean flags are idiomatic, and it
 # catches Exception at the top level to report startup failures cleanly.
 "functions/*/function/main.py" = ["FBT001", "BLE001"]
+
+[tool.ty.environment]
+# The functions target Python 3.12 (see tool.ruff target-version).
+python-version = "3.12"
+
+[tool.ty.src]
+# The generated Pydantic models aren't under our control and aren't checked.
+exclude = ["schemas/python"]

--- a/uv.lock
+++ b/uv.lock
@@ -446,12 +446,16 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "crossplane-function-sdk-python" },
+    { name = "types-protobuf" },
 ]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
-dev = [{ name = "crossplane-function-sdk-python", specifier = ">=0.14.0" }]
+dev = [
+    { name = "crossplane-function-sdk-python", specifier = ">=0.14.0" },
+    { name = "types-protobuf", specifier = ">=4.24" },
+]
 
 [[package]]
 name = "pendulum"
@@ -670,6 +674,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
+]
+
+[[package]]
+name = "types-protobuf"
+version = "7.34.1.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/59/e2b13b499d15e6720150c4b1a8d91e31fcacf716b432397475b3151ff7e4/types_protobuf-7.34.1.20260518.tar.gz", hash = "sha256:28cfaded25889cb83ebfb63cfb0a43628f0b6f3785767bec17287dc6468795f2", size = 68936, upload-time = "2026-05-18T06:01:47.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/1f/ec5caf72c2e3b688ca3927e0979a04ddad19e1afc4bf1c199bd743e0f419/types_protobuf-7.34.1.20260518-py3-none-any.whl", hash = "sha256:a0a5337413347166439c0e07cbc26c6164d091401c6f01b1dfd8cdb966c4dd8f", size = 85992, upload-time = "2026-05-18T06:01:45.696Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Modelplane releases as open source with the expectation of contributions, many machine-generated. Tests catch behavioural regressions, but not a wrong type passed to an SDK call, a dropped required field, or a None flowing where it can't be handled. This wires in [ty](https://docs.astral.sh/ty) as a CI gate on every composition function, and turns on ruff's annotation rules so the code carries the types ty needs.

ty runs per function, each against its own virtualenv, the isolation the unit tests already use. ty and ruff move to `pkgs.unstable`, since stable doesn't package ty.

Getting clean was most of the work. ty surfaced 266 diagnostics: some real bugs, some latent assumptions worth making explicit, and some artifacts of the generated Pydantic models being more permissive than the runtime contract. The artifacts carry a documented `ty: ignore` at the site, each naming why the diagnostic isn't a bug — metadata the API server always populates, XRD-defaulted fields, library stubs that don't model their own types. The largest class traces to the Crossplane CLI's generator typing `metadata.name` as optional where the Go bindings type it as a string; fixing it upstream would remove those suppressions here and in every future function, and is a follow-up. The rest are fixed.

A sample of the genuine issues caught, none by the tests:

- Every `FunctionRunner` subclassed the gRPC client stub rather than the servicer base; it worked only because gRPC dispatch is duck-typed.
- compose-gke-cluster passed `namespace=` to a connection-secret ref with no namespace field, which Pydantic silently dropped.
- A node pool's zones (a constrained-string `RootModel`) were assigned to a plain-string field, producing a serialization warning that only happened to round-trip.
- The ModelDeployment scheduler read `cluster.status.gateway` without checking `cluster.status`, so a cluster yet to report status would raise instead of being judged not-ready.

The per-function commits carry the reasoning for each function's fixes.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
