### PR TITLE
Label GKE GPU node pools so the autoscaler can cold-start from zero

### DIFF
--- a/docs/manifests/getting-started/gke/platform-scale.yaml
+++ b/docs/manifests/getting-started/gke/platform-scale.yaml
@@ -42,7 +42,7 @@ spec:
   - name: gpu-a100
     className: gke-a100-40-1x
     nodeCount: 1
-    minNodeCount: 1   # keep >=1; the autoscaler can't scale a GPU pool up from 0 for DRA pods
+    minNodeCount: 0
     maxNodeCount: 2
     zones:
     - us-west1-b
@@ -63,7 +63,7 @@ spec:
   - name: gpu-a100
     className: gke-a100-40-1x
     nodeCount: 1
-    minNodeCount: 1   # keep >=1; the autoscaler can't scale a GPU pool up from 0 for DRA pods
+    minNodeCount: 0
     maxNodeCount: 2
     zones:
     - us-east1-b

--- a/docs/manifests/getting-started/gke/platform.yaml
+++ b/docs/manifests/getting-started/gke/platform.yaml
@@ -39,7 +39,7 @@ spec:
   - name: gpu-l4
     className: gke-l4-1x-g2
     nodeCount: 1
-    minNodeCount: 1   # keep >=1; the autoscaler can't scale a GPU pool up from 0 for DRA pods
+    minNodeCount: 0
     maxNodeCount: 2
     zones:
     - us-central1-a

--- a/functions/compose-gke-cluster/function/fn.py
+++ b/functions/compose-gke-cluster/function/fn.py
@@ -63,6 +63,15 @@ _SYSTEM_POOL_MAX_NODE_COUNT = 2
 _LABEL_GPU = "modelplane.ai/gpu"
 _LABEL_POOL = "modelplane.ai/pool"
 
+# GKE's cluster autoscaler uses this label to recognise a node pool as one whose
+# nodes run the NVIDIA GPU DRA driver, and so models the DRA ResourceSlices such
+# a node would publish. Without it the autoscaler can't tell that a new node
+# would satisfy a pod's GPU ResourceClaim, so a pool sitting at zero nodes never
+# scales up: the claim binds only against a ResourceSlice, and no slice exists
+# until a node is already running. Setting it lets a GPU pool cold-start from
+# minNodeCount 0.
+_LABEL_GPU_DRA_DRIVER = "cloud.google.com/gke-nvidia-gpu-dra-driver"
+
 # Secret types written to XR status. compose-inference-cluster reads
 # these to wire the kubeconfig and SA key into ProviderConfigs. The SA key's
 # type is the provider identity it authenticates as (see _IDENTITY_TYPE_GCP).
@@ -293,6 +302,7 @@ class Composer:
                 node_config.labels = {
                     _LABEL_GPU: pool.gpu.acceleratorType,
                     _LABEL_POOL: pool.name,
+                    _LABEL_GPU_DRA_DRIVER: "true",
                 }
             else:
                 node_config.labels = {

--- a/functions/compose-gke-cluster/tests/test_fn.py
+++ b/functions/compose-gke-cluster/tests/test_fn.py
@@ -245,6 +245,7 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                                                     "labels": {
                                                         "modelplane.ai/gpu": "nvidia-tesla-a100",
                                                         "modelplane.ai/pool": "gpu-pool",
+                                                        "cloud.google.com/gke-nvidia-gpu-dra-driver": "true",
                                                     },
                                                 },
                                             },
@@ -636,6 +637,7 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                                                     "labels": {
                                                         "modelplane.ai/gpu": "nvidia-tesla-a100",
                                                         "modelplane.ai/pool": "gpu-pool",
+                                                        "cloud.google.com/gke-nvidia-gpu-dra-driver": "true",
                                                     },
                                                 },
                                             },


### PR DESCRIPTION
Fixes #306.

A GPU node pool with `minNodeCount: 0` never scaled up. A model's pod claims its GPU through a DRA `ResourceClaim`, which binds only against a `ResourceSlice` the NVIDIA DRA driver publishes per running GPU node. At zero nodes there are no slices, and GKE's cluster autoscaler couldn't tell that a new node would satisfy the claim, so it refused to create the first one. The pod stayed pending with `cannot allocate all claims`.

This isn't a DRA architectural limitation. GKE's autoscaler recognises a DRA-capable node pool by the `cloud.google.com/gke-nvidia-gpu-dra-driver=true` node label and uses it to model the `ResourceSlices` such a node would publish when simulating a scale-up ([GKE docs](https://cloud.google.com/kubernetes-engine/docs/how-to/set-up-dra#node-pool)). `compose-gke-cluster` set only `modelplane.ai/gpu` and `modelplane.ai/pool`, so the pools were never recognised. This sets the label on every GPU node pool.

The getting-started GKE manifests pinned `minNodeCount: 1` to work around the stall; they now allow `minNodeCount: 0`.

I kept the scope to the autoscaler label. GKE's DRA docs list three more node-pool requirements (`gpu-driver-version=disabled`, `gke-no-default-nvidia-gpu-device-plugin=true`, `nvidia.com/gpu.present=true`) for the manual-driver DRA path, but this repo runs the DEFAULT-driver path (GKE installs the driver at `/home/kubernetes/bin/nvidia`, layering the DRA driver on top) and #306 confirms DRA scheduling works once a node is up. The only gap for cold-start was the label.

Draft: not yet validated on a real GKE cluster. GKE's ["About DRA in GKE"](https://cloud.google.com/kubernetes-engine/docs/concepts/about-dynamic-resource-allocation#limitations) docs also note that for third-party (self-installed) DRA drivers, "the cluster autoscaler requires your node pools to have at least one node," which may or may not apply to the Helm-installed NVIDIA driver this project uses. This needs an end-to-end test against a GKE L4/A100 pool at `minNodeCount: 0` before it merges.

EKS is unaffected by this PR and remains a separate problem: the upstream cluster-autoscaler's AWS provider doesn't model DRA `ResourceSlices` in its scale-from-zero node template at all (no equivalent of GKE's label, or of the `capacity.cluster-autoscaler.kubernetes.io/dra-driver` annotation the cluster-api provider added in [kubernetes/autoscaler#7804](https://github.com/kubernetes/autoscaler/pull/7804)), so a GPU pool there can't cold-start from zero regardless of any label we set. Tracked upstream in [kubernetes/autoscaler#7799](https://github.com/kubernetes/autoscaler/issues/7799).

`docs/content/getting-started/what-youll-build.cast` still shows the old `minNodeCount: 1` line in its recording and needs regenerating separately.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
