### PR TITLE
Tell contributors to work from a fork, not a main-repo branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,6 +285,14 @@ Vercel's GitHub app drives deploys as usual: preview URLs on pull requests
 Before opening a PR, run `nix flake check` and make sure it passes. If you
 changed a composition function, make sure there's a test covering the change.
 
+### Work from a fork
+
+Open every PR from a branch on your own [fork][fork], never a branch of the main
+repo. This holds for maintainers too, and for any agent working on your behalf:
+point it at your fork.
+
+[fork]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo
+
 ### Writing style
 
 Using an agent to help write code, commits, PRs, or issues is fine. But the prose it


### PR DESCRIPTION
### Description of your changes

Some contributors, and the agents acting on their behalf, push branches to the main repo instead of a fork. This adds a short note to CONTRIBUTING telling everyone, maintainers included, to open PRs from their own fork.

~Fixes #~

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
