### PR TITLE
fix(doc): update provider location in prereq

### DIFF
--- a/docs/manifests/getting-started/prerequisites.yaml
+++ b/docs/manifests/getting-started/prerequisites.yaml
@@ -76,7 +76,7 @@ metadata:
 spec:
   matchImages:
   - type: Prefix
-    prefix: xpkg.upbound.io/upbound/provider-helm
+    prefix: xpkg.upbound.io/modelplane/provider-helm
   runtime:
     configRef:
       name: provider-helm-modelplane


### PR DESCRIPTION
<!--
Thanks for contributing to Modelplane! Read CONTRIBUTING.md before opening a PR
and follow it, especially the commit, pull request, and writing style
conventions: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md
PRs that don't follow it will be closed.
-->

### Description of your changes
after merging https://github.com/modelplaneai/modelplane/pull/324 and missing official provider-kubernetes and provider-helm releases we using an intermediate package location - but we missing to set the correct registry path in the prerequisit for the imageConfig 

<!--
Lead with the problem, then the change and why it's right. Direct reviewers to
the parts that need judgment. Don't pad or invent rationale. See the Pull
requests and Writing style sections of CONTRIBUTING.md for what a good
description looks like.

If this PR fixes an open issue, reference it below, e.g. "Fixes #95".
-->

Fixes #

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
