### PR TITLE
Add Apache 2.0 license headers to source files

### DIFF
--- a/docs/utils/validate/validate_manifests.py
+++ b/docs/utils/validate/validate_manifests.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Validate docs example manifests against the generated Pydantic models.
 
 Every Modelplane manifest the docs show — the raw YAML files under

--- a/docs/vercel-build.sh
+++ b/docs/vercel-build.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Build the docs site on Vercel using Nix.
 #
 # Vercel's build image is fixed (Amazon Linux 2023) and can't be swapped for a

--- a/functions/compose-eks-cluster/function/__init__.py
+++ b/functions/compose-eks-cluster/function/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-eks-cluster/function/fn.py
+++ b/functions/compose-eks-cluster/function/fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Compose an EKS cluster with networking, node groups, and IAM roles.
 
 This function provisions the AWS infrastructure for an inference environment:

--- a/functions/compose-eks-cluster/function/main.py
+++ b/functions/compose-eks-cluster/function/main.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The composition function's main CLI."""
 
 import click

--- a/functions/compose-eks-cluster/tests/__init__.py
+++ b/functions/compose-eks-cluster/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-eks-cluster/tests/test_fn.py
+++ b/functions/compose-eks-cluster/tests/test_fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the compose-eks-cluster function."""
 
 import dataclasses

--- a/functions/compose-gke-cluster/function/__init__.py
+++ b/functions/compose-gke-cluster/function/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-gke-cluster/function/fn.py
+++ b/functions/compose-gke-cluster/function/fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Compose a GKE cluster with networking, node pools, and service accounts.
 
 This function provisions the GCP infrastructure for an inference environment:

--- a/functions/compose-gke-cluster/function/main.py
+++ b/functions/compose-gke-cluster/function/main.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The composition function's main CLI."""
 
 import click

--- a/functions/compose-gke-cluster/tests/__init__.py
+++ b/functions/compose-gke-cluster/tests/__init__.py
@@ -1,1 +1,15 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 

--- a/functions/compose-gke-cluster/tests/test_fn.py
+++ b/functions/compose-gke-cluster/tests/test_fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the compose-gke-cluster function."""
 
 import dataclasses

--- a/functions/compose-inference-class/function/__init__.py
+++ b/functions/compose-inference-class/function/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-inference-class/function/fn.py
+++ b/functions/compose-inference-class/function/fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Compose an InferenceClass.
 
 InferenceClass is a data resource: it describes hardware (devices) and

--- a/functions/compose-inference-class/function/main.py
+++ b/functions/compose-inference-class/function/main.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The composition function's main CLI."""
 
 import click

--- a/functions/compose-inference-class/tests/__init__.py
+++ b/functions/compose-inference-class/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-inference-class/tests/test_fn.py
+++ b/functions/compose-inference-class/tests/test_fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the compose-inference-class function."""
 
 import dataclasses

--- a/functions/compose-inference-cluster/function/__init__.py
+++ b/functions/compose-inference-cluster/function/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-inference-cluster/function/fn.py
+++ b/functions/compose-inference-cluster/function/fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Compose an InferenceCluster.
 
 This function orchestrates the internal XRs that make up an inference

--- a/functions/compose-inference-cluster/function/main.py
+++ b/functions/compose-inference-cluster/function/main.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The composition function's main CLI."""
 
 import click

--- a/functions/compose-inference-cluster/tests/__init__.py
+++ b/functions/compose-inference-cluster/tests/__init__.py
@@ -1,1 +1,15 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 

--- a/functions/compose-inference-cluster/tests/test_fn.py
+++ b/functions/compose-inference-cluster/tests/test_fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the compose-inference-cluster function."""
 
 import dataclasses

--- a/functions/compose-inference-gateway/function/__init__.py
+++ b/functions/compose-inference-gateway/function/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-inference-gateway/function/fn.py
+++ b/functions/compose-inference-gateway/function/fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Compose the control plane routing gateway.
 
 This function installs Traefik Proxy on the control plane cluster via Helm,

--- a/functions/compose-inference-gateway/function/main.py
+++ b/functions/compose-inference-gateway/function/main.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The composition function's main CLI."""
 
 import click

--- a/functions/compose-inference-gateway/tests/__init__.py
+++ b/functions/compose-inference-gateway/tests/__init__.py
@@ -1,1 +1,15 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 

--- a/functions/compose-inference-gateway/tests/test_fn.py
+++ b/functions/compose-inference-gateway/tests/test_fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the compose-inference-gateway function."""
 
 import dataclasses

--- a/functions/compose-model-cache/function/__init__.py
+++ b/functions/compose-model-cache/function/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-model-cache/function/fn.py
+++ b/functions/compose-model-cache/function/fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Compose a ModelCache.
 
 Stages a HuggingFace model onto a ReadWriteMany PVC on every matched

--- a/functions/compose-model-cache/function/main.py
+++ b/functions/compose-model-cache/function/main.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The composition function's main CLI."""
 
 import click

--- a/functions/compose-model-cache/tests/test_fn.py
+++ b/functions/compose-model-cache/tests/test_fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the compose-model-cache function."""
 
 import dataclasses

--- a/functions/compose-model-deployment/function/__init__.py
+++ b/functions/compose-model-deployment/function/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-model-deployment/function/cel.py
+++ b/functions/compose-model-deployment/function/cel.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """DRA CEL evaluation for ModelDeployment.nodeSelector.
 
 The design lets an ML team write CEL selectors that the fleet scheduler

--- a/functions/compose-model-deployment/function/fn.py
+++ b/functions/compose-model-deployment/function/fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Fan out a ModelDeployment to ModelReplicas and ModelEndpoints.
 
 This function discovers InferenceClusters, matches the deployment's

--- a/functions/compose-model-deployment/function/main.py
+++ b/functions/compose-model-deployment/function/main.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The composition function's main CLI."""
 
 import click

--- a/functions/compose-model-deployment/function/name.py
+++ b/functions/compose-model-deployment/function/name.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Derive the identifiers a ModelDeployment uses for its replicas.
 
 One place owns every name a replica's resources are known by, so the

--- a/functions/compose-model-deployment/function/quantity.py
+++ b/functions/compose-model-deployment/function/quantity.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Kubernetes resource.Quantity, reimplemented for DRA CEL selectors.
 
 Mirrors the apiserver Quantity CEL library (k8s.io/apiserver/pkg/cel/library/

--- a/functions/compose-model-deployment/function/scheduling.py
+++ b/functions/compose-model-deployment/function/scheduling.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Schedule a ModelDeployment's replicas across inference clusters.
 
 The scheduler is a pure function of observed state. Every reconcile it is

--- a/functions/compose-model-deployment/function/semver.py
+++ b/functions/compose-model-deployment/function/semver.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Semantic versions, reimplemented for DRA CEL selectors.
 
 Mirrors the apiserver Semver CEL library (k8s.io/apiserver/pkg/cel/library/

--- a/functions/compose-model-deployment/tests/__init__.py
+++ b/functions/compose-model-deployment/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-model-deployment/tests/oracle/main.go
+++ b/functions/compose-model-deployment/tests/oracle/main.go
@@ -1,3 +1,17 @@
+// Copyright 2026 The Modelplane Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Command oracle is a parity oracle for the quantity, semver, and cel Python
 // modules. It runs inputs through the real Kubernetes code those modules
 // reimplement and prints what upstream actually does:

--- a/functions/compose-model-deployment/tests/test_cel.py
+++ b/functions/compose-model-deployment/tests/test_cel.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the DRA CEL selector module.
 
 Pins Program.matches - the device activation shape, qualified-name domains,

--- a/functions/compose-model-deployment/tests/test_fn.py
+++ b/functions/compose-model-deployment/tests/test_fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the compose-model-deployment function."""
 
 import dataclasses

--- a/functions/compose-model-deployment/tests/test_quantity.py
+++ b/functions/compose-model-deployment/tests/test_quantity.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the quantity module.
 
 The cases mirror upstream's quantity CEL surface so we catch regressions against

--- a/functions/compose-model-deployment/tests/test_scheduling.py
+++ b/functions/compose-model-deployment/tests/test_scheduling.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the scheduling module.
 
 Unit tests for the retain-then-place scheduler. These construct

--- a/functions/compose-model-deployment/tests/test_semver.py
+++ b/functions/compose-model-deployment/tests/test_semver.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the semver module.
 
 The cases mirror upstream's semver CEL surface so we catch regressions against

--- a/functions/compose-model-endpoint/function/__init__.py
+++ b/functions/compose-model-endpoint/function/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-model-endpoint/function/fn.py
+++ b/functions/compose-model-endpoint/function/fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Compose a Kubernetes Service and EndpointSlice from a ModelEndpoint.
 
 ModelEndpoint is a reachable inference endpoint. This function parses

--- a/functions/compose-model-endpoint/function/main.py
+++ b/functions/compose-model-endpoint/function/main.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The composition function's main CLI."""
 
 import click

--- a/functions/compose-model-endpoint/tests/__init__.py
+++ b/functions/compose-model-endpoint/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-model-endpoint/tests/test_fn.py
+++ b/functions/compose-model-endpoint/tests/test_fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the compose-model-endpoint function."""
 
 import dataclasses

--- a/functions/compose-model-replica/function/__init__.py
+++ b/functions/compose-model-replica/function/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-model-replica/function/backends/__init__.py
+++ b/functions/compose-model-replica/function/backends/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-model-replica/function/backends/base.py
+++ b/functions/compose-model-replica/function/backends/base.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Backend dispatch for compose-model-replica.
 
 A backend turns a ModelReplica + its InferenceCluster into the cluster-level

--- a/functions/compose-model-replica/function/backends/dynamo.py
+++ b/functions/compose-model-replica/function/backends/dynamo.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """NVIDIA Dynamo backend — designed-for, not built in v0.1.
 
 The dispatcher never selects this in v0.1 (no Dynamo-only capability is wired).

--- a/functions/compose-model-replica/function/backends/llmd.py
+++ b/functions/compose-model-replica/function/backends/llmd.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """llm-d multi-pod backend: a LeaderWorkerSet for a Leader/Worker engine.
 
 Selected for an engine with a Leader and a Worker, so this always renders a

--- a/functions/compose-model-replica/function/backends/native.py
+++ b/functions/compose-model-replica/function/backends/native.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Native single-pod backend: a Kubernetes Deployment for a Standalone engine.
 
 For a single self-contained pod no orchestrator is needed. Weights load

--- a/functions/compose-model-replica/function/fn.py
+++ b/functions/compose-model-replica/function/fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Deploy a model on a single InferenceCluster.
 
 This function reads the referenced InferenceCluster via required resources, then

--- a/functions/compose-model-replica/function/main.py
+++ b/functions/compose-model-replica/function/main.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The composition function's main CLI."""
 
 import click

--- a/functions/compose-model-replica/function/routing.py
+++ b/functions/compose-model-replica/function/routing.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Routing: front a replica's engine workloads with a serving surface.
 
 The workload backends (native, llm-d, dynamo) compose engines only; this layer

--- a/functions/compose-model-replica/tests/__init__.py
+++ b/functions/compose-model-replica/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-model-replica/tests/test_backends.py
+++ b/functions/compose-model-replica/tests/test_backends.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for compose-model-replica backends.
 
 A backend builds the workload (Deployment or LeaderWorkerSet) and the

--- a/functions/compose-model-replica/tests/test_fn.py
+++ b/functions/compose-model-replica/tests/test_fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the compose-model-replica function."""
 
 import dataclasses

--- a/functions/compose-model-service/function/__init__.py
+++ b/functions/compose-model-service/function/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-model-service/function/fn.py
+++ b/functions/compose-model-service/function/fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Compose a Gateway-API HTTPRoute from a ModelService.
 
 ModelService selects ModelEndpoints by label and load-balances across

--- a/functions/compose-model-service/function/main.py
+++ b/functions/compose-model-service/function/main.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The composition function's main CLI."""
 
 import click

--- a/functions/compose-model-service/tests/__init__.py
+++ b/functions/compose-model-service/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-model-service/tests/test_fn.py
+++ b/functions/compose-model-service/tests/test_fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the compose-model-service function."""
 
 import dataclasses

--- a/functions/compose-serving-stack/function/__init__.py
+++ b/functions/compose-serving-stack/function/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-serving-stack/function/fn.py
+++ b/functions/compose-serving-stack/function/fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Install the serving substrate on a remote cluster.
 
 This function composes the serving substrate (the cluster-side CRDs,

--- a/functions/compose-serving-stack/function/main.py
+++ b/functions/compose-serving-stack/function/main.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The composition function's main CLI."""
 
 import click

--- a/functions/compose-serving-stack/tests/__init__.py
+++ b/functions/compose-serving-stack/tests/__init__.py
@@ -1,1 +1,15 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 

--- a/functions/compose-serving-stack/tests/test_fn.py
+++ b/functions/compose-serving-stack/tests/test_fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the compose-serving-stack function."""
 
 import unittest

--- a/functions/compose-usages/function/__init__.py
+++ b/functions/compose-usages/function/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-usages/function/fn.py
+++ b/functions/compose-usages/function/fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Protect ProviderConfigs from deletion until their consumers are gone.
 
 This function runs late in a composition pipeline. It reads the desired

--- a/functions/compose-usages/function/main.py
+++ b/functions/compose-usages/function/main.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The composition function's main CLI."""
 
 import click

--- a/functions/compose-usages/tests/__init__.py
+++ b/functions/compose-usages/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/functions/compose-usages/tests/test_fn.py
+++ b/functions/compose-usages/tests/test_fn.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the compose-usages function."""
 
 import dataclasses

--- a/nix.sh
+++ b/nix.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # nix.sh - Run Nix commands via Docker without installing Nix locally.
 #
 # Usage: ./nix.sh <command>

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -21,10 +21,18 @@
           pkgs.shellcheck
           pkgs.shfmt
           pkgs.gnupatch
+          pkgs.addlicense
           pkgs.unstable.uv
         ];
         inheritPath = false;
         text = ''
+          echo "Adding missing license headers..."
+          addlicense -l apache -c "The Modelplane Authors." \
+            -ignore '**/*.toml' \
+            -ignore '**/*.yaml' \
+            -ignore '**/*.yml' \
+            functions/ docs/utils/validate/ nix.sh docs/vercel-build.sh
+
           echo "Formatting and linting Nix..."
           statix fix .
           deadnix --edit flake.nix nix/*.nix

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -86,6 +86,28 @@ in
         touch $out/.python-checks-passed
       '';
 
+  # Fail if any hand-written source file is missing its Apache 2.0 license
+  # header. Scoped to the files we author: the composition functions and the
+  # docs manifest validator. Generated models under schemas/python carry their
+  # own codegen banner, and config (*.toml) and vendored upstream CRDs (*.yaml)
+  # are excluded. addlicense -check only reads, so it runs against the store
+  # path directly. Run 'nix run .#fix' to add any missing headers.
+  license =
+    pkgs.runCommand "modelplane-license-check"
+      {
+        nativeBuildInputs = [ pkgs.addlicense ];
+      }
+      ''
+        cd ${self}
+        addlicense -check \
+          -ignore '**/*.toml' \
+          -ignore '**/*.yaml' \
+          -ignore '**/*.yml' \
+          functions/ docs/utils/validate/ nix.sh docs/vercel-build.sh
+        mkdir -p $out
+        touch $out/.license-check-passed
+      '';
+
   shell-lint =
     pkgs.runCommand "modelplane-shell-lint"
       {


### PR DESCRIPTION
### Description of your changes

The repo is Apache-2.0 but no source file carried the standard per-file header, so any file copied out of the repo loses its license and copyright notice. This adds the header to the hand-written Python, Go, and shell sources (`functions/`, `docs/utils/validate/`, and the two build scripts).

Generated models under `schemas/python/` carry their own codegen banner; config, docs prose, and vendored upstream CRDs are excluded.

To keep it from regressing, a `license` check (`addlicense -check`) is added to `nix flake check`, and header insertion is wired into `nix run .#fix`.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.