### PR TITLE
Serve reference pages as their definition in the Markdown output

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -79,6 +79,11 @@ ignoreFiles = ["themes/geekboot/content/.*", "README.md"]
   [[module.mounts]]
     source = "../apis"
     target = "data/apis/crds"
+  # Also mount it as assets so the Markdown output can emit the raw definition.yaml
+  # verbatim (comments preserved) via resources.Get "apis/<plural>/definition.yaml".
+  [[module.mounts]]
+    source = "../apis"
+    target = "assets/apis"
   # Mount the manifests directory as assets so the manifests shortcode can read
   # raw YAML (preserving comments) via resources.Get "examples/<path>.yaml". The
   # files live under docs/manifests/<section>/, one subtree per docs section.

--- a/docs/themes/geekboot/layouts/_default/single.md
+++ b/docs/themes/geekboot/layouts/_default/single.md
@@ -1,7 +1,11 @@
 {{- /* Raw-Markdown rendering of a docs page, served at page/index.md.
        Powers the "View as Markdown" action and feeds the docs MCP server.
-       Uses .RawContent so the source Markdown is preserved verbatim. */ -}}
+       Normal pages use .RawContent (verbatim source); reference pages, generated
+       from the CRD schema, render via the markdown-body partial, which also emits
+       the lead description. */ -}}
 {{- printf "# %s\n\n" .Title -}}
-{{- with .Description }}{{ printf "%s\n\n" . }}{{ end -}}
+{{- if ne .Params.product "crd" }}{{ with .Description }}{{ printf "%s\n\n" . }}{{ end }}{{ end -}}
 {{- with .OutputFormats.Get "html" }}{{ printf "Source: %s\n\n" .Permalink }}{{ end -}}
-{{- .RawContent -}}
+{{- /* Partials render through html/template, which escapes the body; htmlUnescape
+       recovers the verbatim Markdown for this plain-text output. */ -}}
+{{- partial "markdown-body.txt" . | htmlUnescape -}}

--- a/docs/themes/geekboot/layouts/partials/crd-markdown.txt
+++ b/docs/themes/geekboot/layouts/partials/crd-markdown.txt
@@ -1,0 +1,45 @@
+{{- /*
+  Markdown rendering of a CRD reference page (product: crd) for the Markdown
+  output and Copy page. Reference pages are generated from the CRD schema, not
+  from .RawContent, so without this the Markdown output and Copy page would show
+  only the page description.
+
+  The audience is LLM agents, so this returns the machine-readable contract
+  rather than a prose re-rendering of it: the served apiVersion/kind a user
+  applies, the validated example, then the full CompositeResourceDefinition
+  (the authoritative schema, validation, and defaults) verbatim. Reading the
+  source file means zero drift from the API and nothing for us to keep in sync.
+
+  A plain-text (.txt) partial so the YAML isn't HTML-escaped. The H1 and Source
+  line come from single.md; this starts at the lead paragraph.
+*/ -}}
+{{- $plural := .Params.plural -}}
+{{- $crd := "" -}}
+{{- with index site.Data.apis.crds $plural -}}{{- $crd = .definition -}}{{- end -}}
+
+{{- with $crd -}}
+  {{- $kind  := .spec.names.kind -}}
+  {{- $group := .spec.group -}}
+  {{- $version := "" -}}
+  {{- range .spec.versions -}}{{- if .served -}}{{- $version = .name -}}{{- end -}}{{- end -}}
+
+  {{- /* Lead description (schema's, else the concept doc's) and concept link. */ -}}
+  {{- $concept := "" -}}
+  {{- with index site.Data.apigroups.concepts $kind -}}{{- $concept = site.GetPage . -}}{{- end -}}
+  {{- $lead := $.Params.description -}}
+  {{- if not $lead -}}{{- with $concept -}}{{- $lead = .Description -}}{{- end -}}{{- end -}}
+  {{- with $lead -}}{{- printf "%s\n\n" . -}}{{- end -}}
+
+  {{- printf "Apply instances as `apiVersion: %s/%s`, `kind: %s`.\n\n" $group $version $kind -}}
+  {{- with $concept -}}{{- printf "[Concept guide: %s](%s)\n\n" .Title .Permalink -}}{{- end -}}
+
+  {{- /* Validated example, in the form a user writes. */ -}}
+  {{- with resources.Get (printf "examples/reference/%s.yaml" $plural) -}}
+    {{- printf "## Example\n\n```yaml\n%s\n```\n\n" (.Content | chomp) -}}
+  {{- end -}}
+
+  {{- /* The full definition: the authoritative schema, validation, and defaults. */ -}}
+  {{- with resources.Get (printf "apis/%s/definition.yaml" $plural) -}}
+    {{- printf "## Definition\n\nThe CompositeResourceDefinition this reference is generated from, with the complete OpenAPI schema, validation rules, and defaults:\n\n```yaml\n%s\n```\n" (.Content | chomp) -}}
+  {{- end -}}
+{{- end -}}

--- a/docs/themes/geekboot/layouts/partials/markdown-body.txt
+++ b/docs/themes/geekboot/layouts/partials/markdown-body.txt
@@ -1,0 +1,12 @@
+{{- /*
+  The page body as Markdown, shared by the Markdown output (single.md) and the
+  Copy page button so the two never drift. A plain-text (.txt) partial: it must
+  not HTML-escape .RawContent. Reference pages (product: crd) are generated from
+  the CRD schema and have no .RawContent, so render them from the schema; every
+  other page uses its verbatim source Markdown.
+*/ -}}
+{{- if eq .Params.product "crd" -}}
+  {{- partial "crd-markdown.txt" . -}}
+{{- else -}}
+  {{- .RawContent -}}
+{{- end -}}

--- a/docs/themes/geekboot/layouts/partials/single-list.html
+++ b/docs/themes/geekboot/layouts/partials/single-list.html
@@ -97,7 +97,10 @@
               </li>
             </ul>
           </div>
-          <template id="mp-raw-md">{{ .RawContent | htmlEscape }}</template>
+          {{/* htmlUnescape undoes the partial's html/template escaping to recover
+               the verbatim Markdown; html/template then escapes it once on output,
+               so it survives inside the <template> for mpCopyPage to decode back. */}}
+          <template id="mp-raw-md">{{ partial "markdown-body.txt" . | htmlUnescape }}</template>
           <script>
           function mpFlash(btn, msg) {
             var label = btn.querySelector('.mp-ai-title') || btn.querySelector('span') || btn;


### PR DESCRIPTION
### Description of your changes

The "View as Markdown" link and the Copy page button both read `.RawContent`. Reference pages (`product: crd`) are generated from the CRD OpenAPI schema by `crd-single`, not from a Markdown body, so their `.RawContent` holds only the one-line description. Both features therefore emitted just the title and description for every API type, dropping the entire schema.

The audience for these is LLM agents, which do better with the machine-readable contract than a prose re-rendering of it. So `crd-markdown` returns the served `apiVersion`/`kind` a user applies, the validated example, and then the full `CompositeResourceDefinition` (`definition.yaml`) verbatim, with its OpenAPI schema, CEL validation, and defaults intact. Reading the source file means the output can't drift from the API and there's no parallel schema renderer to maintain. A `markdown-body` partial selects this for CRD pages and `.RawContent` for everything else; `single.md` and the Copy page button both go through it so the two never drift. `definition.yaml` is mounted as assets as well as data so `resources.Get` can read it verbatim, comments included.

These are plain-text (`.txt`) partials, but Hugo still parses partials through `html/template` and escapes their output, so the body is piped through `htmlUnescape` to recover the verbatim YAML: `single.md` emits it directly, and the Copy page template lets `html/template` re-escape it once so `mpCopyPage` decodes it back.

The definition is an XRD (`kind: CompositeResourceDefinition`), not the resource a user writes, so the `apiVersion`/`kind` line and the example, both in the `modelplane.ai` form, make the user-facing shape unambiguous.

Verified in a headless browser: for `/reference/modeldeployments/`, `index.md` and the clipboard text (extracted exactly as `mpCopyPage` does) both contain the GVK line, the example, and the full XRD with its CEL validation, no HTML entities, and `compareTo(quantity("20Gi")) >= 0` verbatim. Spot-checked eksclusters, modelreplicas, inferenceclusters, and servingstacks. Normal pages are unchanged (still `.RawContent`).

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~ (Docs theme change, no composition functions touched.)
- [x] Signed off every commit with `git commit -s`.
