### PR TITLE
Add 0.1 to the docs version dropdown

### DIFF
--- a/docs/data/versions.yaml
+++ b/docs/data/versions.yaml
@@ -6,3 +6,5 @@
 versions:
   - version: "main"
     url: ""
+  - version: "0.1"
+    url: "https://v0-1.docs.modelplane.ai"


### PR DESCRIPTION
### Description of your changes

The v0.1 docs are served from `v0-1.docs.modelplane.ai`, but the version dropdown had no entry for them, so readers couldn't navigate to the 0.1 docs from `main` or from the release build.

This adds the `0.1` entry to `docs/data/versions.yaml`, newest-first below `main`, per CONTRIBUTING.md § Versioning the docs, step 3. The dropdown on every build now links to the subdomain.

Depends on the Vercel branch-domain setup (step 2) and modelplaneai/modelplane#272, which sets `version = "0.1"` on `release-0.1`.

~Fixes #~

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
