### PR TITLE
Note that the ModelService endpoint forwards whatever API the engine serves

### DIFF
--- a/docs/content/models/model-service.md
+++ b/docs/content/models/model-service.md
@@ -14,6 +14,18 @@ Each backendRef in the HTTPRoute carries its own `URLRewrite` filter derived fro
 the endpoint's `spec.rewritePath`, so endpoints from different deployments or
 external providers with different path layouts coexist correctly.
 
+The route matches the `/<namespace>/<service>/` prefix and forwards everything
+below it to the engine, so the endpoint speaks whatever API the engine serves.
+OpenAI compatibility comes from the engines, not the route. An engine that also exposes
+another protocol is reachable on the same URL: a vLLM replica that serves the
+Anthropic Messages API answers on `/v1/messages`, so a client that speaks it
+(including Claude Code, via `ANTHROPIC_BASE_URL`) talks to it directly. The
+engine's operational paths come through the same way: `/health` and the
+Prometheus `/metrics` are reachable on the service URL. The prefill/decode and
+caching routers parse OpenAI-format request bodies, so an endpoint that serves
+another shape uses a plain `ModelService` with even weighting rather than those
+routers.
+
 Read the service's public address from `status.address`:
 
 ```bash


### PR DESCRIPTION
### Description of your changes

The docs consistently describe the unified `ModelService` endpoint as
"OpenAI-compatible." That's accurate for the common case but undersells the
routing: the `HTTPRoute` matches the `/<namespace>/<service>/` prefix and
forwards everything below it to the engine unchanged, so the endpoint speaks
whatever the engine speaks. Validated end to end against a live deployment, with
no config changes:

- a vLLM replica answered the **Anthropic Messages API** on `…/v1/messages`
  (real Anthropic-format response), and
- the engine's operational paths came through the same URL — `…/health` and the
  Prometheus `…/metrics`.

This adds one paragraph to `model-service.md` recording that — framed as
"OpenAI-compatible because the engines are" — with the boundary that prefix-cache
and prefill/decode routing parse OpenAI-format request bodies, so non-OpenAI
shapes use the plain even-split `ModelService` rather than the cache-aware path.
Purely additive; no existing language changed.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~~ One-paragraph docs prose addition; no functions or schemas changed.
- [ ] ~~Added or updated tests covering any composition function changes.~~ No composition function changes.
- [x] Signed off every commit with `git commit -s`.