### PR TITLE
feat(nix): Forward DOCKER_CONFIG into the nix container so push can authenticate

### DIFF
--- a/nix.sh
+++ b/nix.sh
@@ -128,8 +128,18 @@ if [ -t 1 ]; then
 	INTERACTIVE_FLAGS="-it"
 fi
 
+# Forward registry credentials into the container when DOCKER_CONFIG is set,
+# so 'nix run .#push' can authenticate to the package registry:
+#   DOCKER_CONFIG=/tmp/dockercfg ./nix.sh run .#push -- --tag <tag>
+# DOCKER_CONFIG names a directory containing a Docker config.json.
+DOCKER_CONFIG_FLAGS=""
+if [ -n "${DOCKER_CONFIG:-}" ]; then
+	DOCKER_CONFIG_FLAGS="-v ${DOCKER_CONFIG}:/dockercfg:ro -e DOCKER_CONFIG=/dockercfg"
+fi
+
 # Run with --privileged for Docker-in-Docker (required for composition tests).
-docker run --rm --privileged --cgroupns=host ${INTERACTIVE_FLAGS} \
+# shellcheck disable=SC2086  # INTERACTIVE_FLAGS and DOCKER_CONFIG_FLAGS are intentionally word-split.
+docker run --rm --privileged --cgroupns=host ${INTERACTIVE_FLAGS} ${DOCKER_CONFIG_FLAGS} \
 	-v "$(pwd):/modelplane" \
 	-v "modelplane-nix:/nix" \
 	-w /modelplane \


### PR DESCRIPTION
<!--
Thanks for contributing to Modelplane! Read CONTRIBUTING.md before opening a PR
and follow it, especially the commit, pull request, and writing style
conventions: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md
PRs that don't follow it will be closed.
-->

### Description of your changes
nix.sh runs everything inside a container, but nothing forwarded registry credentials into it. 'nix run .#push' therefore couldn't authenticate to the package registry and failed on push, even when the host had valid credentials.

When DOCKER_CONFIG is set, nix.sh now mounts that directory read-only at /dockercfg and sets DOCKER_CONFIG inside the container to point at it:

`    DOCKER_CONFIG=/tmp/dockercfg ./nix.sh run .#push -- --tag <tag>`

When DOCKER_CONFIG is unset, nothing changes.


<!--
Lead with the problem, then the change and why it's right. Direct reviewers to
the parts that need judgment. Don't pad or invent rationale. See the Pull
requests and Writing style sections of CONTRIBUTING.md for what a good
description looks like.

If this PR fixes an open issue, reference it below, e.g. "Fixes #95".
-->

Fixes #

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
