### PR TITLE
Add SECURITY and GOVERNANCE docs; drop the Discussions link

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,33 @@
+# Governance
+
+Modelplane is an early, openly developed project. This document describes how it
+is governed today and where that is headed.
+
+## Today
+
+Modelplane was created by the team behind [Crossplane][crossplane] and is
+currently stewarded by its founding maintainers. Development happens in the open
+on GitHub: design discussions, issues, and pull requests are public, and
+contributions are welcome from anyone. See [CONTRIBUTING.md](CONTRIBUTING.md) to
+get started.
+
+Until the formal structure below is in place, the maintainers make decisions by
+consensus in the open, favoring the project's long-term health and its
+neutrality over any single contributor or company.
+
+## Where we are headed
+
+We intend to donate Modelplane to a neutral open source foundation later in
+2026. Our goal is a project that is owned by its community rather than any single
+vendor, consistent with how it is already built and licensed.
+
+At or around that donation we will establish a formal governance structure,
+including:
+
+- Defined maintainer and contributor roles, and how people move between them.
+- A documented decision-making and conflict-resolution process.
+- Stewardship of the project's trademark and assets by the foundation.
+
+This document will be updated to describe that structure when it is adopted.
+
+[crossplane]: https://crossplane.io

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ Modelplane is at v0.1. It is early and evolving fast. See [issues labeled `enhan
 Contributions, bug reports, and feature requests are welcome.
 
 - **Issues:** [GitHub Issues][issues]
-- **Discussions:** [GitHub Discussions][discussions]
 - **Slack:** [#modelplane][slack] in the Kubernetes workspace
 
 See [CONTRIBUTING.md] for how to get set up, run checks, and submit changes.
@@ -140,5 +139,4 @@ the Modelplane name and logos are not covered by it.
 [examples]: docs/manifests/examples/
 [issues]: https://github.com/modelplaneai/modelplane/issues
 [enhancements]: https://github.com/modelplaneai/modelplane/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement
-[discussions]: https://github.com/modelplaneai/modelplane/discussions
 [slack]: https://kubernetes.slack.com

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+We take the security of Modelplane seriously and appreciate responsible
+disclosure of vulnerabilities.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.**
+
+Instead, report them privately through GitHub's
+[private vulnerability reporting][advisory]: open the **Security** tab of this
+repository and choose **Report a vulnerability**. This opens a private advisory
+visible only to the maintainers.
+
+Please include as much of the following as you can:
+
+- The type of issue and the component or resource affected.
+- The version or commit you observed it on.
+- Steps to reproduce, including any manifests, configuration, or proof-of-concept.
+- The impact: what an attacker could do with it.
+
+## What to expect
+
+- We aim to acknowledge a report within a few business days.
+- We will work with you to understand and validate the issue, and keep you
+  updated on remediation progress.
+- Once a fix is available we will coordinate disclosure and credit you, unless
+  you prefer to remain anonymous.
+
+## Supported versions
+
+Modelplane is an early v0.1 project under active development. Security fixes are
+applied to the latest release on the default branch. There is no long-term
+support branch yet; this policy will expand as the project matures and adopts a
+formal governance structure (see [GOVERNANCE.md](GOVERNANCE.md)).
+
+[advisory]: https://github.com/modelplaneai/modelplane/security/advisories/new


### PR DESCRIPTION
### Description of your changes

The repo had no security disclosure policy and no statement of how it is governed or where ownership is headed. The README also pointed readers to GitHub Discussions, which is not enabled on the repository, so that link went nowhere.

This adds two docs and a small README fix:

- **`SECURITY.md`** — asks reporters not to use public issues and directs them to GitHub's private vulnerability reporting (Security tab → Report a vulnerability), with what to include and what to expect. (Enabling private vulnerability reporting in repo settings is a separate, recommended step.)
- **`GOVERNANCE.md`** — records that Modelplane is stewarded by its founding maintainers today and that we intend to donate it to a neutral open source foundation later in 2026, at which point a formal governance structure (roles, decision-making, trademark/asset stewardship) will be established.
- **README** — removes the dead **Discussions** bullet and its link definition so the only listed channels are ones that exist.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~~ Documentation-only change; no code, manifests, or flake inputs touched.
- [ ] ~~Added or updated tests covering any composition function changes.~~ No composition function changes.
- [x] Signed off every commit with `git commit -s`.