### PR TITLE
[release-0.1] Set docs version to 0.1

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -99,7 +99,7 @@ ignoreFiles = ["themes/geekboot/content/.*", "README.md"]
   docs = true
   description = "Modelplane documentation."
   # "main" on the dev branch; "X.Y" (e.g. "0.1") on release branches.
-  version = "main"
+  version = "0.1"
   # Latest stable release.
   latest = "main"
   [params.anchors]


### PR DESCRIPTION
### Description of your changes

The `release-0.1` branch was cut from `main` and inherited its docs config, which sets `version = "main"` in `docs/hugo.toml`. The versioned docs site served from this branch (`v0-1.docs.modelplane.ai`) would label itself "main" rather than the 0.1 release.

This sets `version = "0.1"` per CONTRIBUTING.md § Versioning the docs, step 1. `latest` stays `"main"` — the latest docs always live at the root.

The matching `versions.yaml` entry on `main` (step 3) and the Vercel branch-domain setup (step 2) are handled separately.

~Fixes #~

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
