### PR TITLE
Name each serving-stack Helm release after its chart

### DIFF
--- a/functions/compose-serving-stack/function/fn.py
+++ b/functions/compose-serving-stack/function/fn.py
@@ -47,6 +47,15 @@ from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
 # Label key for composed resources that need deletion ordering via Usages.
 _LABEL_RESOURCE = "modelplane.ai/resource"
 
+# Annotation provider-helm reads as the Helm release name (see _helm_release).
+_EXTERNAL_NAME_ANNOTATION = "crossplane.io/external-name"
+
+# Reserved prefix for the Helm release names this function manages. Names every
+# release "mp-<chart>" so it's clearly modelplane-owned and can't adopt or
+# collide with a same-named release a user already runs in the same namespace
+# (e.g. a cluster's own "cert-manager"). See _helm_release.
+_RELEASE_NAME_PREFIX = "mp-"
+
 # CEL readiness query for the Envoy Gateway Object. The Gateway's LoadBalancer
 # address is assigned asynchronously by the controller after the Object is
 # applied. With the default SuccessfulCreate policy the Object is Ready the
@@ -131,20 +140,28 @@ def _helm_release(
     labels: dict | None = None,
     metadata_namespace: str | None = None,
 ) -> helmv1beta1.Release:
-    """Build a Helm Release targeting a remote (or local) cluster."""
-    md = None
-    if labels or metadata_namespace:
+    """Build a Helm Release targeting a remote (or local) cluster.
+
+    The crossplane.io/external-name annotation sets a fixed "mp-<chart>" release
+    name, which provider-helm uses verbatim. Left unset, the release inherits the
+    composed resource's generated "<inferencecluster>-<hash>" name; charts derive
+    resource names from it and append suffixes, so names can exceed the 63-char
+    label-value limit and break consumers like Cilium's per-pod CiliumIdentity.
+    "mp-<chart>" keeps every derived name short regardless of InferenceCluster
+    name (worst case is the DRA driver's ServiceAccount at 54 chars), is stable
+    across chart-version upgrades so provider-helm upgrades in place, and its
+    "mp-" prefix reserves a namespace for the releases this function owns. Each
+    chart runs once per workload cluster, so the name is unique. See issue #215."""
+    md = metav1.ObjectMeta(
+        annotations={_EXTERNAL_NAME_ANNOTATION: f"{_RELEASE_NAME_PREFIX}{chart}"},
         # Only set fields that are present; under exclude_unset, an explicit
         # namespace=None or labels=None would leak a null into the metadata.
-        md = metav1.ObjectMeta(
-            **({"namespace": metadata_namespace} if metadata_namespace is not None else {}),
-            **({"labels": labels} if labels is not None else {}),
-        )
+        **({"namespace": metadata_namespace} if metadata_namespace is not None else {}),
+        **({"labels": labels} if labels is not None else {}),
+    )
 
     release = helmv1beta1.Release(
-        # Only set metadata when present (see _k8s_object: avoids a null
-        # metadata leaking under exclude_unset serialization).
-        **({"metadata": md} if md is not None else {}),
+        metadata=md,
         spec=helmv1beta1.Spec(
             providerConfigRef=helmv1beta1.ProviderConfigRef(
                 kind="ProviderConfig",

--- a/functions/compose-serving-stack/tests/test_fn.py
+++ b/functions/compose-serving-stack/tests/test_fn.py
@@ -135,6 +135,7 @@ _USAGE_GATEWAY_CLASS_BY_GATEWAY = {
 _CERT_MANAGER = {
     "apiVersion": "helm.m.crossplane.io/v1beta1",
     "kind": "Release",
+    "metadata": {"annotations": {"crossplane.io/external-name": "mp-cert-manager"}},
     "spec": {
         "forProvider": {
             "chart": {
@@ -161,6 +162,7 @@ _ENVOY_GATEWAY = {
     "apiVersion": "helm.m.crossplane.io/v1beta1",
     "kind": "Release",
     "metadata": {
+        "annotations": {"crossplane.io/external-name": "mp-gateway-helm"},
         "labels": {"modelplane.ai/resource": "envoy-gateway"},
     },
     "spec": {
@@ -215,6 +217,7 @@ _ENVOY_GATEWAY = {
 _AI_GATEWAY_CRDS = {
     "apiVersion": "helm.m.crossplane.io/v1beta1",
     "kind": "Release",
+    "metadata": {"annotations": {"crossplane.io/external-name": "mp-ai-gateway-crds-helm"}},
     "spec": {
         "forProvider": {
             "chart": {
@@ -234,6 +237,7 @@ _AI_GATEWAY_CRDS = {
 _AI_GATEWAY = {
     "apiVersion": "helm.m.crossplane.io/v1beta1",
     "kind": "Release",
+    "metadata": {"annotations": {"crossplane.io/external-name": "mp-ai-gateway-helm"}},
     "spec": {
         "forProvider": {
             "chart": {
@@ -369,6 +373,7 @@ _GATEWAY_CLASS = {
 _LEADER_WORKER_SET = {
     "apiVersion": "helm.m.crossplane.io/v1beta1",
     "kind": "Release",
+    "metadata": {"annotations": {"crossplane.io/external-name": "mp-lws"}},
     "spec": {
         "forProvider": {
             "chart": {
@@ -388,6 +393,7 @@ _LEADER_WORKER_SET = {
 _NODE_FEATURE_DISCOVERY = {
     "apiVersion": "helm.m.crossplane.io/v1beta1",
     "kind": "Release",
+    "metadata": {"annotations": {"crossplane.io/external-name": "mp-node-feature-discovery"}},
     "spec": {
         "forProvider": {
             "chart": {
@@ -407,6 +413,7 @@ _NODE_FEATURE_DISCOVERY = {
 _DRA_DRIVER = {
     "apiVersion": "helm.m.crossplane.io/v1beta1",
     "kind": "Release",
+    "metadata": {"annotations": {"crossplane.io/external-name": "mp-dra-driver-nvidia-gpu"}},
     "spec": {
         "forProvider": {
             "chart": {
@@ -467,6 +474,7 @@ _DRA_DRIVER_QUOTA = {
 _PROMETHEUS = {
     "apiVersion": "helm.m.crossplane.io/v1beta1",
     "kind": "Release",
+    "metadata": {"annotations": {"crossplane.io/external-name": "mp-kube-prometheus-stack"}},
     "spec": {
         "forProvider": {
             "chart": {
@@ -525,7 +533,10 @@ _PROMETHEUS = {
 }
 
 
-def _base_request(nvidia_driver_root: str = "/home/kubernetes/bin/nvidia") -> fnv1.RunFunctionRequest:
+def _base_request(
+    nvidia_driver_root: str = "/home/kubernetes/bin/nvidia",
+    name: str = "test-backend",
+) -> fnv1.RunFunctionRequest:
     """Build the base RunFunctionRequest used by all test cases.
 
     Defaults to the GKE driver root, which drives the DRA driver's
@@ -537,7 +548,7 @@ def _base_request(nvidia_driver_root: str = "/home/kubernetes/bin/nvidia") -> fn
                 resource=resource.dict_to_struct(
                     v1alpha1.ServingStack(
                         metadata=metav1.ObjectMeta(
-                            name="test-backend",
+                            name=name,
                             namespace="test-ns",
                         ),
                         spec=v1alpha1.Spec(


### PR DESCRIPTION
### Description of your changes

Fixes #215.

provider-helm names each Helm release after the composed resource, whose generated name is `<inferencecluster>-<hash>`. That name is long, unpredictable, and length-capped, and it flows into every chart's fullname and from there into the names of the resources the chart creates. A chart truncates its own fullname to 63 chars and then appends suffixes — the NVIDIA DRA driver's kubelet-plugin ServiceAccount is `<fullname>-service-account-kubeletplugin` — so the final name can exceed 63 even when the fullname did not. Kubernetes label values are capped at 63 chars, so any consumer that copies such a name into a label value rejects it. On Cilium clusters the per-pod CiliumIdentity keys on the ServiceAccount name, so the DRA driver's kubelet-plugin pod never gets a network sandbox, never schedules, and no GPU is ever bound.

This isn't specific to the DRA driver. Rendering every chart at a realistic release name shows the DRA driver overflows at essentially any InferenceCluster name, while `node-feature-discovery` and `lws` overflow once the name is a little longer, and the kube-prometheus-stack node-exporter subchart overflows the same way (it ignores the chart's `fullnameOverride` and uses the release name directly). The shared cause is the release name, so the fix belongs there rather than per chart.

`_helm_release` now sets `crossplane.io/external-name` to `mp-<chart>`, which provider-helm uses verbatim as the release name. Each release is named for its chart (`mp-dra-driver-nvidia-gpu`) instead of the InferenceCluster, so every derived name is short and independent of the InferenceCluster name: the budget below holds for any deployment, not only the ones tested. The `mp-` prefix reserves a release-name namespace for the releases this function owns; without it a release named `cert-manager` would adopt or collide with a `cert-manager` release a user already runs in that namespace, and `mp-cert-manager` cannot.

| Limit | Tightest case | Length |
|---|---|---|
| Helm release name ≤ 53 | `mp-node-feature-discovery` | 25 |
| ServiceAccount name ≤ 63 | `mp-dra-driver-nvidia-gpu-service-account-kubeletplugin` | 54 |

The DRA driver is the binding constraint at 54/63: it appends the longest suffix (`-service-account-kubeletplugin`, 30 chars) to a release name that already contains the chart name. Every other chart is smaller. The release name is stable across chart-version upgrades, so provider-helm upgrades in place rather than treating each version as a new release, and the composed resource keeps its generated, hashed `metadata.name`, so managed-resource uniqueness in the control plane is unchanged.

This does change release identity. On an existing install provider-helm installs fresh releases under the new `mp-<chart>` names and orphans the old `<inferencecluster>-<hash>` releases, so migrating a running stack means a teardown and reinstall. That's acceptable pre-1.0, and the Cilium clusters this fixes are non-functional today regardless.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
