### PR TITLE
Note the Modelplane trademark in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ See [CONTRIBUTING.md] for how to get set up, run checks, and submit changes.
 
 Modelplane is under the [Apache 2.0 license](LICENSE).
 
+Modelplane™ is a trademark. The Apache 2.0 license grants no trademark rights:
+the Modelplane name and logos are not covered by it.
+
 <!-- Named links -->
 [Crossplane]: https://crossplane.io
 [CONTRIBUTING.md]: CONTRIBUTING.md


### PR DESCRIPTION
### Description of your changes

The Apache 2.0 license covers the code but, by design (section 6), grants no trademark rights. Nothing in the repo recorded that the Modelplane name and logos are a mark, so a reader could assume the license lets them use those freely. This matches the trademark note added to the website repo.

Adds two sentences to the README License section stating that Modelplane is a trademark and that the name and logos sit outside the Apache license. The mark (MODELPLANE & Design, US serial 99743704, filed 2026-04-03) is a pending application, not yet registered, so it uses **™** rather than ®. The owner is intentionally not named; it remains on public USPTO record.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~~ Documentation-only change (README prose); no code, manifests, or flake inputs touched.
- [ ] ~~Added or updated tests covering any composition function changes.~~ No composition function changes.
- [x] Signed off every commit with `git commit -s`.