### PR TITLE
Fix and rebrand the docs social cards

### DIFF
--- a/docs/themes/geekboot/layouts/partials/meta-common.html
+++ b/docs/themes/geekboot/layouts/partials/meta-common.html
@@ -1,15 +1,13 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="author" content="Crossplane Community">
+<meta name="author" content="Modelplane">
 <meta name="color-scheme" content="light dark">
 <meta name="docsearch:language" content="en" />
 {{ hugo.Generator }}
-<meta property="og:image"           content="{{ "img/modelplane-logo-inverted.svg" | absURL }}" />
-<meta property="twitter:card"       content="{{ "img/modelplane-logo-inverted.svg" | absURL }}" />
-<meta property="og:image:width"     content="600" />
-<meta property="og:image:height"    content="199" />
-<meta property="og:image:alt"       content="Crossplane name and popsicle logo" />
-<meta property="twitter:image:alt"  content="Crossplane name and popsicle logo" />
+{{- /* Page-invariant social tags only. The per-page og:image and og:title live in
+       social.html, because this partial is partialCached and would otherwise reuse
+       one page's card across the whole site. */ -}}
 <meta property="og:type"            content="website" />
-<meta name="twitter:site"           content="@modelplane_ai">
-<meta property="og:site_name"       content="Crossplane Documentation" />
+<meta property="og:site_name"       content="Modelplane Docs" />
+<meta name="twitter:card"           content="summary_large_image" />
+<meta name="twitter:site"           content="@ModelplaneAI" />

--- a/docs/themes/geekboot/layouts/partials/social.html
+++ b/docs/themes/geekboot/layouts/partials/social.html
@@ -1,14 +1,16 @@
-{{ $ver := .Page.Params.version | default .Site.Params.latest }}
-{{- if .IsHome -}}
-    <meta property="og:title" {{ printf "content=%s" .Site.Title }} />
-{{- else }}
-    {{ if eq .Page.Params.version "master" }}
-        <meta property="og:title" {{ printf "content='Crossplane Docs · master · %s'" .Params.Title | safeHTMLAttr }} />
-    {{ else if and (ne .Page.Params.version "0") (ne .Page.Params.version "master") }}
-        <meta property="og:title" {{ printf "content='Crossplane Docs · v%s · %s'" $ver .Params.Title | safeHTMLAttr }} />
-    {{ else }}
-        <meta property="og:title" {{ printf "content='Crossplane %s · %s'" .Params.Product .Page.Params.Title | safeHTMLAttr  }} />
-    {{ end }}
-{{ end }}
-
-<meta property="og:description"     content="{{ .Summary | truncate 200 }}" />
+{{- /* Per-page social tags. Kept here (not in the partialCached meta-common) so each
+       page gets its own title and branded card. */ -}}
+{{- $title := cond .IsHome .Site.Title (printf "%s · %s" .Title .Site.Title) -}}
+{{- $desc := .Description | default (.Summary | truncate 200) | default .Site.Params.description -}}
+{{- $cardTitle := cond .IsHome .Site.Title (.Title | default .Site.Title) -}}
+{{- $ogImage := printf "https://modelplane.ai/api/og?%s" (querify "title" $cardTitle) -}}
+<meta property="og:title"           content="{{ $title }}" />
+<meta name="twitter:title"          content="{{ $title }}" />
+<meta property="og:description"     content="{{ $desc }}" />
+<meta name="twitter:description"    content="{{ $desc }}" />
+<meta property="og:image"           content="{{ $ogImage }}" />
+<meta property="og:image:width"     content="1200" />
+<meta property="og:image:height"    content="630" />
+<meta property="og:image:alt"       content="{{ $cardTitle }}" />
+<meta name="twitter:image"          content="{{ $ogImage }}" />
+<meta name="twitter:image:alt"      content="{{ $cardTitle }}" />


### PR DESCRIPTION
### Description of your changes

The docs site's social cards were broken and still carried Crossplane branding from the `geekboot` theme:

- **`og:title` rendered as `zgotmplz`** — the home branch in `social.html` wrote an *unquoted* `content` attribute, which Go's `html/template` refuses to emit.
- **`og:image` was an SVG** logo — LinkedIn/X/Slack/Bluesky don't render SVG OG images, so no card showed.
- **`twitter:card` was non-functional** — set with `property=` (Twitter reads `name=`) and pointed at an image URL instead of the card type.
- **Stale Crossplane copy** — `og:site_name` "Crossplane Documentation", alt text "Crossplane name and popsicle logo", `author` "Crossplane Community", `twitter:site` `@modelplane_ai`, and version-branch titles like "Crossplane Docs · …".

This renders a **per-page branded card** via the website's OG generator (`https://modelplane.ai/api/og?title=<page title>`, a 1200×630 PNG), and emits proper `twitter:card=summary_large_image` + `twitter:image/title/description`.

The judgment call worth reviewing: the per-page tags live in **`social.html`**, not `meta-common.html`, because `header.html` calls `{{ partialCached "meta-common" . }}` with no per-page key — so a per-page card placed there renders once and is reused site-wide. Only page-invariant tags (`og:type`, `og:site_name`, `twitter:card`, `twitter:site`) stay in the cached partial. Docs are single-version (`version = "main"`), so the old Crossplane version-branch title logic is dropped.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~~Run `nix flake check`~~ — couldn't in this sandbox (the PostCSS native addon is disabled, so the asset pipeline panics locally). Verified instead by building with Hugo and confirming each page emits its own `og:title`/`og:image` with no `zgotmplz`; CI's `nix flake check` will gate it.
- [x] ~~Added or updated tests covering any composition function changes.~~ No composition function changes — docs theme templates only.
- [x] Signed off every commit with `git commit -s`.
