### PR TITLE
Tag docs pageviews with the Docs Google Analytics content group

### DIFF
--- a/docs/themes/geekboot/layouts/partials/analytics-config.html
+++ b/docs/themes/geekboot/layouts/partials/analytics-config.html
@@ -5,7 +5,9 @@
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', 'G-YP8274QQR9');
+  gtag('config', 'G-YP8274QQR9', {
+    'content_group': 'Docs'
+  });
 </script>
 <!-- Common Room -->
 <script>


### PR DESCRIPTION
Google Analytics received pageviews from the docs site with no content_group set, so docs traffic couldn't be separated from the blog and main website in reporting.

This passes `content_group: 'Docs'` to the gtag config call in the docs theme's analytics partial. The geekboot theme is used only by the docs site, so the group is constant for every page this partial renders. The block only emits when `VERCEL_ENV` is `production`, so the dimension reports from production deploys, not local or preview builds.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.