### PR TITLE
[release-0.1] Wire up version switching on the v0.1 docs

### DIFF
--- a/docs/data/versions.yaml
+++ b/docs/data/versions.yaml
@@ -1,8 +1,12 @@
-# Released doc versions, newest first. main is not listed here — the root
-# redirects to the latest release. See CONTRIBUTING.md § Versioning the docs.
+# Doc versions for the version dropdown, newest first. main is the dev build,
+# browsable at its own subdomain; the canonical apex (docs.modelplane.ai)
+# redirects to the latest release (params.latest in hugo.toml). See
+# CONTRIBUTING.md § Versioning the docs.
 #
-# version: X.Y minor version string (e.g. "0.1")
+# version: X.Y minor version string (e.g. "0.1"), or "main" for the dev build
 # url:     absolute base URL for that version's content
 versions:
   - version: "main"
-    url: ""
+    url: "https://main.docs.modelplane.ai"
+  - version: "0.1"
+    url: "https://v0-1.docs.modelplane.ai"

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -100,8 +100,8 @@ ignoreFiles = ["themes/geekboot/content/.*", "README.md"]
   description = "Modelplane documentation."
   # "main" on the dev branch; "X.Y" (e.g. "0.1") on release branches.
   version = "0.1"
-  # Latest stable release.
-  latest = "main"
+  # Latest stable release. The apex build redirects its root here.
+  latest = "0.1"
   [params.anchors]
     min = 2
     max = 5

--- a/docs/themes/geekboot/layouts/index.html
+++ b/docs/themes/geekboot/layouts/index.html
@@ -1,5 +1,40 @@
 {{ define "main" }}
-{{ with .Site.GetPage "/overview" }}
-{{ partial "single-list" . }}
+{{/* The dev (main) docs are built twice: once for the canonical apex
+     (docs.modelplane.ai) and once for their own subdomain
+     (main.docs.modelplane.ai). The apex build redirects its root to the
+     latest release so a reader on the bare domain lands on the latest docs;
+     the main-subdomain build serves the dev docs so they stay browsable.
+
+     Both builds are version == "main"; what tells them apart is the baseURL.
+     versions.yaml records each version's home URL, so the apex is "the main
+     build whose baseURL isn't main's own subdomain". Release builds
+     (version != "main") never redirect and fall straight through.
+
+     The redirect mirrors the window.location.replace plus noscript
+     meta-refresh that list.html uses for section index pages. */}}
+{{ $dest := "" }}
+{{ if eq .Site.Params.version "main" }}
+  {{ $here := strings.TrimSuffix "/" .Site.BaseURL }}
+  {{ $mainURL := "" }}
+  {{ $latestURL := "" }}
+  {{ range .Site.Data.versions.versions }}
+    {{ if eq .version "main" }}{{ $mainURL = strings.TrimSuffix "/" .url }}{{ end }}
+    {{ if and (eq .version $.Site.Params.latest) .url }}{{ $latestURL = strings.TrimSuffix "/" .url }}{{ end }}
+  {{ end }}
+  {{/* Redirect only when main's own subdomain is known and this build isn't it,
+       and only if a latest release exists to redirect to. Requiring $mainURL to
+       be set makes the dev-docs build fail open (serve content) rather than
+       redirect if the main entry is missing from versions.yaml. */}}
+  {{ if and $latestURL $mainURL (ne $here $mainURL) }}
+    {{ $dest = printf "%s/" $latestURL }}
+  {{ end }}
+{{ end }}
+{{ if $dest }}
+  <script>window.location.replace("{{ $dest | safeURL }}");</script>
+  <noscript><meta http-equiv="refresh" content="0; url={{ $dest | safeURL }}"></noscript>
+{{ else }}
+  {{ with .Site.GetPage "/overview" }}
+  {{ partial "single-list" . }}
+  {{ end }}
 {{ end }}
 {{ end }}

--- a/docs/themes/geekboot/layouts/partials/version-dropdown-menu.html
+++ b/docs/themes/geekboot/layouts/partials/version-dropdown-menu.html
@@ -1,11 +1,12 @@
 {{ $cur := .Site.Params.version }}
 {{ $latest := .Site.Params.latest }}
 {{ $versions := .Site.Data.versions.versions }}
-{{/* Only render on release branches — main content redirects to latest,
-     so there's nothing to switch between from the root. */}}
-{{ if and $versions (ne $cur "main") }}
+{{/* Render wherever there's more than one version to switch between. Every
+     build, including main (browsable at main.docs.modelplane.ai), serves real
+     content, so all of them carry the switcher. */}}
+{{ if and $versions (gt (len $versions) 1) }}
 
-{{/* Each version is served from its own subdomain (e.g. v0.1.docs.modelplane.ai),
+{{/* Each version is served from its own subdomain (e.g. v0-1.docs.modelplane.ai),
      so baseURL has no path component and RelPermalink is already root-relative. */}}
 {{ $pagePath := .RelPermalink }}
 


### PR DESCRIPTION
### Description of your changes

The v0.1 docs identified themselves correctly but couldn't switch versions: the home page rendered the overview inline, the version dropdown only rendered against a `versions.yaml` that listed `main` alone with no URL, and `latest` was still `"main"`, so v0.1 wasn't badged as the latest release.

This brings the release build in line with `main`. `versions.yaml` lists every version with a real URL, the dropdown renders wherever there's more than one version, and the home page redirects only on the apex — never on this release build, which serves its content at the root. `latest` becomes `"0.1"` so v0.1 carries the "Latest" badge.

`versions.yaml` and the home/dropdown templates are byte-identical with `main`, so both builds offer the same switcher. The apex-redirect change on `main` is modelplaneai/modelplane#274.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
