### PR TITLE
Fix docs describing ModelCache storage, serving, and a README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ Follow the [getting started guide][getting-started] to deploy Modelplane on a
 local kind cluster and serve a model. The [how it works][how-it-works] page
 covers the resources and what happens when you deploy a model.
 
-The [`examples/`](examples/) directory has annotated manifests covering the full
-workflow: gateway setup, cluster provisioning, and model deployments.
+The [example manifests][examples] are validated, end-to-end recipes that serve
+specific models, each covering the full workflow from inference class and cluster
+through model cache, deployment, and service.
 
 ## How it works
 
@@ -131,9 +132,9 @@ Modelplane is under the [Apache 2.0 license](LICENSE).
 <!-- Named links -->
 [Crossplane]: https://crossplane.io
 [CONTRIBUTING.md]: CONTRIBUTING.md
-[Nix]: https://nixos.org
 [getting-started]: https://docs.modelplane.ai/getting-started/
 [how-it-works]: https://docs.modelplane.ai/overview/how-it-works/
+[examples]: docs/manifests/examples/
 [issues]: https://github.com/modelplaneai/modelplane/issues
 [enhancements]: https://github.com/modelplaneai/modelplane/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement
 [discussions]: https://github.com/modelplaneai/modelplane/discussions

--- a/docs/content/models/model-cache.md
+++ b/docs/content/models/model-cache.md
@@ -50,32 +50,26 @@ What the platform admin must set up depends on the cloud:
 
 - **GKE:** auto-provisioned. Modelplane composes the `modelplane-rwx` Filestore
   StorageClass and enables `file.googleapis.com`. Nothing for the admin to do.
-- **EKS:** bring-your-own for v0.1. On the workload cluster the admin must
-  install the `aws-efs-csi-driver` EKS add-on (with an IRSA role bound to
-  `AmazonEFSCSIDriverPolicy`); create an EFS file system with a mount target in
-  each node subnet and a security group allowing inbound NFS (2049) from the node
-  security group; and create a StorageClass named `modelplane-rwx-efs` with
-  `provisioner: efs.csi.aws.com`, `provisioningMode: efs-ap`, and
-  `fileSystemId: <fs-id>`. Set `eks.cache.storageClassName` if the admin's class
-  has a different name. EFS is elastic, so the cache's `sizeGiB` is informational
-  on EKS. The PVC API still requires a size, but EFS ignores it.
-  Auto-provisioning EFS is tracked in
-  [#114](https://github.com/modelplaneai/modelplane/issues/114).
+- **EKS:** auto-provisioned. Modelplane composes an EFS file system with a mount
+  target in each node subnet, the EFS storage driver (its IAM role bound through
+  Pod Identity), and a `modelplane-rwx-efs` StorageClass pinned to the file
+  system. Nothing for the admin to do. EFS is elastic, so the cache's `sizeGiB`
+  is informational on EKS: the PVC API still requires a size, but EFS ignores it.
+- **Existing:** bring-your-own. The admin creates a `ReadWriteMany` StorageClass
+  on the cluster and names it in `cluster.existing.cache.storageClassName`. See
+  [Custom cache backends](#custom-cache-backends).
 
 ## Custom cache backends
 
 <!-- vale Google.Acronyms = NO -->
-Modelplane provisions Filestore Enterprise on `GKE` clusters and expects a
-StorageClass named `modelplane-rwx` on `Existing` clusters. When the default
-doesn't fit (a different cost profile, an RWX backend the org already runs,
-etc.). Platform teams point Modelplane at a different StorageClass via
-`cluster.<source>.cache.storageClassName` on the
-[InferenceCluster]({{< ref "platform/inference-cluster.md" >}}). On GKE the
-admin must first create the StorageClass on the workload cluster (any backend
-supporting ReadWriteMany dynamic provisioning like WekaIO, NetApp Trident, `FSx`
-for NetApp, and similar). On Existing clusters the field points at whatever name
-the admin chose. The ML team's `ModelCache` and `ModelDeployment` specs are
-unchanged regardless.
+Modelplane provisions RWX storage on `GKE` (Filestore Enterprise) and `EKS`
+(EFS) clusters, and those classes are fixed. On `Existing` clusters the admin
+brings the storage: create a `ReadWriteMany` StorageClass on the cluster (any
+backend supporting dynamic provisioning like WekaIO, NetApp Trident, `FSx` for
+NetApp, and similar) and name it in `cluster.existing.cache.storageClassName` on
+the [InferenceCluster]({{< ref "platform/inference-cluster.md" >}}). Any name
+works; `modelplane-rwx` is just a convention. The ML team's `ModelCache` and
+`ModelDeployment` specs are unchanged regardless.
 <!-- vale Google.Acronyms = YES -->
 
 Backends that don't fit dynamic-PVC provisioning (Dragonfly's P2P distribution

--- a/docs/content/models/model-deployment.md
+++ b/docs/content/models/model-deployment.md
@@ -79,8 +79,10 @@ via `spec.modelCacheRef.name`, since every pod in the gang mounts it.
 
 Disaggregation runs on the multi-node (llm-d) path. A request is routed to a
 prefill instance and then to the decode instance holding its KV cache by the same
-endpoint picker that fronts multi-node serving. A deployment without a `prefill`
-block is unified serving and is unaffected.
+endpoint picker that fronts multi-node serving. Set `spec.serving.mode` to
+`PrefillDecode` and mark each engine's `phase` as `Prefill` or `Decode` to enable
+it. A deployment that omits `spec.serving` (or leaves `mode` as the default
+`Unified`) is unified serving and is unaffected.
 
 Disaggregation pays off for large models under load with strict latency targets
 and long context. For small models or low traffic the KV-transfer overhead

--- a/docs/content/platform/inference-cluster.md
+++ b/docs/content/platform/inference-cluster.md
@@ -38,9 +38,11 @@ which Modelplane assumes are solely for its use.
 
 ## Cache storage
 
-To override the default ReadWriteMany StorageClass Modelplane uses for
-[ModelCache]({{< ref "models/model-cache.md#custom-cache-backends" >}}) PVCs on
-this cluster, set `cluster.<source>.cache.storageClassName`. See
+On provisioned `GKE` and `EKS` clusters, the ReadWriteMany StorageClass
+Modelplane uses for
+[ModelCache]({{< ref "models/model-cache.md#custom-cache-backends" >}}) PVCs is
+auto-provisioned. On an `Existing` cluster, name the StorageClass you created in
+`cluster.existing.cache.storageClassName`. See
 [Custom cache backends]({{< ref "models/model-cache.md#custom-cache-backends" >}})
-for details.
+for how storage is provided on each.
 <!-- vale write-good.Passive = YES -->

--- a/docs/manifests/concepts/inference-cluster-eks.yaml
+++ b/docs/manifests/concepts/inference-cluster-eks.yaml
@@ -11,10 +11,10 @@
 # groups - each referencing an InferenceClass that describes the
 # hardware shape and how to provision it - need to be declared.
 #
-# Modelplane does not currently provision EFS for RWX ModelCache
-# storage on EKS. The admin should create an EFS file system and the
-# EFS CSI StorageClass on the cluster, then set cache.storageClassName
-# to its name (default 'modelplane-rwx-efs').
+# Modelplane provisions EFS RWX storage for ModelCache on EKS: an
+# Elastic-throughput file system, mount targets, the EFS CSI driver, and
+# a 'modelplane-rwx-efs' StorageClass pinned to it. The admin does
+# nothing, and provisioned EKS clusters take no StorageClass override.
 #
 # Delete this InferenceCluster with foreground cascading deletion for a
 # clean teardown:


### PR DESCRIPTION
### Description of your changes

While reviewing the recent docs work I cross-checked the documented manifests and prose against both the XRD schemas under `apis/` and the composition functions. Several claims didn't match the implementation, so a reader following them would either write a manifest the API rejects or do manual setup Modelplane already handles. This also fixes a broken README link.

The ModelDeployment page said a deployment "without a `prefill` block is unified serving." There is no `prefill` field. Disaggregation is selected via `spec.serving.mode: PrefillDecode` with each engine marking its `phase` as `Prefill` or `Decode`. The page now describes that mechanism, which the kimi-k2 example already uses.

The ModelCache and InferenceCluster pages described EKS ModelCache storage as bring-your-own, telling admins to install the EFS CSI driver, create an EFS file system, and define the StorageClass by hand, with auto-provisioning linked as future work. The EKS composition already does all of this: `compose_efs()` provisions the file system, mount targets, and driver, and `compose_storage_class()` composes the `modelplane-rwx-efs` class (issue #114, now closed). The docs now describe EKS storage as auto-provisioned, matching GKE.

The same pages described the cache StorageClass override as `cluster.<source>.cache.storageClassName` across sources. The override exists only under `cluster.existing`; provisioned GKE and EKS take no override. For `Existing` clusters the StorageClass name is required configuration, not an override of a default, and any name works, so `modelplane-rwx` is a convention rather than a requirement. The override is now scoped to `Existing` clusters and reframed accordingly.

Finally, the README's examples link pointed at a top-level `examples/` directory that doesn't exist; it now points at `docs/manifests/examples/`, where the per-model recipes live. The unused `[Nix]` link definition is dropped.

Thanks to @Copilot, whose review caught that EKS now auto-provisions EFS — my first pass corrected the schema-level claims but still described the old manual EKS setup. The storage behavior is the part worth a close read.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
