### PR TITLE
Point remaining Slack references at slack.modelplane.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Modelplane is at v0.1. It is early and evolving fast. See [issues labeled `enhan
 Contributions, bug reports, and feature requests are welcome.
 
 - **Issues:** [GitHub Issues][issues]
-- **Slack:** [#modelplane][slack] in the Kubernetes workspace
+- **Slack:** [Join our Slack][slack]
 
 See [CONTRIBUTING.md] for how to get set up, run checks, and submit changes.
 

--- a/docs/themes/geekboot/static/llms.txt
+++ b/docs/themes/geekboot/static/llms.txt
@@ -77,5 +77,5 @@ Aggregates all ModelEndpoints for a ModelDeployment into a single, unified, Open
 - GitHub: https://github.com/modelplaneai/modelplane
 - Issues: https://github.com/modelplaneai/modelplane/issues
 - Discussions: https://github.com/modelplaneai/modelplane/discussions
-- Slack: https://crossplane.slack.com (#modelplane)
+- Slack: https://slack.modelplane.ai
 - License: Apache 2.0

--- a/docs/utils/htmltest/.htmltest.yml
+++ b/docs/utils/htmltest/.htmltest.yml
@@ -6,5 +6,5 @@ IgnoreURLs:
   - "/safari-pinned-tab.svg"
   - "github.com/modelplaneai/modelplane/issues/new.*"
   - "github.com/modelplaneai/modelplane/issues\\?.*"
-  - "crossplane.slack.com"
+  - "slack.modelplane.ai"
   - "twitter.com/.*"


### PR DESCRIPTION
### Description of your changes

After the move to Modelplane's own Slack workspace (behind `slack.modelplane.ai`), a few references were missed and still pointed at the Crossplane workspace or described the channel as living in the Kubernetes workspace:

- `docs/themes/geekboot/static/llms.txt` — Slack URL was `https://crossplane.slack.com (#modelplane)`; now `https://slack.modelplane.ai`.
- `docs/utils/htmltest/.htmltest.yml` — the link-checker ignore entry `crossplane.slack.com` is now `slack.modelplane.ai` (kept ignored since it's a redirect to the join URL).
- `README.md` — dropped the stale "in the Kubernetes workspace" wording; the `[slack]` link already targets `slack.modelplane.ai`.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~~Run `nix flake check`~~ — couldn't in this sandbox (PostCSS native addon disabled, asset pipeline panics locally). Changes are static text/config only (no template or build-logic changes); CI's `nix flake check` will gate it.
- [x] ~~Added or updated tests covering any composition function changes.~~ No composition function changes.
- [x] Signed off every commit with `git commit -s`.
