### PR TITLE
Add a Llama-3.1-8B single-L4 serving example

### DIFF
--- a/docs/content/examples/llama-3.1-8b.md
+++ b/docs/content/examples/llama-3.1-8b.md
@@ -1,0 +1,46 @@
+---
+title: Llama-3.1-8B
+weight: 40
+description: An 8B dense chat model on a single NVIDIA L4.
+---
+<!-- vale write-good.Passive = NO -->
+An 8B dense chat model on a single NVIDIA L4. The entry recipe: one `Standalone`
+engine, no cache, public weights from a Hugging Face mirror. It carries no
+`clusterSelector`, so device capacity alone matches it to any compatible L4 in
+the fleet.
+
+This recipe was run end to end on GKE; the `InferenceClass`, `InferenceCluster`,
+and `ModelDeployment` are the exact manifests from that run. The EKS platform
+shape is the standard single-L4 recipe. It passes server validation but was not
+served in this run. Apply the platform side first, then the ML side. The GKE
+`InferenceCluster` carries a GCP project placeholder to edit before applying.
+
+## Platform
+
+{{< tabs >}}
+{{< tab "EKS" >}}
+{{< manifests "examples/llama-3.1-8b/inference-class-eks.yaml" >}}
+
+{{< manifests "examples/llama-3.1-8b/inference-cluster-eks.yaml" >}}
+{{< /tab >}}
+{{< tab "GKE" >}}
+{{< manifests "examples/llama-3.1-8b/inference-class-gke.yaml" >}}
+
+{{< manifests path="examples/llama-3.1-8b/inference-cluster-gke.yaml" apply="false" >}}
+
+{{< editCode >}}
+```bash
+curl -fsSL {{< manifest-url "examples/llama-3.1-8b/inference-cluster-gke.yaml" >}} \
+  | sed 's/my-gcp-project/$@<your-gcp-project-id>$@/' \
+  | kubectl apply -f -
+```
+{{< /editCode >}}
+{{< /tab >}}
+{{< /tabs >}}
+
+## Deployment
+
+{{< manifests "examples/llama-3.1-8b/model-deployment.yaml" >}}
+
+{{< manifests "examples/llama-3.1-8b/model-service.yaml" >}}
+<!-- vale write-good.Passive = YES -->

--- a/docs/manifests/examples/llama-3.1-8b/inference-class-eks.yaml
+++ b/docs/manifests/examples/llama-3.1-8b/inference-class-eks.yaml
@@ -1,0 +1,31 @@
+# InferenceClass for the L4 shape on EKS, validated serving Llama-3.1-8B.
+#
+# One NVIDIA L4 on a g6.2xlarge. The GPU is declared as a DRA device: the
+# scheduler matches a ModelDeployment's nodeSelector against this capacity, then
+# DRA binds the physical GPU to the serving pod.
+apiVersion: modelplane.ai/v1alpha1
+kind: InferenceClass
+metadata:
+  name: eks-l4-1x-g6
+spec:
+  description: "EKS g6.2xlarge, 1x NVIDIA L4"
+  provisioning:
+    provider: EKS
+    eks:
+      instanceType: g6.2xlarge
+      diskSizeGb: 100
+      accelerator:
+        type: nvidia-l4
+        count: 1
+  devices:
+  - name: gpu
+    claim: DRA
+    driver: gpu.nvidia.com
+    deviceClassName: gpu.nvidia.com
+    count: 1
+    attributes:
+      architecture: { string: Ada Lovelace }
+    capacity:
+      # The L4's real usable VRAM as the NVIDIA DRA driver reports it, not the
+      # nominal 24GB.
+      memory: { value: "23034Mi" }

--- a/docs/manifests/examples/llama-3.1-8b/inference-class-gke.yaml
+++ b/docs/manifests/examples/llama-3.1-8b/inference-class-gke.yaml
@@ -1,0 +1,31 @@
+# InferenceClass for the L4 shape on GKE, validated serving Llama-3.1-8B.
+#
+# One NVIDIA L4 on a g2-standard-8. The GPU is declared as a DRA device: the
+# scheduler matches a ModelDeployment's nodeSelector against this capacity, then
+# DRA binds the physical GPU to the serving pod.
+apiVersion: modelplane.ai/v1alpha1
+kind: InferenceClass
+metadata:
+  name: gke-l4-1x-g2
+spec:
+  description: "GKE g2-standard-8, 1x NVIDIA L4"
+  provisioning:
+    provider: GKE
+    gke:
+      machineType: g2-standard-8
+      diskSizeGb: 100
+      accelerator:
+        type: nvidia-l4
+        count: 1
+  devices:
+  - name: gpu
+    claim: DRA
+    driver: gpu.nvidia.com
+    deviceClassName: gpu.nvidia.com
+    count: 1
+    attributes:
+      architecture: { string: Ada Lovelace }
+    capacity:
+      # The L4's real usable VRAM as the NVIDIA DRA driver reports it, not the
+      # nominal 24GB.
+      memory: { value: "23034Mi" }

--- a/docs/manifests/examples/llama-3.1-8b/inference-cluster-eks.yaml
+++ b/docs/manifests/examples/llama-3.1-8b/inference-cluster-eks.yaml
@@ -1,0 +1,23 @@
+# EKS InferenceCluster with one L4 node pool. No clusterSelector targets it; the
+# ModelDeployment matches on device capacity alone, so it lands here or on any
+# other compatible cluster in the fleet.
+apiVersion: modelplane.ai/v1alpha1
+kind: InferenceCluster
+metadata:
+  name: eks-l4-single
+  labels:
+    modelplane.ai/cloud: eks
+    modelplane.ai/region: us-west
+spec:
+  cluster:
+    source: EKS
+    eks:
+      region: us-west-2
+  nodePools:
+  - name: gpu-l4
+    className: eks-l4-1x-g6
+    nodeCount: 1
+    zones:
+    - us-west-2a
+    minNodeCount: 0
+    maxNodeCount: 4

--- a/docs/manifests/examples/llama-3.1-8b/inference-cluster-gke.yaml
+++ b/docs/manifests/examples/llama-3.1-8b/inference-cluster-gke.yaml
@@ -1,0 +1,24 @@
+# GKE InferenceCluster with one L4 node pool. Replace the project ID before
+# applying. No clusterSelector targets it; the ModelDeployment matches on device
+# capacity alone, so it lands here or on any other compatible cluster.
+apiVersion: modelplane.ai/v1alpha1
+kind: InferenceCluster
+metadata:
+  name: gke-l4-single
+  labels:
+    modelplane.ai/cloud: gke
+    modelplane.ai/region: us-central
+spec:
+  cluster:
+    source: GKE
+    gke:
+      project: my-gcp-project  # Replace with your GCP project ID.
+      region: us-central1
+  nodePools:
+  - name: gpu-l4
+    className: gke-l4-1x-g2
+    nodeCount: 1
+    zones:
+    - us-central1-a
+    minNodeCount: 0
+    maxNodeCount: 4

--- a/docs/manifests/examples/llama-3.1-8b/model-deployment.yaml
+++ b/docs/manifests/examples/llama-3.1-8b/model-deployment.yaml
@@ -1,0 +1,51 @@
+# Llama-3.1-8B Instruct served on a single NVIDIA L4 by vLLM, validated end to
+# end on GKE (the model layer is cloud-agnostic; the same manifest serves on EKS).
+#
+# 8B in bf16 is ~16Gi of weights, leaving room for the KV cache on the L4's
+# ~23Gi. Llama's default context is 128K, whose KV cache does not fit beside the
+# weights, so --max-model-len caps it at 8192 - raise it only as far as the
+# leftover VRAM allows.
+#
+# Weights come from the public NousResearch mirror, so no Hugging Face token is
+# needed. The gated meta-llama/Llama-3.1-8B-Instruct original needs an hf-token
+# Secret on the *workload* cluster (the engine pod reads it, not the control
+# plane) and HF_TOKEN passed on the engine container.
+#
+# No --port or --host: Modelplane's routing expects the engine on its default
+# :8000 with a /health probe, and passes args through verbatim.
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelDeployment
+metadata:
+  name: llama-3-1-8b
+  namespace: ml-team
+spec:
+  # One replica, matched to any compatible InferenceCluster by device capacity.
+  replicas: 1
+  engines:
+  - name: llama
+    members:
+    # A single self-contained vLLM pod. The container named "engine" is the
+    # inference server; its image and args pass through verbatim.
+    - role: Standalone
+      nodeSelector:
+        devices:
+        - name: gpu
+          count: 1
+          selectors:
+          # An 8B model needs most of an L4. >=20Gi selects the L4 (which
+          # reports ~23Gi) without over-constraining. DRA evaluates this CEL
+          # against the InferenceClass device, then against the GPU's
+          # ResourceSlice when it binds the claim.
+          - cel: |
+              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
+      template:
+        spec:
+          containers:
+          - name: engine
+            image: vllm/vllm-openai:v0.7.3
+            args:
+            - "--model=NousResearch/Meta-Llama-3.1-8B-Instruct"
+            # The id clients pass as "model" in OpenAI requests.
+            - "--served-model-name=llama-3.1-8b"
+            # Cap the context so the KV cache fits beside the weights on the L4.
+            - "--max-model-len=8192"

--- a/docs/manifests/examples/llama-3.1-8b/model-service.yaml
+++ b/docs/manifests/examples/llama-3.1-8b/model-service.yaml
@@ -1,0 +1,15 @@
+# Exposes the llama-3-1-8b deployment's endpoints as a single OpenAI-compatible
+# URL. Modelplane labels each composed ModelEndpoint with the deployment name, so
+# this selector reaches every replica. Read the public address from
+# status.address:
+#   kubectl get ms llama-3-1-8b -n ml-team -o jsonpath='{.status.address}'
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelService
+metadata:
+  name: llama-3-1-8b
+  namespace: ml-team
+spec:
+  endpoints:
+  - selector:
+      matchLabels:
+        modelplane.ai/deployment: llama-3-1-8b


### PR DESCRIPTION
### Description of your changes

The Examples section has no entry-level recipe for a dense model on a single GPU. qwen3-8b is the smallest, but its Qwen-specific reasoning and tool-call parser flags obscure what a minimal deployment actually needs.

This adds a Llama-3.1-8B example: `meta-llama/Llama-3.1-8B-Instruct` served from the public `NousResearch` mirror (no Hugging Face token) on one NVIDIA L4 with vLLM. It is one `Standalone` engine, no cache, and no `clusterSelector`, so device capacity alone places it on any compatible L4 in the fleet. `--max-model-len` caps the context at 8192 so the KV cache fits beside the bf16 weights on the L4's ~23Gi. Platform covers both clouds in tabs (EKS `g6.2xlarge`, GKE `g2-standard-8`) reusing the standard `l4-single` class and cluster shapes; the model layer is shared across them.

I deployed it end to end on a real GKE L4 cluster through the control plane. The cluster reached `Ready`, the `ModelDeployment` reached `Ready`, and the served endpoint returned a real completion:

```
$ curl $ADDR/v1/chat/completions -d '{"model":"llama-3.1-8b","messages":[{"role":"user","content":"In one sentence, what is Crossplane?"}],"max_tokens":80}'
{"model":"llama-3.1-8b", ... "content":"Crossplane is an open-source framework that enables users to abstract, compose, and manage infrastructure and services across multiple clouds and on-premises environments ...","finish_reason":"stop"}
```

The EKS platform manifests pass `kubectl apply --dry-run=server` against the Modelplane CRDs but were not served in this run, so the page's provenance attributes the live run to GKE only.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~~ No local Nix; the CI `check` job runs `nix flake check` and passed on this PR.
- [ ] ~~Added or updated tests covering any composition function changes.~~ Docs-only change, no composition functions touched.
- [x] Signed off every commit with `git commit -s`.
