### PR TITLE
Make the docs nav sidebar scroll when taller than the viewport

### DIFF
--- a/docs/themes/geekboot/assets/scss/_sidebar.scss
+++ b/docs/themes/geekboot/assets/scss/_sidebar.scss
@@ -193,9 +193,18 @@
 // ── Scrolling nav area ──────────────────────────────────────────
 .bd-sidebar-scroll {
   padding: 1rem 0.75rem 2.5rem;
+}
 
+// The nav fills the remaining sidebar height and scrolls when it's taller than
+// the viewport. The compound selector is deliberate: .bd-sidebar-scroll also
+// carries Bootstrap's `offcanvas-body` class, and Bootstrap's responsive
+// offcanvas reset (`.offcanvas-lg .offcanvas-body { flex-grow: 0; overflow-y:
+// visible }`) otherwise outranks a single-class rule and stops the nav from
+// scrolling, leaving the lower nav items unreachable.
+.bd-sidebar-container .bd-sidebar-scroll {
   @include media-breakpoint-up(lg) {
     flex: 1 1 auto;
+    min-height: 0;
     overflow-y: auto;
     overscroll-behavior: contain;
   }


### PR DESCRIPTION
### Description of your changes

The docs nav sidebar carries Bootstrap's `offcanvas-body` class. At the `lg` breakpoint Bootstrap's responsive offcanvas reset (`.offcanvas-lg .offcanvas-body { flex-grow: 0; overflow-y: visible }`) outranks the theme's single-class rule setting `flex: 1 1 auto; overflow-y: auto`, so the nav grew to its full content height and the parent `.bd-sidebar` (`overflow: hidden`) clipped it. On a viewport shorter than the nav, the lower items were unreachable.

Re-asserting the scroll with a higher-specificity selector (`.bd-sidebar-container .bd-sidebar-scroll`) wins over the Bootstrap reset, and `min-height: 0` lets the flex item shrink below its content so the internal scroll engages.

Verified in a headless browser over the DevTools Protocol. Before, the nav computed `overflow-y: visible` at 845px tall inside a 600px viewport and did not move on a wheel event; after, it is height-constrained with `overflow-y: auto` and scrolls (scrollHeight 821 > clientHeight 500). The right "On this page" rail already scrolled and is unaffected.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~ (CSS-only change, no composition functions touched.)
- [x] Signed off every commit with `git commit -s`.
