### PR TITLE
docs: Pin kind cluster image version for compatibility

### DIFF
--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -24,7 +24,10 @@ Crossplane provides the reconciliation engine and package management. Create the
 kind cluster and install it with Helm:
 
 ```bash
-kind create cluster --name modelplane
+# Pin to kind v0.30.0 default image (containerd 2.1.4)
+# kind v0.31+ ships containerd 2.2.0 which breaks Modelplane
+kind create cluster --name modelplane \
+  --image kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
 ```
 
 ```bash


### PR DESCRIPTION
Updated kind cluster creation command to specify a pinned image version to avoid compatibility issues.

<!--
Thanks for contributing to Modelplane! Read CONTRIBUTING.md before opening a PR
and follow it, especially the commit, pull request, and writing style
conventions: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md
PRs that don't follow it will be closed.
-->

### Description of your changes

The containerd version in Kind has a regression that fails Modelplane. 
Adds a pinned version of the node image to remove a regression error with containerd.
<!--
Lead with the problem, then the change and why it's right. Direct reviewers to
the parts that need judgment. Don't pad or invent rationale. See the Pull
requests and Writing style sections of CONTRIBUTING.md for what a good
description looks like.

If this PR fixes an open issue, reference it below, e.g. "Fixes #95".
-->

Fixes #

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- []  ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
