### PR TITLE
Fix the docs favicon head: dead refs and stale Crossplane branding

### DIFF
--- a/docs/themes/geekboot/layouts/partials/favicons.html
+++ b/docs/themes/geekboot/layouts/partials/favicons.html
@@ -3,8 +3,7 @@
 <link rel="icon" type="image/png" sizes="192x192" href="{{ "android-chrome-192x192.png" | relURL }}">
 <link rel="icon" type="image/png" sizes="16x16" href="{{ "favicon-16x16.png" | relURL }}">
 <link rel="manifest" href="{{ "site.webmanifest" | relURL }}">
-<link rel="mask-icon" href="{{ "safari-pinned-tab.svg" | relURL }}" color="#f87c44">
-<meta name="apple-mobile-web-app-title" content="Crossplane Docs">
-<meta name="application-name" content="Crossplane Docs">
-<meta name="msapplication-TileColor" content="#333f5b">
+<meta name="apple-mobile-web-app-title" content="Modelplane Docs">
+<meta name="application-name" content="Modelplane Docs">
+<meta name="msapplication-TileColor" content="#001D2F">
 <meta name="theme-color" content="#ffffff">

--- a/docs/themes/geekboot/static/site.webmanifest
+++ b/docs/themes/geekboot/static/site.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "Modelplane Docs",
+  "short_name": "Modelplane",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#001D2F",
+  "background_color": "#001D2F",
+  "display": "standalone"
+}


### PR DESCRIPTION
### Description of your changes

The docs `<head>` (theme `favicons.html`) had two problems, both surfaced while checking why Google wasn't showing favicons:

- **Two declared assets 404'd:** `<link rel="manifest" href="/site.webmanifest">` and `<link rel="mask-icon" href="/safari-pinned-tab.svg" …>` — neither file exists in the theme's `static/`.
- **Stale Crossplane branding:** `apple-mobile-web-app-title` and `application-name` read "Crossplane Docs", `msapplication-TileColor` was `#333f5b`, and the mask-icon color was Crossplane's coral.

Fix:
- Add a Modelplane `site.webmanifest` (name "Modelplane Docs", referencing the existing `android-chrome-192/512` icons, spruce theme/background color), so the manifest link resolves.
- Drop the dead `safari-pinned-tab.svg` mask-icon link (no such asset; Safari pinned-tab icons are niche and modern Safari falls back to the regular favicon).
- Rebrand `apple-mobile-web-app-title` / `application-name` to "Modelplane Docs" and the tile color to `#001D2F`.

Note: the Google-facing favicon was already fine — `/favicon.ico` (48×48 square, transparent, Modelplane mark) plus the sized PNGs are valid and unchanged; this only fixes the broken/stale head entries around them.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~~Run `nix flake check`~~ — couldn't in this sandbox (PostCSS native addon disabled, asset pipeline panics locally). Verified by building the docs with Hugo: head no longer references the 404 assets, `site.webmanifest` emits as valid JSON, no "Crossplane" left in the head. CI's `nix flake check` will gate it.
- [x] ~~Added or updated tests covering any composition function changes.~~ No composition function changes.
- [x] Signed off every commit with `git commit -s`.
