### PR TITLE
Keep light-mode card surfaces from being purged in production

### DIFF
--- a/docs/themes/geekboot/assets/scss/_components.scss
+++ b/docs/themes/geekboot/assets/scss/_components.scss
@@ -4,13 +4,10 @@
 // Tuned for the dark default (matching the website). Light-mode overrides at the
 // end keep them legible when the theme toggle is set to light.
 
-// Per-component tokens, dark by default.
-.bd-content {
-  --mp-card-bg: #{$mp-bg-card};
-  --mp-card-border: #{$mp-border};
-  --mp-card-border-hi: #{$mp-border-hi};
-  --mp-card-muted: #{$mp-muted};
-}
+// Per-component card tokens (--mp-card-bg, --mp-card-border, --mp-card-border-hi,
+// --mp-card-muted) live in the light-mode/dark-mode mixins, not here: defining
+// the light override on a `.bd-content` selector let PurgeCSS drop it in
+// production, leaving the dark surface in light mode.
 
 // ── Support matrix ────────────────────────────────────────────
 .mp-matrix-group { margin: 1.5rem 0 2rem; }
@@ -379,12 +376,6 @@ a.mp-chip:hover { border-color: var(--mp-card-border-hi); text-decoration: none;
 }
 
 // ── Light-mode overrides ──────────────────────────────────────
-[color-theme="light"] .bd-content {
-  --mp-card-bg: #{$fog-25};
-  --mp-card-border: #{$fog-150};
-  --mp-card-border-hi: rgba(154, 94, 252, 0.4);
-  --mp-card-muted: #{$fog-600};
-}
 [color-theme="light"] {
   // Brand accents need darker shades to stay legible on white (the dark-mode
   // purple/sky/green wash out at WCAG-AA contrast).

--- a/docs/themes/geekboot/assets/scss/dark-mode.scss
+++ b/docs/themes/geekboot/assets/scss/dark-mode.scss
@@ -20,6 +20,13 @@
     --mp-muted: #{$mp-muted};
     --mp-muted-hi: #{$mp-muted-hi};
 
+    // Component card tokens (catalog/persona cards, hints, matrix). Defined here
+    // rather than on .bd-content so the light-mode override survives PurgeCSS.
+    --mp-card-bg: #{$mp-bg-card};
+    --mp-card-border: #{$mp-border};
+    --mp-card-border-hi: #{$mp-border-hi};
+    --mp-card-muted: #{$mp-muted};
+
     // Sidebar nav
     --nav-highlight-color: rgba(154,94,252,0.12);
     --btn-close-color: #ffffff;

--- a/docs/themes/geekboot/assets/scss/light-mode.scss
+++ b/docs/themes/geekboot/assets/scss/light-mode.scss
@@ -28,6 +28,13 @@
     --mp-muted: #{$fog-700};
     --mp-muted-hi: #{$fog-800};
 
+    // Component card tokens (catalog/persona cards, hints, matrix). Defined here
+    // rather than on .bd-content so this override survives PurgeCSS.
+    --mp-card-bg: #{$fog-25};
+    --mp-card-border: #{$fog-150};
+    --mp-card-border-hi: rgba(154, 94, 252, 0.4);
+    --mp-card-muted: #{$fog-600};
+
     // Sidebar nav
     --nav-highlight-color: #f1ebfe;
     --btn-close-color: #{$fog-1000};


### PR DESCRIPTION
### Description of your changes

Cards, note hints, the persona-lane diagram on How Modelplane works, and the card-based reference index render with the dark spruce surface in light mode, but only in the production build, not the local dev server.

The component card tokens (`--mp-card-bg`, `--mp-card-border`, `--mp-card-border-hi`, `--mp-card-muted`) had their dark defaults on a plain `.bd-content` rule and their light values on a `[color-theme="light"] .bd-content` override. The production PurgeCSS pass drops that override rule, so light mode falls back to the dark default and those components show a dark surface on a white page. The dev server doesn't purge, so it looked fine locally. This moves the four tokens into the light-mode and dark-mode mixins, alongside the other theme variables defined on `:root[color-theme="…"]` that PurgeCSS keeps. Values are unchanged. Verified against the production `nix build .#docs` output: both the light and dark `--mp-card-*` values now survive under their respective `[color-theme]` roots.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~~Added or updated tests covering any composition function changes.~~
- [x] Signed off every commit with `git commit -s`.
