### PR TITLE
Redirect the docs root to the latest release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,22 +22,47 @@ release from it and run the workflow against the new tag.
 
 ## Versioning the docs
 
-Docs are versioned at the minor level. Each minor release is served from its own
-subdomain (`v0-1.docs.modelplane.ai`, `v0-2.docs.modelplane.ai`, …) using a single
-Vercel project with one branch domain per release. The `main` branch always serves
-the latest docs at `docs.modelplane.ai`. Patch releases push to the existing release
-branch and need no changes to `main`.
+Docs are versioned at the minor level, each version on its own subdomain, served
+by a single Vercel project with one branch domain per build:
+
+- `docs.modelplane.ai` — the canonical apex. Its home page redirects to the
+  latest release, so a reader who types the bare domain lands on the latest docs.
+- `vX-Y.docs.modelplane.ai` — each minor release (`v0-1`, `v0-2`, …), built from
+  its `release-X.Y` branch.
+- `main.docs.modelplane.ai` — the dev docs, built from `main`, so unreleased docs
+  stay browsable.
+
+Both `main.docs` and the apex are built from `main`; what tells them apart is the
+baseURL. The apex build redirects because its baseURL isn't `main`'s own subdomain
+(`docs/themes/geekboot/layouts/index.html`). The redirect target is the latest
+release's URL, looked up in `docs/data/versions.yaml` by `latest` in
+`docs/hugo.toml`.
+
+`docs/data/versions.yaml` is the single list of every version and its URL. It
+drives the version dropdown and the apex redirect, and must be identical on every
+branch — `main` and all release branches — so each build offers the same switcher.
 
 One-time DNS setup (already done): a wildcard CNAME `*.docs.modelplane.ai →
-cname.vercel-dns.com` covers every future release subdomain automatically. No new
-DNS record is needed per release.
+cname.vercel-dns.com` covers `main.docs` and every release subdomain. No new DNS
+record is needed per release.
 
 To publish docs for a new minor release (e.g. `v0.1.0`):
 
-1. On `release-0.1`, set `version = "0.1"` in `docs/hugo.toml`. Leave
-   `latest = "main"` unchanged — the latest docs always live at the root.
+1. On `release-0.1`, set `version = "0.1"` in `docs/hugo.toml`.
 
-2. In the Vercel dashboard, open the `modelplane-docs` project and add a branch
+2. Add the release to `docs/data/versions.yaml`, newest first, on both `main` and
+   `release-0.1` (keep the file identical across branches):
+   ```yaml
+   versions:
+     - version: "main"
+       url: "https://main.docs.modelplane.ai"
+     - version: "0.1"
+       url: "https://v0-1.docs.modelplane.ai"
+   ```
+   On `main`, also set `latest = "0.1"` in `docs/hugo.toml` so the apex redirects
+   to the new release.
+
+3. In the Vercel dashboard, open the `modelplane-docs` project and add a branch
    domain for the release:
    - Go to Settings → Domains, add `v0-1.docs.modelplane.ai`, and assign it
      to the `release-0.1` branch.
@@ -45,20 +70,15 @@ To publish docs for a new minor release (e.g. `v0.1.0`):
      `HUGO_BASEURL` = `https://v0-1.docs.modelplane.ai/`.
    - Trigger a redeployment of `release-0.1` and confirm the subdomain serves.
 
-3. On `main`, add an entry to `docs/data/versions.yaml`, newest first:
-   ```yaml
-   versions:
-     - version: "main"
-       url: ""
-     - version: "0.1"
-       url: "https://v0-1.docs.modelplane.ai"
-   ```
+4. Merge the changes. The apex now redirects to the new release, and the version
+   dropdown on every build links to it.
 
-4. Merge the `versions.yaml` change to `main`. The version dropdown on all release
-   builds now links to the new subdomain.
+The `main.docs.modelplane.ai` domain and its `HUGO_BASEURL = https://main.docs.modelplane.ai/`
+env var (scoped to `main`) are a one-time setup, done when the first release ships.
 
 To fix a typo or update content in an archived version, push to the release branch.
 The versioned deployment rebuilds automatically.
 
-When a new minor ships (e.g. `v0.2.0`), repeat steps 1–4 for `release-0.2`,
-adding the `v0.2` entry above `v0.1` in `versions.yaml`.
+When a new minor ships (e.g. `v0.2.0`), repeat steps 1–4 for `release-0.2`, adding
+the `v0.2` entry above `v0.1` in `versions.yaml` on every branch and bumping
+`latest` to `0.2` on `main`.

--- a/docs/data/versions.yaml
+++ b/docs/data/versions.yaml
@@ -1,10 +1,12 @@
-# Released doc versions, newest first. main is not listed here — the root
-# redirects to the latest release. See RELEASING.md § Versioning the docs.
+# Doc versions for the version dropdown, newest first. main is the dev build,
+# browsable at its own subdomain; the canonical apex (docs.modelplane.ai)
+# redirects to the latest release (params.latest in hugo.toml). See
+# RELEASING.md § Versioning the docs.
 #
-# version: X.Y minor version string (e.g. "0.1")
+# version: X.Y minor version string (e.g. "0.1"), or "main" for the dev build
 # url:     absolute base URL for that version's content
 versions:
   - version: "main"
-    url: ""
+    url: "https://main.docs.modelplane.ai"
   - version: "0.1"
     url: "https://v0-1.docs.modelplane.ai"

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -100,8 +100,8 @@ ignoreFiles = ["themes/geekboot/content/.*", "README.md"]
   description = "Modelplane documentation."
   # "main" on the dev branch; "X.Y" (e.g. "0.1") on release branches.
   version = "main"
-  # Latest stable release.
-  latest = "main"
+  # Latest stable release. The apex build redirects its root here.
+  latest = "0.1"
   [params.anchors]
     min = 2
     max = 5

--- a/docs/themes/geekboot/layouts/index.html
+++ b/docs/themes/geekboot/layouts/index.html
@@ -1,5 +1,40 @@
 {{ define "main" }}
-{{ with .Site.GetPage "/overview" }}
-{{ partial "single-list" . }}
+{{/* The dev (main) docs are built twice: once for the canonical apex
+     (docs.modelplane.ai) and once for their own subdomain
+     (main.docs.modelplane.ai). The apex build redirects its root to the
+     latest release so a reader on the bare domain lands on the latest docs;
+     the main-subdomain build serves the dev docs so they stay browsable.
+
+     Both builds are version == "main"; what tells them apart is the baseURL.
+     versions.yaml records each version's home URL, so the apex is "the main
+     build whose baseURL isn't main's own subdomain". Release builds
+     (version != "main") never redirect and fall straight through.
+
+     The redirect mirrors the window.location.replace plus noscript
+     meta-refresh that list.html uses for section index pages. */}}
+{{ $dest := "" }}
+{{ if eq .Site.Params.version "main" }}
+  {{ $here := strings.TrimSuffix "/" .Site.BaseURL }}
+  {{ $mainURL := "" }}
+  {{ $latestURL := "" }}
+  {{ range .Site.Data.versions.versions }}
+    {{ if eq .version "main" }}{{ $mainURL = strings.TrimSuffix "/" .url }}{{ end }}
+    {{ if and (eq .version $.Site.Params.latest) .url }}{{ $latestURL = strings.TrimSuffix "/" .url }}{{ end }}
+  {{ end }}
+  {{/* Redirect only when main's own subdomain is known and this build isn't it,
+       and only if a latest release exists to redirect to. Requiring $mainURL to
+       be set makes the dev-docs build fail open (serve content) rather than
+       redirect if the main entry is missing from versions.yaml. */}}
+  {{ if and $latestURL $mainURL (ne $here $mainURL) }}
+    {{ $dest = printf "%s/" $latestURL }}
+  {{ end }}
+{{ end }}
+{{ if $dest }}
+  <script>window.location.replace("{{ $dest | safeURL }}");</script>
+  <noscript><meta http-equiv="refresh" content="0; url={{ $dest | safeURL }}"></noscript>
+{{ else }}
+  {{ with .Site.GetPage "/overview" }}
+  {{ partial "single-list" . }}
+  {{ end }}
 {{ end }}
 {{ end }}

--- a/docs/themes/geekboot/layouts/partials/version-dropdown-menu.html
+++ b/docs/themes/geekboot/layouts/partials/version-dropdown-menu.html
@@ -1,11 +1,12 @@
 {{ $cur := .Site.Params.version }}
 {{ $latest := .Site.Params.latest }}
 {{ $versions := .Site.Data.versions.versions }}
-{{/* Only render on release branches — main content redirects to latest,
-     so there's nothing to switch between from the root. */}}
-{{ if and $versions (ne $cur "main") }}
+{{/* Render wherever there's more than one version to switch between. Every
+     build, including main (browsable at main.docs.modelplane.ai), serves real
+     content, so all of them carry the switcher. */}}
+{{ if and $versions (gt (len $versions) 1) }}
 
-{{/* Each version is served from its own subdomain (e.g. v0.1.docs.modelplane.ai),
+{{/* Each version is served from its own subdomain (e.g. v0-1.docs.modelplane.ai),
      so baseURL has no path component and RelPermalink is already root-relative. */}}
 {{ $pagePath := .RelPermalink }}
 


### PR DESCRIPTION
### Description of your changes

`docs.modelplane.ai` is built from `main` and served the dev docs at its root, so readers landing on the bare domain saw unreleased docs instead of the latest release. The version dropdown's own comment already assumed the root redirects to latest — a behavior that was never wired up.

This makes the apex redirect to the latest release while keeping the dev docs browsable on their own subdomain:

| URL | Serves |
|---|---|
| `docs.modelplane.ai` | redirect to the latest release |
| `main.docs.modelplane.ai` | the dev (`main`) docs |
| `vX-Y.docs.modelplane.ai` | each minor release |

The apex and `main.docs` builds both come from `main` and are both `version == "main"`; what tells them apart is the baseURL. The home page redirects only when the build's baseURL isn't `main`'s own subdomain — both URLs read from `versions.yaml`. The redirect target is the latest release's URL, keyed by `params.latest` in `hugo.toml`, so the dropdown and the redirect share one source of truth. The redirect uses the same `window.location.replace` + `noscript` meta-refresh that `list.html` already uses for section index pages.

`versions.yaml` now lists every version, including `main`, each with a real URL, so the dropdown renders on every build (its old guard skipped `main`). `latest` moves from `"main"` to `"0.1"`.

`versions.yaml` and the home/dropdown templates must stay byte-identical across branches so every build offers the same switcher. The matching release-side change is in modelplaneai/modelplane#275.

**Vercel setup this depends on:** add `main.docs.modelplane.ai` to the `modelplane-docs` project on the `main` branch, with a Production env var `HUGO_BASEURL=https://main.docs.modelplane.ai/` scoped to `main`. Without it the apex still redirects correctly, but `main.docs` won't resolve.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
