### PR TITLE
Fix external-provider ModelEndpoint example's double /v1 prefix

### DIFF
--- a/docs/content/models/model-endpoint.md
+++ b/docs/content/models/model-endpoint.md
@@ -31,9 +31,10 @@ spec:
   # 2. The provider's base URL.
   url: https://api.together.xyz/
   # 3. The path to rewrite requests to. A ModelService receives requests at
-  #    /<namespace>/<service>/v1/... and rewrites them to this prefix, so an
-  #    OpenAI-compatible provider that serves /v1/... takes /v1/.
-  rewritePath: /v1/
+  #    /<namespace>/<service>/v1/... and strips only the /<namespace>/<service>/
+  #    prefix, so an OpenAI-compatible provider that already serves /v1/...
+  #    takes just /.
+  rewritePath: /
 ```
 
 Then point a [`ModelService`]({{< ref "model-service.md" >}}) at it. Selecting

--- a/docs/manifests/concepts/model-endpoint.yaml
+++ b/docs/manifests/concepts/model-endpoint.yaml
@@ -14,4 +14,4 @@ metadata:
     modelplane.ai/external-provider: together
 spec:
   url: https://api.together.xyz/
-  rewritePath: /v1/
+  rewritePath: /


### PR DESCRIPTION
### Description of your changes

Fixes #327

The "Route to External Providers" doc set `rewritePath: /v1/` for a Together-backed `ModelEndpoint`. A `ModelService`'s composed `HTTPRoute` only strips the `/<namespace>/<service>/` prefix from the client's request path, leaving the client's own `v1/...` segment as the preserved remainder. Prepending `/v1/` on top of that produces `/v1/v1/...`, which 404s against the backend, exactly as reported in #327.

`rewritePath` should replace only the namespace/service prefix, the same way the reference example for composed replicas already does (`rewritePath: /ml-team/qwen-72b/`, no added segment). This fixes the two copies of the Together example (`docs/content/models/model-endpoint.md` and the embedded `docs/manifests/concepts/model-endpoint.yaml`) to use `rewritePath: /`, so the client's `v1/...` passes through unchanged to Together's own `/v1/...` endpoint.

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
