### PR TITLE
feat(nix): drop into dev shell

### DIFF
--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -129,6 +129,7 @@
             pkgs.kind
             pkgs.kubectl
             pkgs.docker-client
+            pkgs.nix
           ];
           inheritPath = false;
           text = ''
@@ -137,6 +138,15 @@
             ln -s ${functionsPkg} _output/functions
 
             crossplane project run "$@"
+
+            # When running via nix.sh, the cluster lives inside the container's
+            # Docker daemon and would vanish when the container exits. Drop into
+            # a dev shell so the user can interact with it before exiting.
+            if [ "''${NIX_SH_CONTAINER:-}" = "1" ]; then
+              echo ""
+              echo "Entering development shell (exit to stop)..."
+              exec nix develop
+            fi
           '';
         }
       );


### PR DESCRIPTION
<!--
Thanks for contributing to Modelplane! Read CONTRIBUTING.md before opening a PR
and follow it, especially the commit, pull request, and writing style
conventions: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md
PRs that don't follow it will be closed.
-->

### Description of your changes

When running via nix.sh, the cluster lives inside the container's Docker daemon and would vanish when the container exits. Drop into a dev shell so the user can interact with it before exiting. 
copies the behaviour we have in crossplane core https://github.com/crossplane/crossplane/blob/main/nix/apps.nix#L316-L321

<!--
Lead with the problem, then the change and why it's right. Direct reviewers to
the parts that need judgment. Don't pad or invent rationale. See the Pull
requests and Writing style sections of CONTRIBUTING.md for what a good
description looks like.

If this PR fixes an open issue, reference it below, e.g. "Fixes #95".
-->

Fixes #

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
