### PR TITLE
Refocus the contributor guide on the most common contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,8 @@ Search open issues before raising a new one.
 
 See the Reporting issues section of CONTRIBUTING.md for what makes a good bug
 report: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md
-Lead with the problem, be specific, and back it with evidence.
+Lead with the problem, be specific, and back it with evidence. Low-effort or
+unreviewed AI-generated reports will be closed.
 -->
 
 ### What happened?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,8 @@ Search open issues before raising a new one.
 
 See the Reporting issues section of CONTRIBUTING.md for what makes a good feature
 request: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md
-Lead with the problem, not the solution.
+Lead with the problem, not the solution. Low-effort or unreviewed AI-generated
+requests will be closed.
 -->
 
 ### What problem are you facing?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,7 @@
 Thanks for contributing to Modelplane! Read CONTRIBUTING.md before opening a PR
 and follow it, especially the commit, pull request, and writing style
 conventions: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md
-
-If you're using a coding agent, this means you: read CONTRIBUTING.md every
-session, not just the first time. You don't carry it over from a previous one.
+PRs that don't follow it will be closed.
 -->
 
 ### Description of your changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
   # Pushes the package on every push to main and on any manual run. Both push a
   # dev version derived from git metadata unless the run supplies a tag input,
-  # which is how releases are cut - see CONTRIBUTING.md.
+  # which is how releases are cut - see RELEASING.md.
   push-package:
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent guide
 
-Modelplane's contributor guide is [`CONTRIBUTING.md`](CONTRIBUTING.md). Read it
-before making changes and follow it. It covers development setup, running checks,
-working on composition functions, and the conventions for commits and pull
-requests — including how to write commit messages and PR descriptions.
+Read [`CONTRIBUTING.md`](CONTRIBUTING.md) before making any change, and follow
+it. It is the contribution process: development setup, checks, commit and pull
+request conventions, and writing style. Contributions that don't follow it will
+be closed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,1 @@
 @AGENTS.md
-
-Read `CONTRIBUTING.md` before making changes and follow it, including its commit
-and pull request conventions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,21 @@
 # Contributing to Modelplane
 
+## Discuss first
+
+Modelplane is a discuss-first project. For anything beyond a small bug fix, open
+an issue before you write code. The point is to agree on the shape of a change
+before you (or your agent) spend time and tokens building it, so nobody pours
+effort into a contribution we then can't accept.
+
+PRs are welcome for small, self-evident fixes: a typo, a broken link, a one-line
+correction. For anything that changes behavior, an API, or a design, raise an
+issue first and let's align on the approach. When in doubt, open an issue, not a
+PR.
+
+Using an agent is fine, but contributions still have to clear the bar the
+Writing style section sets out. We may close low-effort issues and PRs,
+including unreviewed AI-generated ones, without much discussion.
+
 ## Writing style
 
 Using an agent to help write code, commits, PRs, or issues is fine. But the prose it
@@ -10,27 +26,30 @@ isn't carrying information a reader needs, delete it.
 
 The tells to edit out:
 
-- **Filler and throat-clearing.** "It's important to note that", "In order to",
+- Filler and throat-clearing. "It's important to note that", "In order to",
   "This change serves to". Say the thing directly.
-- **Table stakes.** "Updated the tests", "Ran the linter", "Ensured the code is
+- Table stakes. "Updated the tests", "Ran the linter", "Ensured the code is
   well-formatted". These are expected, so reporting them is noise.
-- **Bragging.** "Robust", "elegant", "comprehensive", "powerful", "seamless". A
+- Bragging. "Robust", "elegant", "comprehensive", "powerful", "seamless". A
   description should let the reader judge the change, not judge it for them.
-- **Decorative em dashes.** Agents reach for an em dash whenever a sentence could
+- Decorative em dashes. Agents reach for an em dash whenever a sentence could
   use a comma, a colon, or a full stop. An occasional one is fine; a paragraph
   built on them reads like a machine wrote it.
-- **Restating the obvious.** "This PR adds X" when the title says "Add X". Lead
+- Restating the obvious. "This PR adds X" when the title says "Add X". Lead
   with the problem instead.
+- Over-formatting. Bold, headers, and bullets sprinkled in to look organized or
+  authoritative. Prose carries reasoning; reserve structure for content that's
+  genuinely structured.
 
 Never invent rationale. The "why" behind a change comes from the author's
 intent, which a diff doesn't contain: a diff shows that a field was renamed, not
 why. A plausible-sounding reason made up to fill the gap is worse than no reason
 at all, because a reader can't tell it apart from a real one and it lands in the
-permanent record as fact. **If you don't know why a change was made, describe
-what it does and stop.**
+permanent record as fact. If you don't know why a change was made, describe what
+it does and stop.
 
-The underlying goal is plain, dense prose that respects the reader's time.
-**When in doubt, shorter.**
+The underlying goal is plain, dense prose that respects the reader's time. When
+in doubt, shorter.
 
 ## Reporting issues
 
@@ -233,9 +252,8 @@ single function live in that function's `function/` package alongside `fn.py`.
 
 The Pydantic models in `schemas/python/` are generated from the XRDs under
 `apis/` and the project's dependency CRDs. They're committed to git so tests and
-type checking don't need to run the Crossplane CLI first. Building the project
-regenerates them, so regenerate them by building after changing an XRD or
-bumping a dependency:
+type checking don't need to run the Crossplane CLI first. Regenerate them by
+building after you change an XRD or bump a dependency:
 
 ```bash
 nix run .#build
@@ -320,11 +338,10 @@ nix run .#run
 ```
 
 This needs a running Docker-compatible container runtime (for KIND and the local
-registry). It works on Linux and macOS: the function images are Linux images,
-but they're assembled entirely from data — a Python interpreter and dependency
-wheels fetched prebuilt, plus our own source — so they build on any host with no
-cross-compilation or emulation. The same is true of `nix run .#build`, which
-builds the project's packages without running them.
+registry). It works on Linux and macOS with no emulation: the function images
+are Linux images assembled entirely from data — a prebuilt Python interpreter
+and dependency wheels plus our own source — so there's no cross-compilation. The
+same is true of `nix run .#build`.
 
 ## Working on the docs site
 
@@ -362,7 +379,7 @@ the platform and model concept pages, and `examples/` backs the Examples page.
 A page references only manifests from its own section's subtree. Two shortcodes
 render them in content pages.
 
-**`manifests`** — renders the file inline with syntax highlighting, followed by
+`manifests` renders the file inline with syntax highlighting, followed by
 a `kubectl apply -f <url>` block pointing to the published file:
 
 ```markdown
@@ -383,7 +400,7 @@ call that passes `apply=` or `command=` must pass the path as `path=` too:
 {{</* manifests path="concepts/inference-gateway.yaml" apply="false" */>}}
 ```
 
-**`manifest-url`** — emits just the absolute URL of the file, for use inside
+`manifest-url` emits just the absolute URL of the file, for use inside
 an existing code fence:
 
 ```markdown
@@ -422,7 +439,7 @@ recognise. Add them to
 the single place for all Vale exceptions. Entries are case-sensitive regular
 expressions, one per line.
 
-Both run automatically on every pull request as part of `nix flake check` (see
+CI runs them on every pull request via the same check (see
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml)).
 
 ### Deployment
@@ -437,60 +454,5 @@ Vercel's GitHub app drives deploys as usual: preview URLs on pull requests
 
 ## Releasing
 
-Releases are cut from a release branch and published by the `CI` workflow. To
-release a new minor version, e.g. `v0.1.0`:
-
-1. From the GitHub UI, create a `release-0.1` branch from `main`.
-2. Create a GitHub release targeting that branch, and let the release create the
-   tag `v0.1.0`.
-3. Run the `CI` workflow (Actions → CI → Run workflow) against the `v0.1.0` tag,
-   setting the `tag` input to `v0.1.0`.
-
-The `tag` input makes the workflow push the package with that exact version
-rather than the dev version it derives from git metadata on ordinary runs.
-Patch releases (e.g. `v0.1.1`) reuse the existing `release-0.1` branch: cut the
-release from it and run the workflow against the new tag.
-
-### Versioning the docs
-
-Docs are versioned at the minor level. Each minor release is served from its own
-subdomain (`v0-1.docs.modelplane.ai`, `v0-2.docs.modelplane.ai`, …) using a single
-Vercel project with one branch domain per release. The `main` branch always serves
-the latest docs at `docs.modelplane.ai`. Patch releases push to the existing release
-branch; the versioned deployment rebuilds automatically with no changes to `main`
-required.
-
-**One-time DNS setup (already done):** a wildcard CNAME `*.docs.modelplane.ai →
-cname.vercel-dns.com` covers every future release subdomain automatically. No new
-DNS record is needed per release.
-
-**To publish docs for a new minor release (e.g. `v0.1.0`):**
-
-1. On `release-0.1`, set `version = "0.1"` in `docs/hugo.toml`. Leave
-   `latest = "main"` unchanged — the latest docs always live at the root.
-
-2. In the Vercel dashboard, open the `modelplane-docs` project and add a branch
-   domain for the release:
-   - Go to **Settings → Domains**, add `v0-1.docs.modelplane.ai`, and assign it
-     to the `release-0.1` branch.
-   - Add a Production environment variable scoped to the `release-0.1` branch:
-     `HUGO_BASEURL` = `https://v0-1.docs.modelplane.ai/`.
-   - Trigger a redeployment of `release-0.1` and confirm the subdomain serves.
-
-3. On `main`, add an entry to `docs/data/versions.yaml`, newest first:
-   ```yaml
-   versions:
-     - version: "main"
-       url: ""
-     - version: "0.1"
-       url: "https://v0-1.docs.modelplane.ai"
-   ```
-
-4. Merge the `versions.yaml` change to `main`. The version dropdown on all release
-   builds now links to the new subdomain.
-
-To fix a typo or update content in an archived version, push to the release branch.
-The versioned deployment rebuilds automatically.
-
-When a new minor ships (e.g. `v0.2.0`), repeat steps 1–4 for `release-0.2`,
-adding the `v0.2` entry above `v0.1` in `versions.yaml`.
+Cutting a release and versioning the docs is a maintainer task; see
+[RELEASING.md](RELEASING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -477,7 +477,8 @@ adding the `v0.2` entry above `v0.1` in `versions.yaml`.
 
 Open an issue with the bug report or feature request template. The Writing style
 section above applies here too: lead with the problem, be specific, and don't pad
-or invent.
+or invent. Don't hard-wrap the body; like a PR, GitHub renders it as Markdown and
+reflows to the viewport, so write each paragraph as one line and let it wrap.
 
 For a bug, the title should name the symptom, and the root cause if you know it:
 "InferenceGateway never becomes ready on a fresh control plane: Gateway API CRDs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,59 @@
 # Contributing to Modelplane
 
+## Writing style
+
+Using an agent to help write code, commits, PRs, or issues is fine. But the prose it
+produces should be indistinguishable from something you'd write yourself. An
+agent's first draft rarely is: it tends to pad, hedge, and decorate. Treat that
+draft as a starting point and cut it hard, often by half or more. If a sentence
+isn't carrying information a reader needs, delete it.
+
+The tells to edit out:
+
+- **Filler and throat-clearing.** "It's important to note that", "In order to",
+  "This change serves to". Say the thing directly.
+- **Table stakes.** "Updated the tests", "Ran the linter", "Ensured the code is
+  well-formatted". These are expected, so reporting them is noise.
+- **Bragging.** "Robust", "elegant", "comprehensive", "powerful", "seamless". A
+  description should let the reader judge the change, not judge it for them.
+- **Decorative em dashes.** Agents reach for an em dash whenever a sentence could
+  use a comma, a colon, or a full stop. An occasional one is fine; a paragraph
+  built on them reads like a machine wrote it.
+- **Restating the obvious.** "This PR adds X" when the title says "Add X". Lead
+  with the problem instead.
+
+Never invent rationale. The "why" behind a change comes from the author's
+intent, which a diff doesn't contain: a diff shows that a field was renamed, not
+why. A plausible-sounding reason made up to fill the gap is worse than no reason
+at all, because a reader can't tell it apart from a real one and it lands in the
+permanent record as fact. **If you don't know why a change was made, describe
+what it does and stop.**
+
+The underlying goal is plain, dense prose that respects the reader's time.
+**When in doubt, shorter.**
+
+## Reporting issues
+
+Open an issue with the bug report or feature request template. The Writing style
+section above applies here too: lead with the problem, be specific, and don't pad
+or invent. Don't hard-wrap the body; like a PR, GitHub renders it as Markdown and
+reflows to the viewport, so write each paragraph as one line and let it wrap.
+
+For a bug, the title should name the symptom, and the root cause if you know it:
+"InferenceGateway never becomes ready on a fresh control plane: Gateway API CRDs
+not installed". Describe what you observed before what you think causes it, and
+back it with evidence a reader can't reconstruct themselves — the actual error
+message, status condition, or log output in a fenced block, and a link to the
+offending code with line numbers if you found it. Give numbered, copy-pasteable
+reproduction steps, and a workaround if you have one. List the versions of
+everything involved: Modelplane, Crossplane, the inference backend, the cluster
+and its provider, and Kubernetes.
+
+For a feature request, describe the problem or limitation before any solution; a
+well-framed problem is worth more than a proposed fix. If you do have a shape in
+mind, show it concretely — the YAML, CLI, or API a user would write — and note
+the trade-offs and the alternatives you considered.
+
 ## Development setup
 
 Modelplane uses [Nix](https://nixos.org) for builds, checks, and the
@@ -41,6 +95,107 @@ nix flake check            # or: ./nix.sh flake check
 
 `nix run .#fix` auto-fixes most lint and formatting issues. Run it before
 opening a PR.
+
+## Submitting changes
+
+Before opening a PR, run `nix flake check` and make sure it passes. If you
+changed a composition function, make sure there's a test covering the change.
+
+### Commit messages
+
+Each commit is a self-contained, logical layer of the change. The history tells
+the story of *what the code does and why*, not how you developed it. Fold
+incremental work into the commit it belongs to; don't leave behind "address
+review feedback", "fix tests", WIP, or rebase-merge commits.
+
+Write the subject in the imperative mood, naming specifically what the change
+does, so it's legible at a glance in a log: "Order KServe CRD deletion after the
+resources that use it", not "fix deletion" or "update composition". Keep it under
+~70 characters, capitalized, with no trailing period and no typed prefix like
+`feat:`, `fix:`, or `chore:`.
+
+Write a body for every commit except the most mechanical, like a schema regen.
+Lead with the problem: what was wrong, missing, or how things behaved before.
+Then give the change and why it's right; the reasoning is what a future reader
+needs and can't recover from the diff. Note trade-offs honestly. Use prose, not
+a list recounting which files you touched; the diff already shows what changed,
+so the message is for what it doesn't show. Reserve bullets for genuinely
+parallel items. Wrap at ~72 characters, and reference issues with a terse
+trailer at the end: `Fixes #96.`, `Towards #92.`, `Depends on crossplane/cli#24.`
+
+Sign off every commit with `git commit -s`. This adds a `Signed-off-by` line
+certifying you have the right to submit the code under the project's license
+(the [Developer Certificate of Origin](https://developercertificate.org/)).
+
+A representative commit:
+
+```
+Order KServe CRD deletion after the resources that use it
+
+compose-kserve-backend installs KServe as two Helm releases: kserve-crds
+provides the CRDs, and kserve-controller installs custom resources of those
+CRDs.
+
+Nothing ordered their deletion. On teardown the CRD release could uninstall
+first, removing a CRD while the resources release still owned CRs of that kind.
+The resources release's uninstall then failed and hung indefinitely, blocking
+the rest of the teardown.
+
+This adds a Usage holding the CRD release until the resources release is gone,
+so the CRs are deleted while their CRD still exists.
+
+Signed-off-by: Nic Cope <nicc@rk0n.org>
+```
+
+### Pull requests
+
+A PR description carries the same problem-first story as a commit, scaled up to
+the whole change. Open with the issue it resolves — `Fixes #95.` on its own line,
+one per issue — then describe what was wrong or missing, the change, and why it's
+the right one. Be honest about trade-offs, breaking changes, and anything still
+unresolved.
+
+Don't single out parts of the diff as noteworthy or risky to fill a "things to
+review" section. Flag something only when you actually know it warrants a closer
+look; a list of callouts chosen just to have one reads as signal while carrying
+none.
+
+Don't hard-wrap the body. GitHub renders it as Markdown and reflows to the
+viewport, so write each paragraph as one line and let it wrap; manual breaks show
+up as ragged lines in the rendered view. (This is the opposite of commit
+messages, which are read raw and so are wrapped at ~72.)
+
+Be selective. A description isn't a summary of every commit; it's the headline
+of the change with enough context to review it. Lead with what matters, and let
+preparatory or secondary commits fall to a sentence or drop out entirely — the
+reviewer has the commits and the diff for the rest. Resist giving each commit its
+own `###` section; reach for subheadings only when one genuinely large change has
+distinct parts worth separating. When the change is small, a paragraph or two is
+the whole description.
+
+Reach for the things a diff can't show: before/after YAML for an API change, a
+plainly stated breaking-change note, or how you validated the change end to end.
+Use bullets only for genuinely parallel items.
+
+A representative description:
+
+```
+Fixes #45.
+
+The ModelDeployment scheduler considered all InferenceEnvironments as scheduling candidates regardless of their readiness. An environment still provisioning its cluster would be selected if its computed capacity matched, creating a ModelPlacement that targets an environment that can't serve traffic yet. The user then sees errors until the environment becomes Ready.
+
+This makes the scheduler skip environments without a `Ready=True` condition. When a new environment finishes provisioning, the next reconcile picks it up.
+
+The pool-fitting logic moves into a `_best_pool_fit` helper to keep `schedule()` under the branch-count lint threshold. A new `test-model-deployment-not-ready-env` case covers the skip behavior.
+```
+
+### Work from a fork
+
+Open every PR from a branch on your own [fork][fork], never a branch of the main
+repo. This holds for maintainers too, and for any agent working on your behalf:
+point it at your fork.
+
+[fork]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo
 
 ## Working on composition functions
 
@@ -280,139 +435,6 @@ Vercel's build image, runs the build, and writes the static site to `public/`.
 Vercel's GitHub app drives deploys as usual: preview URLs on pull requests
 (including from forks) and production on merge to `main`.
 
-## Submitting changes
-
-Before opening a PR, run `nix flake check` and make sure it passes. If you
-changed a composition function, make sure there's a test covering the change.
-
-### Work from a fork
-
-Open every PR from a branch on your own [fork][fork], never a branch of the main
-repo. This holds for maintainers too, and for any agent working on your behalf:
-point it at your fork.
-
-[fork]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo
-
-### Writing style
-
-Using an agent to help write code, commits, PRs, or issues is fine. But the prose it
-produces should be indistinguishable from something you'd write yourself. An
-agent's first draft rarely is: it tends to pad, hedge, and decorate. Treat that
-draft as a starting point and cut it hard, often by half or more. If a sentence
-isn't carrying information a reader needs, delete it.
-
-The tells to edit out:
-
-- **Filler and throat-clearing.** "It's important to note that", "In order to",
-  "This change serves to". Say the thing directly.
-- **Table stakes.** "Updated the tests", "Ran the linter", "Ensured the code is
-  well-formatted". These are expected, so reporting them is noise.
-- **Bragging.** "Robust", "elegant", "comprehensive", "powerful", "seamless". A
-  description should let the reader judge the change, not judge it for them.
-- **Decorative em dashes.** Agents reach for an em dash whenever a sentence could
-  use a comma, a colon, or a full stop. An occasional one is fine; a paragraph
-  built on them reads like a machine wrote it.
-- **Restating the obvious.** "This PR adds X" when the title says "Add X". Lead
-  with the problem instead.
-
-Never invent rationale. The "why" behind a change comes from the author's
-intent, which a diff doesn't contain: a diff shows that a field was renamed, not
-why. A plausible-sounding reason made up to fill the gap is worse than no reason
-at all, because a reader can't tell it apart from a real one and it lands in the
-permanent record as fact. **If you don't know why a change was made, describe
-what it does and stop.**
-
-The underlying goal is plain, dense prose that respects the reader's time.
-**When in doubt, shorter.**
-
-### Commit messages
-
-Each commit is a self-contained, logical layer of the change. The history tells
-the story of *what the code does and why*, not how you developed it. Fold
-incremental work into the commit it belongs to; don't leave behind "address
-review feedback", "fix tests", WIP, or rebase-merge commits.
-
-Write the subject in the imperative mood, naming specifically what the change
-does, so it's legible at a glance in a log: "Order KServe CRD deletion after the
-resources that use it", not "fix deletion" or "update composition". Keep it under
-~70 characters, capitalized, with no trailing period and no typed prefix like
-`feat:`, `fix:`, or `chore:`.
-
-Write a body for every commit except the most mechanical, like a schema regen.
-Lead with the problem: what was wrong, missing, or how things behaved before.
-Then give the change and why it's right; the reasoning is what a future reader
-needs and can't recover from the diff. Note trade-offs honestly. Use prose, not
-a list recounting which files you touched; the diff already shows what changed,
-so the message is for what it doesn't show. Reserve bullets for genuinely
-parallel items. Wrap at ~72 characters, and reference issues with a terse
-trailer at the end: `Fixes #96.`, `Towards #92.`, `Depends on crossplane/cli#24.`
-
-Sign off every commit with `git commit -s`. This adds a `Signed-off-by` line
-certifying you have the right to submit the code under the project's license
-(the [Developer Certificate of Origin](https://developercertificate.org/)).
-
-A representative commit:
-
-```
-Order KServe CRD deletion after the resources that use it
-
-compose-kserve-backend installs KServe as two Helm releases: kserve-crds
-provides the CRDs, and kserve-controller installs custom resources of those
-CRDs.
-
-Nothing ordered their deletion. On teardown the CRD release could uninstall
-first, removing a CRD while the resources release still owned CRs of that kind.
-The resources release's uninstall then failed and hung indefinitely, blocking
-the rest of the teardown.
-
-This adds a Usage holding the CRD release until the resources release is gone,
-so the CRs are deleted while their CRD still exists.
-
-Signed-off-by: Nic Cope <nicc@rk0n.org>
-```
-
-### Pull requests
-
-A PR description carries the same problem-first story as a commit, scaled up to
-the whole change. Open with the issue it resolves — `Fixes #95.` on its own line,
-one per issue — then describe what was wrong or missing, the change, and why it's
-the right one. Be honest about trade-offs, breaking changes, and anything still
-unresolved.
-
-Don't single out parts of the diff as noteworthy or risky to fill a "things to
-review" section. Flag something only when you actually know it warrants a closer
-look; a list of callouts chosen just to have one reads as signal while carrying
-none.
-
-Don't hard-wrap the body. GitHub renders it as Markdown and reflows to the
-viewport, so write each paragraph as one line and let it wrap; manual breaks show
-up as ragged lines in the rendered view. (This is the opposite of commit
-messages, which are read raw and so are wrapped at ~72.)
-
-Be selective. A description isn't a summary of every commit; it's the headline
-of the change with enough context to review it. Lead with what matters, and let
-preparatory or secondary commits fall to a sentence or drop out entirely — the
-reviewer has the commits and the diff for the rest. Resist giving each commit its
-own `###` section; reach for subheadings only when one genuinely large change has
-distinct parts worth separating. When the change is small, a paragraph or two is
-the whole description.
-
-Reach for the things a diff can't show: before/after YAML for an API change, a
-plainly stated breaking-change note, or how you validated the change end to end.
-Use bullets only for genuinely parallel items.
-
-A representative description:
-
-```
-Fixes #45.
-
-The ModelDeployment scheduler considered all InferenceEnvironments as scheduling candidates regardless of their readiness. An environment still provisioning its cluster would be selected if its computed capacity matched, creating a ModelPlacement that targets an environment that can't serve traffic yet. The user then sees errors until the environment becomes Ready.
-
-This makes the scheduler skip environments without a `Ready=True` condition. When a new environment finishes provisioning, the next reconcile picks it up.
-
-The pool-fitting logic moves into a `_best_pool_fit` helper to keep `schedule()` under the branch-count lint threshold. A new `test-model-deployment-not-ready-env` case covers the skip behavior.
-```
-
 ## Releasing
 
 Releases are cut from a release branch and published by the `CI` workflow. To
@@ -472,25 +494,3 @@ The versioned deployment rebuilds automatically.
 
 When a new minor ships (e.g. `v0.2.0`), repeat steps 1–4 for `release-0.2`,
 adding the `v0.2` entry above `v0.1` in `versions.yaml`.
-
-## Reporting issues
-
-Open an issue with the bug report or feature request template. The Writing style
-section above applies here too: lead with the problem, be specific, and don't pad
-or invent. Don't hard-wrap the body; like a PR, GitHub renders it as Markdown and
-reflows to the viewport, so write each paragraph as one line and let it wrap.
-
-For a bug, the title should name the symptom, and the root cause if you know it:
-"InferenceGateway never becomes ready on a fresh control plane: Gateway API CRDs
-not installed". Describe what you observed before what you think causes it, and
-back it with evidence a reader can't reconstruct themselves — the actual error
-message, status condition, or log output in a fenced block, and a link to the
-offending code with line numbers if you found it. Give numbered, copy-pasteable
-reproduction steps, and a workaround if you have one. List the versions of
-everything involved: Modelplane, Crossplane, the inference backend, the cluster
-and its provider, and Kubernetes.
-
-For a feature request, describe the problem or limitation before any solution; a
-well-framed problem is worth more than a proposed fix. If you do have a shape in
-mind, show it concretely — the YAML, CLI, or API a user would write — and note
-the trade-offs and the alternatives you considered.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,64 @@
+# Releasing Modelplane
+
+This is the maintainer process for cutting a Modelplane release and versioning
+the docs. Contributing changes is covered in [CONTRIBUTING.md](CONTRIBUTING.md);
+this file is only for the small set of people who publish releases.
+
+## Releasing
+
+Releases are cut from a release branch and published by the `CI` workflow. To
+release a new minor version, e.g. `v0.1.0`:
+
+1. From the GitHub UI, create a `release-0.1` branch from `main`.
+2. Create a GitHub release targeting that branch, and let the release create the
+   tag `v0.1.0`.
+3. Run the `CI` workflow (Actions → CI → Run workflow) against the `v0.1.0` tag,
+   setting the `tag` input to `v0.1.0`.
+
+The `tag` input makes the workflow push the package with that exact version
+rather than the dev version it derives from git metadata on ordinary runs.
+Patch releases (e.g. `v0.1.1`) reuse the existing `release-0.1` branch: cut the
+release from it and run the workflow against the new tag.
+
+## Versioning the docs
+
+Docs are versioned at the minor level. Each minor release is served from its own
+subdomain (`v0-1.docs.modelplane.ai`, `v0-2.docs.modelplane.ai`, …) using a single
+Vercel project with one branch domain per release. The `main` branch always serves
+the latest docs at `docs.modelplane.ai`. Patch releases push to the existing release
+branch and need no changes to `main`.
+
+One-time DNS setup (already done): a wildcard CNAME `*.docs.modelplane.ai →
+cname.vercel-dns.com` covers every future release subdomain automatically. No new
+DNS record is needed per release.
+
+To publish docs for a new minor release (e.g. `v0.1.0`):
+
+1. On `release-0.1`, set `version = "0.1"` in `docs/hugo.toml`. Leave
+   `latest = "main"` unchanged — the latest docs always live at the root.
+
+2. In the Vercel dashboard, open the `modelplane-docs` project and add a branch
+   domain for the release:
+   - Go to Settings → Domains, add `v0-1.docs.modelplane.ai`, and assign it
+     to the `release-0.1` branch.
+   - Add a Production environment variable scoped to the `release-0.1` branch:
+     `HUGO_BASEURL` = `https://v0-1.docs.modelplane.ai/`.
+   - Trigger a redeployment of `release-0.1` and confirm the subdomain serves.
+
+3. On `main`, add an entry to `docs/data/versions.yaml`, newest first:
+   ```yaml
+   versions:
+     - version: "main"
+       url: ""
+     - version: "0.1"
+       url: "https://v0-1.docs.modelplane.ai"
+   ```
+
+4. Merge the `versions.yaml` change to `main`. The version dropdown on all release
+   builds now links to the new subdomain.
+
+To fix a typo or update content in an archived version, push to the release branch.
+The versioned deployment rebuilds automatically.
+
+When a new minor ships (e.g. `v0.2.0`), repeat steps 1–4 for `release-0.2`,
+adding the `v0.2` entry above `v0.1` in `versions.yaml`.

--- a/docs/data/versions.yaml
+++ b/docs/data/versions.yaml
@@ -1,5 +1,5 @@
 # Released doc versions, newest first. main is not listed here — the root
-# redirects to the latest release. See CONTRIBUTING.md § Versioning the docs.
+# redirects to the latest release. See RELEASING.md § Versioning the docs.
 #
 # version: X.Y minor version string (e.g. "0.1")
 # url:     absolute base URL for that version's content


### PR DESCRIPTION
### Description of your changes

This reworks CONTRIBUTING.md and the agent- and contributor-facing pointers around it. The guide had grown to mix maintainer-only material with the things any contributor does, ordered roughly by how the project was built rather than by how often a contributor needs each part. For a project that's just gone public and hopes to attract newcomers, many of them using coding agents, that buries the most common contributions (reporting an issue, writing a commit, opening a PR) and surfaces the rarest (cutting a release).

The main changes:

- Reorder the guide by how often contributors need each section. Writing style leads, since it governs issues, commits, and PRs alike; reporting an issue, the most common contribution, follows it. Development setup and checks come next, then submitting changes, then the deeper function and docs work.

- Add a "Discuss first" section. For anything beyond a small fix, open an issue before writing code, so nobody spends time or tokens on a change the project can't accept. It states plainly that low-effort or unreviewed AI-generated contributions may be closed.

- Extract the release process into RELEASING.md. It's a maintainer-only task most contributors and agents never perform, and every agent that loaded the guide to make a change carried it in context. A pointer remains in CONTRIBUTING.md, and the inbound references in `ci.yml` and `versions.yaml` now point at RELEASING.md.

- Drop the bold formatting throughout and add over-formatting to the list of writing tells. The Writing style section had been the most heavily formatted part of the file, committing the tell it warns against.

- Reduce the agent guides and issue/PR templates to firm pointers at CONTRIBUTING.md as the single source, stating that non-compliant contributions will be closed. CLAUDE.md becomes an AGENTS.md include so the two can't drift.

Beyond the reorder, de-duplication, and de-bolding, the prose is left as it was where it was already tight.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
