### PR TITLE
Add a local kind capability-scheduling example (CPU, no GPU)

### DIFF
--- a/docs/manifests/examples/kind-local-cpu/README.md
+++ b/docs/manifests/examples/kind-local-cpu/README.md
@@ -1,0 +1,79 @@
+# Capability scheduling on a local kind fleet (CPU, no GPU)
+
+Show off the core of Modelplane — **a model lands on the hardware it asks for and
+skips the cheaper option** — on a laptop, with no cloud and no GPUs.
+
+The trick: a local kind cluster with two node pools that **declare** different
+GPU sizes (`fake-l4` = 24 Gi, `fake-a100` = 40 Gi), both backed by one **mock**
+DRA driver. The sizes are declarative, so the scheduler matches a model's memory
+selector against them; the engine runs on CPU.
+
+Two clusters:
+- **Control plane** — a kind cluster running Crossplane + the Modelplane
+  Configuration (from the getting-started install).
+- **Workload** — a second kind cluster this example creates, with the two pools.
+
+## 1. Create the inference cluster
+
+```bash
+./create-inference-cluster.sh
+```
+
+This creates a 2-worker kind cluster, installs the mock DRA driver and MetalLB
+(the workload's gateway needs a LoadBalancer IP, which kind has no cloud LB to
+provide), labels one worker `modelplane.ai/pool=fake-l4` and the other
+`fake-a100`, and registers the cluster's kubeconfig as a Secret on the control
+plane.
+
+## 2. Publish the classes + deploy the model (against the control plane)
+
+Creating the workload cluster in step 1 left kubectl pointed at it, so pin the
+control-plane context explicitly here — these resources belong on the control
+plane, not the workload:
+
+```bash
+kubectl --context kind-crossplane-modelplane create namespace ml-team \
+  --dry-run=client -o yaml | kubectl --context kind-crossplane-modelplane apply -f -
+kubectl --context kind-crossplane-modelplane apply -f .   # two InferenceClasses, the Existing InferenceCluster, a ModelDeployment, a ModelService
+```
+
+`qwen-fleet` asks for `>= 35Gi`. Modelplane installs the serving stack on the
+workload (~2 min), then schedules the replica onto **fake-a100** and **skips
+fake-l4**.
+
+## 3. See the placement
+
+```bash
+kubectl --context kind-crossplane-modelplane -n ml-team get modelreplica -l modelplane.ai/deployment=qwen-fleet \
+  -o custom-columns='REPLICA:.metadata.name,POOL:.spec.engines[0].members[0].nodePoolName,READY:.status.conditions[?(@.type=="Ready")].status'
+# POOL is fake-a100 — the model skipped the 24Gi fake-l4 pool.
+```
+
+Change the selector to `>= 20Gi` and either pool is eligible; `>= 41Gi` and
+nothing matches (the deployment reports `InsufficientCapacity`).
+
+## 4. Call it
+
+The workload's gateway gets a MetalLB address that isn't routable from your
+host, so port-forward the engine pod:
+
+```bash
+kubectl --context kind-mp-fleet -n default port-forward \
+  "$(kubectl --context kind-mp-fleet -n default get pods -o name | grep qwen-fleet | head -1)" 8000:8000 &
+
+curl -s http://localhost:8000/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{"model":"qwen","messages":[{"role":"user","content":"Say hi in 5 words."}],"max_tokens":40,"chat_template_kwargs":{"enable_thinking":false}}' \
+  | jq -r '.choices[0].message.content'
+```
+
+## Notes
+
+- **Mock sizes are declarative.** The fake-l4/fake-a100 capacities live in the
+  InferenceClasses; the mock devices carry no real VRAM. The scheduler matches
+  the model's `device.capacity[...].memory` selector against the declared values.
+- **CPU inference is slow.** Keep the model tiny (0.6B here). For development,
+  not throughput.
+- Modelplane also installs the NVIDIA DRA driver with the serving stack; on a
+  GPU-less node it sits idle and doesn't interfere with the mock driver.
+- This is a dev convenience, not a supported production topology.

--- a/docs/manifests/examples/kind-local-cpu/create-inference-cluster.sh
+++ b/docs/manifests/examples/kind-local-cpu/create-inference-cluster.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Create a local kind cluster to use as a Modelplane inference (workload)
+# cluster — separate from the control plane — with two node pools of different
+# (fake) GPU sizes, so you can watch Modelplane schedule a model by capability.
+#
+# It: creates a 2-worker kind cluster, installs a mock DRA driver (advertises
+# fake GPUs so a GPU-less node satisfies the scheduler), labels each worker into
+# a pool, and registers the cluster's kubeconfig as a Secret on the control
+# plane for a `source: Existing` InferenceCluster.
+#
+# Prereqs: a separate kind cluster running the Modelplane control plane, plus
+# kind, kubectl, helm, and docker. After this, apply the manifests here.
+set -euo pipefail
+
+CLUSTER="${CLUSTER:-mp-fleet}"                          # workload kind cluster name
+CP_CONTEXT="${CP_CONTEXT:-kind-crossplane-modelplane}"  # control-plane kube context
+SECRET="${SECRET:-mp-fleet-kubeconfig}"                 # secret name in modelplane-system
+
+echo ">> creating 2-worker workload kind cluster '$CLUSTER'"
+cat <<KIND | kind create cluster --name "$CLUSTER" --config -
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+KIND
+WCTX="kind-$CLUSTER"
+kubectl --context "$WCTX" wait --for=condition=Ready nodes --all --timeout=120s
+
+echo ">> installing the mock DRA driver (fake GPUs, no hardware)"
+helm install dra-example-driver \
+  oci://registry.k8s.io/dra-example-driver/charts/dra-example-driver \
+  --kube-context "$WCTX" --namespace dra-example-driver --create-namespace --wait
+
+echo ">> installing MetalLB (the workload's gateway needs a LoadBalancer IP; kind has no cloud LB)"
+# Pool is in the kind docker network (172.18.0.0/16), distinct from the control
+# plane's own MetalLB range. Adjust if your kind network differs:
+#   docker network inspect kind --format '{{range .IPAM.Config}}{{.Subnet}} {{end}}'
+kubectl --context "$WCTX" apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.9/config/manifests/metallb-native.yaml
+kubectl --context "$WCTX" -n metallb-system wait --for=condition=Available deploy/controller --timeout=180s
+kubectl --context "$WCTX" apply -f - <<MLB
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata: { name: kind-pool, namespace: metallb-system }
+spec:
+  addresses: ["172.18.255.150-172.18.255.199"]
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata: { name: l2, namespace: metallb-system }
+spec:
+  ipAddressPools: [kind-pool]
+MLB
+
+echo ">> labeling the two workers into pools (fake-l4 / fake-a100)"
+# Read into an array without mapfile/readarray (bash 4+), so this also runs on
+# the bash 3.2 that ships with macOS.
+WORKERS=()
+while IFS= read -r w; do WORKERS+=("$w"); done < <(kubectl --context "$WCTX" get nodes \
+  -l '!node-role.kubernetes.io/control-plane' -o name | cut -d/ -f2)
+kubectl --context "$WCTX" label node "${WORKERS[0]}" modelplane.ai/pool=fake-l4   --overwrite
+kubectl --context "$WCTX" label node "${WORKERS[1]}" modelplane.ai/pool=fake-a100 --overwrite
+
+echo ">> registering the workload kubeconfig on the control plane"
+# --internal gives the in-docker-network address, reachable from the control
+# plane's pods (the default kubeconfig points at 127.0.0.1, which they can't reach).
+kind get kubeconfig --name "$CLUSTER" --internal > "/tmp/${CLUSTER}-kubeconfig"
+kubectl --context "$CP_CONTEXT" -n modelplane-system create secret generic "$SECRET" \
+  --from-file="kubeconfig=/tmp/${CLUSTER}-kubeconfig" \
+  --dry-run=client -o yaml | kubectl --context "$CP_CONTEXT" apply -f -
+rm -f "/tmp/${CLUSTER}-kubeconfig"
+
+cat <<EOF
+
+Done. Workload cluster '$CLUSTER' (pools fake-l4 + fake-a100) is registered as
+Secret 'modelplane-system/$SECRET' on the control plane.
+
+Next, against the control plane ($CP_CONTEXT):
+  kubectl create namespace ml-team
+  kubectl apply -f .
+EOF

--- a/docs/manifests/examples/kind-local-cpu/inference-class.yaml
+++ b/docs/manifests/examples/kind-local-cpu/inference-class.yaml
@@ -1,0 +1,33 @@
+# Two fake GPU classes of different sizes, both backed by the one mock DRA
+# driver. The sizes are DECLARED here (capacity.memory) — the mock devices have
+# no real VRAM; the scheduler matches a model's selector against this declared
+# capacity. That is what lets you demo capability scheduling with no hardware.
+apiVersion: modelplane.ai/v1alpha1
+kind: InferenceClass
+metadata:
+  name: fake-l4
+spec:
+  description: "Fake L4-class (24Gi) — mock DRA device"
+  devices:
+  - name: gpu
+    claim: DRA
+    driver: gpu.example.com
+    deviceClassName: gpu.example.com
+    count: 1
+    capacity:
+      memory: { value: "24Gi" }
+---
+apiVersion: modelplane.ai/v1alpha1
+kind: InferenceClass
+metadata:
+  name: fake-a100
+spec:
+  description: "Fake A100-class (40Gi) — mock DRA device"
+  devices:
+  - name: gpu
+    claim: DRA
+    driver: gpu.example.com
+    deviceClassName: gpu.example.com
+    count: 1
+    capacity:
+      memory: { value: "40Gi" }

--- a/docs/manifests/examples/kind-local-cpu/inference-cluster.yaml
+++ b/docs/manifests/examples/kind-local-cpu/inference-cluster.yaml
@@ -1,0 +1,24 @@
+# The local kind cluster (created by create-inference-cluster.sh) registered as
+# a workload via source: Existing, with two pools of different fake sizes. A BYO
+# cluster declares its nodePools so the scheduler knows its capacity; the script
+# labels each node modelplane.ai/pool=<name>.
+apiVersion: modelplane.ai/v1alpha1
+kind: InferenceCluster
+metadata:
+  name: mp-fleet
+  labels:
+    modelplane.ai/region: local
+spec:
+  cluster:
+    source: Existing
+    existing:
+      secretRef:
+        name: mp-fleet-kubeconfig
+        key: kubeconfig
+  nodePools:
+  - name: fake-l4
+    className: fake-l4
+    nodeCount: 1
+  - name: fake-a100
+    className: fake-a100
+    nodeCount: 1

--- a/docs/manifests/examples/kind-local-cpu/model-deployment.yaml
+++ b/docs/manifests/examples/kind-local-cpu/model-deployment.yaml
@@ -1,0 +1,30 @@
+# Ask for >= 35Gi of GPU memory. The fake-a100 pool (40Gi) qualifies; the
+# fake-l4 pool (24Gi) is skipped — capability scheduling, locally, with no GPUs.
+# The engine is the CPU llama.cpp image serving a tiny GGUF: the model is small
+# (it runs on CPU), and the selector is what drives placement. Bump the
+# threshold to >= 41Gi and nothing matches; lower it to >= 20Gi and either pool
+# is eligible.
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelDeployment
+metadata:
+  name: qwen-fleet
+  namespace: ml-team
+spec:
+  replicas: 1
+  engines:
+  - name: qwen
+    members:
+    - role: Standalone
+      nodeSelector:
+        devices:
+        - name: gpu
+          count: 1
+          selectors:
+          - cel: |
+              device.capacity["gpu.example.com"].memory.compareTo(quantity("35Gi")) >= 0
+      template:
+        spec:
+          containers:
+          - name: engine
+            image: ghcr.io/ggml-org/llama.cpp:server
+            args: ["-hf","unsloth/Qwen3-0.6B-GGUF:Q4_K_M","--host","0.0.0.0","--port","8000","--jinja"]

--- a/docs/manifests/examples/kind-local-cpu/model-service.yaml
+++ b/docs/manifests/examples/kind-local-cpu/model-service.yaml
@@ -1,0 +1,13 @@
+# One OpenAI-compatible endpoint for the deployment. On kind the gateway gets a
+# MetalLB address that isn't routable from your host, so reach it with a
+# port-forward (see the README).
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelService
+metadata:
+  name: qwen-fleet
+  namespace: ml-team
+spec:
+  endpoints:
+  - selector:
+      matchLabels:
+        modelplane.ai/deployment: qwen-fleet


### PR DESCRIPTION
### Description of your changes

Modelplane's headline behavior — declare the hardware a model needs and it lands on the right pool, skipping cheaper ones — has only ever been demonstrable with real cloud GPUs, which makes it hard to learn or to develop against. This adds a fully local example that shows the same capability scheduling on a laptop, no cloud and no GPUs.

`create-inference-cluster.sh` creates a second kind cluster (separate from the control plane) with two workers, installs the upstream `dra-example-driver` so a GPU-less node advertises mock GPUs the scheduler can claim, labels the workers into `fake-l4` (24Gi) and `fake-a100` (40Gi) pools, and registers the cluster via `source: Existing` (`kind get kubeconfig --internal`, reachable across the kind docker network). A `ModelDeployment` asking for `>= 35Gi` then lands on `fake-a100` and skips `fake-l4`; the engine is the CPU llama.cpp image serving a tiny GGUF (the sizes are declarative — what drives placement is the InferenceClass capacity, not real VRAM).

The reviewable judgment is the `Existing`/mock-DRA approach and whether a dev-only topology belongs in the examples.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~~Run `nix flake check`~~ — manifest/script example only; no functions or schemas changed. YAML validated against the CRDs and the flow exercised on a live kind setup.
- [ ] ~~Added or updated tests covering any composition function changes.~~ — no composition function changes.
- [x] Signed off every commit with `git commit -s`.