### PR TITLE
Add a GLM-4.5-Air GGUF example served via llama.cpp on one A100

### DIFF
--- a/docs/manifests/examples/glm-4.5-air/inference-class.yaml
+++ b/docs/manifests/examples/glm-4.5-air/inference-class.yaml
@@ -1,0 +1,28 @@
+# A single A100 40GB on GKE. GLM-4.5-Air is a ~106B MoE; a 4-bit GGUF doesn't
+# fit one A100's VRAM, but llama.cpp offloads the expert tensors to host RAM
+# (see the ModelDeployment's --n-cpu-moe), so the GPU only holds the active path
+# + KV cache. One A100, not a multi-GPU node.
+apiVersion: modelplane.ai/v1alpha1
+kind: InferenceClass
+metadata:
+  name: gke-a100-40-1x
+spec:
+  description: "GKE a2-highgpu-1g, 1x NVIDIA A100 40GB"
+  provisioning:
+    provider: GKE
+    gke:
+      machineType: a2-highgpu-1g
+      diskSizeGb: 200
+      accelerator:
+        type: nvidia-tesla-a100
+        count: 1
+  devices:
+  - name: gpu
+    claim: DRA
+    driver: gpu.nvidia.com
+    deviceClassName: gpu.nvidia.com
+    count: 1
+    attributes:
+      architecture: { string: Ampere }
+    capacity:
+      memory: { value: "40960Mi" }

--- a/docs/manifests/examples/glm-4.5-air/inference-cluster.yaml
+++ b/docs/manifests/examples/glm-4.5-air/inference-cluster.yaml
@@ -1,0 +1,21 @@
+# A GKE cluster with a single A100 node offering the class above.
+apiVersion: modelplane.ai/v1alpha1
+kind: InferenceCluster
+metadata:
+  name: gke-a100
+  labels:
+    modelplane.ai/region: us-west
+spec:
+  cluster:
+    source: GKE
+    gke:
+      project: my-gcp-project   # set to your project
+      region: us-west1
+  nodePools:
+  - name: gpu-a100
+    className: gke-a100-40-1x
+    nodeCount: 1
+    minNodeCount: 1
+    maxNodeCount: 1
+    zones:
+    - us-west1-b

--- a/docs/manifests/examples/glm-4.5-air/model-deployment.yaml
+++ b/docs/manifests/examples/glm-4.5-air/model-deployment.yaml
@@ -1,0 +1,48 @@
+# GLM-4.5-Air (~106B MoE) served from an Unsloth GGUF via llama.cpp instead of
+# vLLM, on a SINGLE A100. Modelplane treats the engine as any OpenAI-compatible
+# container, so the only changes from a vLLM deployment are the image and args:
+# the container is still named `engine` and listens on :8000. vLLM can't load
+# Unsloth's UD- dynamic quants; llama.cpp can, and `-hf` pulls the quant from
+# HuggingFace at startup (no ModelCache needed for a one-off).
+#
+# The model is bigger than one A100's VRAM, so --n-cpu-moe offloads the MoE
+# expert tensors to host RAM; the GPU runs the active path. That's how a 106B
+# model fits one A100 instead of a multi-GPU node. --port 8000 because llama.cpp
+# defaults to 8080 and Modelplane scrapes 8000.
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelDeployment
+metadata:
+  name: glm-air
+  namespace: ml-team
+spec:
+  replicas: 1
+  engines:
+  - name: glm
+    members:
+    - role: Standalone
+      nodeSelector:
+        devices:
+        - name: gpu
+          count: 1
+          selectors:
+          - cel: |
+              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("35Gi")) >= 0
+      template:
+        spec:
+          containers:
+          - name: engine
+            image: ghcr.io/ggml-org/llama.cpp:server-cuda
+            args:
+            - "-hf"
+            - "unsloth/GLM-4.5-Air-GGUF:IQ4_XS"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8000"
+            - "-ngl"
+            - "999"
+            - "--n-cpu-moe"
+            - "99"
+            - "--jinja"
+            - "-c"
+            - "8192"

--- a/docs/manifests/examples/glm-4.5-air/model-service.yaml
+++ b/docs/manifests/examples/glm-4.5-air/model-service.yaml
@@ -1,0 +1,12 @@
+# One OpenAI-compatible endpoint for the deployment. Read its public address:
+#   kubectl get ms glm-air -n ml-team -o jsonpath='{.status.address}'
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelService
+metadata:
+  name: glm-air
+  namespace: ml-team
+spec:
+  endpoints:
+  - selector:
+      matchLabels:
+        modelplane.ai/deployment: glm-air


### PR DESCRIPTION
### Description of your changes

Modelplane's engine is any OpenAI-compatible container, so serving a model vLLM can't load is just a matter of swapping the image and args. This example serves GLM-4.5-Air (a ~106B MoE) from an Unsloth GGUF with llama.cpp instead of vLLM — vLLM can't load Unsloth's `UD-` dynamic quants.

The model is larger than a single A100's 40GB, so the deployment offloads the MoE expert tensors to host RAM via llama.cpp's `--n-cpu-moe` and keeps the active path on the GPU. That fits a 106B model on **one** A100 rather than a multi-GPU node. The engine pulls the quant from HuggingFace at startup via `-hf`, listens on the `:8000` Modelplane expects, and is fronted by the same `ModelService`/OpenAI endpoint as any other model.

Four manifests under `docs/manifests/examples/glm-4.5-air/`: an `InferenceClass` for a single A100-40 (`a2-highgpu-1g`), a GKE `InferenceCluster`, the `ModelDeployment` (llama.cpp `server-cuda`, `unsloth/GLM-4.5-Air-GGUF:IQ4_XS`), and a `ModelService`. Validated live on a GKE A100.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- ~~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~~ Docs-only example manifests; no Nix-checked code changed.
- ~~Added or updated tests covering any composition function changes.~~ No composition function changes.
- [x] Signed off every commit with `git commit -s`.