### PR TITLE
Fix docs footer showing a dark background in light mode

### DIFF
--- a/docs/themes/geekboot/assets/scss/_modelplane.scss
+++ b/docs/themes/geekboot/assets/scss/_modelplane.scss
@@ -270,8 +270,8 @@ nav.site-nav a { vertical-align: baseline; }
 // ── Footer ────────────────────────────────────────────────────
 
 .bd-footer {
-  background: var(--mp-bg) !important; // always the dark brand colour, like modelplane.ai
-  border-top: 1px solid var(--mp-border);
+  background: var(--body-background) !important; // follow the active theme: dark brand colour in dark mode, light in light mode
+  border-top: 1px solid var(--mp-card-border);
   margin-top: auto; // pin to the bottom of the .bd-main column on short pages
   padding: 48px 18px;
   position: relative; z-index: 1;
@@ -284,15 +284,15 @@ nav.site-nav a { vertical-align: baseline; }
   }
   .footer-left  { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; }
   .footer-logo  { display: flex; align-items: center; flex-shrink: 0; text-decoration: none; }
-  .footer-tagline { font-size: 13px; color: var(--mp-text-muted); line-height: 1.4; }
-  .footer-legal { margin: 0; font-size: 12px; color: var(--mp-text-muted); line-height: 1.4; }
+  .footer-tagline { font-size: 13px; color: var(--mp-muted); line-height: 1.4; }
+  .footer-legal { margin: 0; font-size: 12px; color: var(--mp-muted); line-height: 1.4; }
   .footer-right {
     display: flex; align-items: center; flex-wrap: wrap; gap: 32px;
     a {
-      font-size: 13px; color: var(--mp-text-muted); text-decoration: none;
+      font-size: 13px; color: var(--mp-muted); text-decoration: none;
       transition: color 0.2s; display: flex; align-items: center;
       svg { width: 20px; height: 20px; display: block; }
-      &:hover { color: var(--mp-text); }
+      &:hover { color: var(--body-font-color); }
     }
   }
   .social-icons { display: inline-flex; align-items: center; gap: 16px; }


### PR DESCRIPTION
### Description of your changes

In light mode the docs site footer rendered as a dark block (dark spruce background, light text) while the rest of the page was white.

The footer styling (`docs/themes/geekboot/assets/scss/_modelplane.scss`) hardcoded the dark brand tokens: `--mp-bg` for the background, `--mp-text-muted` / `--mp-text` for text, and `--mp-border` for the top divider. Those tokens are defined once at `:root` in `_variables.scss` and never flip between colour themes, so the footer stayed dark regardless of the active theme. A comment on the rule said this was deliberate ("always the dark brand colour, like modelplane.ai"), but on the docs site, which has a working light/dark toggle, it reads as a bug.

The fix swaps those for the theme's mode-aware tokens, which are defined in both the `light-mode` and `dark-mode` mixins:

- `background`: `--mp-bg` to `--body-background`
- divider: `--mp-border` to `--mp-card-border`
- text: `--mp-text-muted` to `--mp-muted`
- link hover: `--mp-text` to `--body-font-color`

Each of these resolves to the **exact same value in dark mode** (`--body-background` is `--mp-bg`, `--mp-muted` is `--mp-text-muted`, etc.), so dark mode is visually unchanged. In light mode the footer now follows the page: light background, a subtle border, and readable dark text.

For reviewers: the thing to confirm is the dark-mode no-op claim. The dark-mode values for all four tokens live in `dark-mode.scss` (`--body-background`, `--mp-muted`, `--mp-card-border`) and `_variables.scss` (`--body-font-color` resolves via `--mp-text`).

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~ Nix isn't installed on the machine I'm working from. I verified the SCSS compiles via a local Hugo build and confirmed the swapped tokens are defined in both colour themes; CI's flake check builds the docs site and will run here.
- [ ] ~Added or updated tests covering any composition function changes.~ CSS-only change, no composition functions touched.
- [x] Signed off every commit with `git commit -s`.