### PR TITLE
Create /dev/fd before building docs on Vercel

### DIFF
--- a/docs/vercel-build.sh
+++ b/docs/vercel-build.sh
@@ -56,6 +56,15 @@ rm -f "$installer"
 
 export PATH="/nix/var/nix/profiles/default/bin:$PATH"
 
+# Vercel's Amazon Linux 2023 build image doesn't provide /dev/fd, which bash
+# process substitution (< <(...)) needs. patchelf's setup-hook uses it during
+# the fixup phase of any derivation containing ELF files — e.g. the fetchNpmDeps
+# FOD, whose npm cache includes native bindings like lightningcss. Without this
+# symlink, patchelf fails with "/dev/fd/63: No such file or directory" and the
+# entire docs build cascades to failure. See:
+#   https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/patchelf/setup-hook.sh
+[ -e /dev/fd ] || ln -s /proc/self/fd /dev/fd
+
 # The Vercel project's Root Directory is docs/, so the api/ serverless functions
 # live under the docs site rather than polluting the repo root. The build runs
 # with the working directory at docs/, but the flake that defines .#docs is at


### PR DESCRIPTION
### Description of your changes

Vercel docs preview builds started failing. patchelf's setup-hook shrinks RPATHs with bash process substitution (`< <(find ...)`), which needs `/dev/fd`. Vercel's build image doesn't provide it, so building the fetchNpmDeps cache (native bindings like lightningcss) fails and cascades to the whole build:

```
npm-deps> .../patchelf-0.15.2/nix-support/setup-hook: line 7: /dev/fd/63: No such file or directory
```

This symlinks `/dev/fd` to `/proc/self/fd` before `nix build` when it's missing.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
