### PR TITLE
Expand shortcodes in the llms.json and llms-full.txt corpora

### DIFF
--- a/docs/themes/geekboot/layouts/_default/home.llmsfull.txt
+++ b/docs/themes/geekboot/layouts/_default/home.llmsfull.txt
@@ -9,5 +9,5 @@
 
 Source: {{ .Permalink }}
 
-{{ .RawContent }}
+{{ .RenderShortcodes | replaceRE "<[^>]*[=/][^>]*>" "" | htmlUnescape }}
 {{ end }}{{ end }}

--- a/docs/themes/geekboot/layouts/_default/home.llmsjson.json
+++ b/docs/themes/geekboot/layouts/_default/home.llmsjson.json
@@ -1,5 +1,19 @@
 {{- /* llms.json: the structured corpus the docs MCP server searches.
-       One entry per content page; the MCP server chunks by heading at load time. */ -}}
+       One entry per content page; the MCP server chunks by heading at load time.
+
+       Content is .RenderShortcodes (not .RawContent) so shortcodes are expanded
+       rather than leaking as their literal source (manifests, ref, tabs, etc.).
+       .RenderShortcodes leaves the surrounding Markdown intact (unlike .Plain), so
+       headings survive for the MCP server's heading-based chunking, and newlines
+       are kept (plainify would collapse them, flattening the YAML and headings).
+
+       The replaceRE strips the HTML the shortcodes emit (manifest code cards, SVG
+       icons). It deliberately matches only tags that contain "=" or "/" — i.e.
+       real tags, which always have an attribute or are closing/self-closing — so
+       it does NOT eat bare angle-bracket placeholders in prose like the inline
+       `http://<address>/<namespace>/<service>`. Do not simplify it to <[^>]+>:
+       that strips those placeholders too. htmlUnescape then restores entities
+       (e.g. escaped angle brackets from highlighted YAML) to readable text. */ -}}
 {{- $pages := slice -}}
 {{- range (where .Site.Pages "Kind" "in" (slice "home" "page" "section")).ByWeight -}}
   {{- if .RawContent -}}
@@ -11,7 +25,7 @@
         "url" .Permalink
         "path" .RelPermalink
         "markdown_url" $md
-        "content" .RawContent) -}}
+        "content" (.RenderShortcodes | replaceRE "<[^>]*[=/][^>]*>" "" | htmlUnescape)) -}}
   {{- end -}}
 {{- end -}}
 {{- dict


### PR DESCRIPTION
### Description of your changes

The docs MCP server at `docs.modelplane.ai/mcp` (and the `llms-full.txt` download) served page content straight from `.RawContent`, so Hugo shortcodes leaked verbatim into the corpus. **25 of 31 pages** contained literal shortcode source — `manifests` (50×), `ref` (52×), `tabs`/`tab`, `card`, `qa`, `accel`, and more — instead of the manifests, resolved links, and prose they stand for. Anyone (or any model) reading these docs via MCP or `llms-full.txt` saw template directives where the YAML and URLs should be: e.g. `get_modelplane_doc("/models/model-deployment/")` returned `{{< manifests "..." >}}` rather than the `ModelDeployment` YAML.

The fix is in the two corpus templates (`home.llmsjson.json`, `home.llmsfull.txt`):

- Render with **`.RenderShortcodes`** instead of `.RawContent`. Unlike `.Plain`/`plainify`, it keeps the surrounding Markdown, so `#` headings survive for the MCP server's heading-based chunking and YAML keeps its newlines.
- A **narrow `replaceRE`** strips the HTML the shortcodes emit (manifest code cards, SVG icons). It matches only tags containing `=` or `/` (real tags always have an attribute or are closing/self-closing), so it leaves bare angle-bracket placeholders in prose — like the inline `` `http://<address>/<namespace>/<service>` `` — intact. There's an explicit comment warning not to simplify it to `<[^>]+>`, which corrupts those placeholders.
- `htmlUnescape` restores entities (e.g. escaped angle brackets from highlighted YAML).

For reviewers: the judgment is in the `replaceRE`. I tried `plainify` first — it collapses all newlines (whole page becomes one line, no headings, YAML flattened), and the naive `<[^>]+>` strips legitimate inline `<placeholder>` text, turning URL examples into `http:///`. The attribute/slash-aware pattern avoids both.

### Verification

Built locally and inspected the generated `llms.json` / `llms-full.txt`:
- 0 shortcode leaks across all 31 pages (down from 25 pages leaking)
- 0 leftover HTML tags, 0 `<svg>`
- headings preserved (e.g. model-deployment page: 34 headings / 478 lines) so MCP chunking is unaffected
- YAML manifests now present with structure intact
- inline-code placeholders (`<address>`, `<gateway>`, `<service-name>`, …) survive — no `http:///` corruption

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~ Nix isn't installed on the machine I'm working from. I verified by building the docs site locally (Hugo) and inspecting both generated corpora as above; CI's flake check builds the docs and will run here.
- [ ] ~Added or updated tests covering any composition function changes.~ Docs templating change, no composition functions touched.
- [x] Signed off every commit with `git commit -s`.