### PR TITLE
build: Pin the Crossplane CLI to v2.4.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,15 +7,16 @@
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1781939520,
-        "narHash": "sha256-VLe6oJkS/OSQj9wte2jS+ZBeZRn+XZso7GnId0o0dCU=",
+        "lastModified": 1782321263,
+        "narHash": "sha256-pD91bH+K0nWDXv51mWtNlQVtBLi/zDEjAxAJ6ywd69g=",
         "owner": "crossplane",
         "repo": "cli",
-        "rev": "25f568197dce50c0520efd94ec07f2e1e65556b8",
+        "rev": "ef9b974770a45e085aacee3b2cdda6284ab6cf51",
         "type": "github"
       },
       "original": {
         "owner": "crossplane",
+        "ref": "v2.4.0",
         "repo": "cli",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,22 +12,7 @@
     # tracking the latest uv_build releases.
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    # Pinned to crossplane/cli main rather than a released version, because we
-    # depend on several CLI changes that aren't in a release yet:
-    #
-    #   * #24, #64: a datamodel-code-generator bump that fixes Python model
-    #     generation for fields named int/bool.
-    #   * #119: stops an XRD's scale subresource from clobbering the generated
-    #     model with the autoscaling Scale type.
-    #   * #126: makes the flake's default package the host-native CLI binary
-    #     instead of the full multi-platform release bundle. Building one platform
-    #     instead of seven cuts the CLI build from ~55 minutes to ~8 on a cold
-    #     machine.
-    #   * #127: decompresses function runtime tarballs once when loading them,
-    #     rather than once per layer.
-    #
-    # Repin to a tag once these all release.
-    crossplane-cli.url = "github:crossplane/cli";
+    crossplane-cli.url = "github:crossplane/cli/v2.4.0";
 
     # uv2nix reads a uv workspace's uv.lock and generates Nix derivations
     # for each Python package, using pyproject.nix's build infrastructure.


### PR DESCRIPTION
### Description of your changes

The v2.4.0 release contains a few features that were added in support of modelplane development, so we no longer need to use the main branch.

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
~- [ ] Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
