### PR TITLE
Route Unified serving through an endpoint picker

### DIFF
--- a/functions/compose-model-replica/function/backends/base.py
+++ b/functions/compose-model-replica/function/backends/base.py
@@ -166,11 +166,10 @@ def leader_address_env() -> dict:
     return {"name": LEADER_ADDRESS_ENV, "value": f"$({_LWS_LEADER_ADDRESS_ENV})"}
 
 
-# Response resource keys. A replica's shared Service and HTTPRoute keep stable
-# keys; each engine's workload gets an engine-scoped key and each member's
-# claim a member-scoped one (the engine name plus the member role) so a
-# multi-engine replica's resources don't collide in the response map.
-SERVICE_KEY = "model-service"
+# Response resource keys. A replica's HTTPRoute keeps a stable key; each engine's
+# workload gets an engine-scoped key and each member's claim a member-scoped one
+# (the engine name plus the member role) so a multi-engine replica's resources
+# don't collide in the response map.
 ROUTE_KEY = "model-route"
 _WORKLOAD_KEY = "model-serving"
 _CLAIM_KEY = "resource-claim"
@@ -270,58 +269,6 @@ def wrap_object(
             forProvider=k8sobjv1alpha1.ForProvider(manifest=manifest),
         ),
     )
-
-
-def serving_resources(replica: v1alpha1.ModelReplica, provider_config: str) -> dict[str, k8sobjv1alpha1.Object]:
-    """Compose the Service and HTTPRoute that front a replica's serving pods.
-
-    One Service spans every engine's serving pods (Standalone pods and LWS
-    leaders) via the shared serving label; one HTTPRoute exposes that Service at
-    the replica's per-placement path. Built once per replica, independent of how
-    many engines it has - the unified serving surface the design's Unified mode
-    describes.
-
-    Named after the replica (unique per placement) so co-located replicas on one
-    cluster don't collide. The replica name is reserved for these serving
-    resources; workloads are named per engine (see engine_name) so a
-    LeaderWorkerSet never shares this Service's name and its controller can
-    create the headless gang-DNS Service it needs. The route attaches to the
-    workload cluster's inference gateway; the control plane rewrites the public
-    /<ns>/<service>/ prefix to this replica's /<ns>/<replica>/, which the route
-    strips to /.
-    """
-    name = _name(replica.metadata)
-    service = {
-        "apiVersion": "v1",
-        "kind": "Service",
-        "metadata": {"name": name, "namespace": REMOTE_NAMESPACE},
-        "spec": {"selector": {LABEL_SERVING: name}, "ports": [{"port": 80, "targetPort": ENGINE_PORT}]},
-    }
-    http_route = {
-        "apiVersion": "gateway.networking.k8s.io/v1",
-        "kind": "HTTPRoute",
-        "metadata": {"name": name, "namespace": REMOTE_NAMESPACE},
-        "spec": {
-            "parentRefs": [{"name": "inference-gateway", "namespace": "modelplane-system"}],
-            "rules": [
-                {
-                    "matches": [{"path": {"type": "PathPrefix", "value": f"/{_namespace(replica.metadata)}/{name}/"}}],
-                    "timeouts": {"request": REQUEST_TIMEOUT},
-                    "filters": [
-                        {
-                            "type": "URLRewrite",
-                            "urlRewrite": {"path": {"type": "ReplacePrefixMatch", "replacePrefixMatch": "/"}},
-                        }
-                    ],
-                    "backendRefs": [{"name": name, "port": 80}],
-                }
-            ],
-        },
-    }
-    return {
-        SERVICE_KEY: wrap_object(provider_config, service),
-        ROUTE_KEY: wrap_object(provider_config, http_route),
-    }
 
 
 def serving_label(replica: v1alpha1.ModelReplica) -> str:

--- a/functions/compose-model-replica/function/routing.py
+++ b/functions/compose-model-replica/function/routing.py
@@ -18,7 +18,11 @@ The workload backends (native, llm-d, dynamo) compose engines only; this layer
 decorates them with the routing the replica's serving.mode selects. apply picks
 the strategy:
 
-- Unified fronts every engine's serving pods with one Service + HTTPRoute.
+- Unified fronts the serving pods with a GAIE InferencePool + endpoint picker,
+  so requests route by prefix cache and load rather than round-robin. One path
+  whether the replica serves from a single pod or many: the picker is vestigial
+  for one pod, but the alternative is swapping a Service + HTTPRoute for a pool
+  the moment a second pod appears, which would drop in-flight requests.
 - PrefillDecode (disaggregated) role-labels the two phase engines, injects the
   pd-sidecar on decode, and fronts both with a GAIE InferencePool + endpoint
   picker, routed to in place of a Service.
@@ -30,11 +34,20 @@ Engine flags, including --kv-transfer-config for the NixlConnector, are the
 user's; this layer injects none.
 """
 
+import hashlib
+
 from models.ai.modelplane.modelreplica import v1alpha1
 from models.io.crossplane.m.kubernetes.object import v1alpha1 as k8sobjv1alpha1
 from models.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
 
 from function.backends import base
+
+
+def _name(meta: metav1.ObjectMeta | None) -> str:
+    """The object's name, always set on resources read from the API server."""
+    if meta is None or meta.name is None:
+        raise ValueError("metadata.name is unexpectedly absent")
+    return meta.name
 
 
 def _namespace(meta: metav1.ObjectMeta | None) -> str:
@@ -46,6 +59,12 @@ def _namespace(meta: metav1.ObjectMeta | None) -> str:
 
 _EPP_IMAGE = "ghcr.io/llm-d/llm-d-inference-scheduler:v0.8.0"
 _SIDECAR_IMAGE = "ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0"
+
+# ConfigMap key and mount-path filename for each strategy's EPP config.
+# ConfigMap key and mount-path filename for the EPP config. One name for both
+# strategies: the ConfigMap is per-replica and carries a single strategy's
+# config, so the mount path never needs to encode which one.
+_EPP_CONFIG_FILE = "epp-config.yaml"
 
 # The pd-sidecar takes ENGINE_PORT (8000), so the decode engine listens here.
 _DECODE_ENGINE_PORT = 8001
@@ -131,12 +150,49 @@ schedulingProfiles:
     weight: 1
 """
 
+# EndpointPickerConfig for Unified serving: one profile scoring by prefix cache
+# and queue depth, with no prefill/decode split. A single schedulingProfile makes
+# the EPP fall back to its SingleProfileHandler, and prefix-cache-scorer still
+# needs approx-prefix-cache-producer to populate the prefix-match attribute it
+# scores on (see the disaggregated config above for why the producer pins
+# autoTune and blockSizeTokens). prefix-cache-scorer is weighted 2 to
+# queue-scorer's 1: cache locality dominates placement until queue depths
+# diverge, when the queue score breaks the tie. It's a starting default, not a
+# tuned one.
+_UNIFIED_EPP_CONFIG_TEMPLATE = """\
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: approx-prefix-cache-producer
+  parameters:
+    autoTune: false
+    blockSizeTokens: BLOCK_SIZE_TOKENS
+    maxPrefixBlocksToMatch: 256
+    lruCapacityPerServer: 31250
+- type: prefix-cache-scorer
+- type: queue-scorer
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: max-score-picker
+  - pluginRef: prefix-cache-scorer
+    weight: 2
+  - pluginRef: queue-scorer
+    weight: 1
+"""
+
 _DEFAULT_KV_BLOCK_SIZE = 16
 
 
-def _epp_config_yaml(block_size: int) -> str:
-    """Render the EPP config with the engine's KV block size."""
+def _disaggregated_epp_config_yaml(block_size: int) -> str:
+    """Render the disaggregated EPP config with the engine's KV block size."""
     return _EPP_CONFIG_TEMPLATE.replace("BLOCK_SIZE_TOKENS", str(block_size))
+
+
+def _unified_epp_config_yaml(block_size: int) -> str:
+    """Render the unified EPP config with the engine's KV block size."""
+    return _UNIFIED_EPP_CONFIG_TEMPLATE.replace("BLOCK_SIZE_TOKENS", str(block_size))
 
 
 def _flag_value(args: list, *flags: str) -> str | None:
@@ -189,8 +245,8 @@ def apply(
 ) -> dict[str, k8sobjv1alpha1.Object]:
     """Decorate the engine workloads with the replica's routing surface.
 
-    PrefillDecode serving picks the disaggregated stack; everything else (Unified
-    or no serving block) picks the plain Service.
+    PrefillDecode serving picks the disaggregated stack; Unified (or no serving
+    block) fronts the serving pods with an InferencePool + endpoint picker.
     """
     serving = replica.spec.serving
     if serving and serving.mode == "PrefillDecode":
@@ -203,8 +259,27 @@ def _unified(
     replica: v1alpha1.ModelReplica,
     provider_config: str,
 ) -> dict[str, k8sobjv1alpha1.Object]:
-    """Front every engine's serving pods with one Service + HTTPRoute."""
-    return {**composed, **base.serving_resources(replica, provider_config)}
+    """Front the replica's serving pods with an InferencePool + endpoint picker.
+
+    Selects the pods by the serving label they already carry, and routes the
+    replica's path at the pool. The picker scores by prefix cache and queue depth
+    (see _UNIFIED_EPP_CONFIG_TEMPLATE) rather than spraying requests round-robin.
+
+    One pod or many, the surface is the same. A single pod has nothing to pick
+    between, so the picker is vestigial there; but always fronting with a pool
+    avoids swapping a Service for one the moment a second pod appears - a swap
+    that would drop in-flight requests.
+    """
+    name = _name(replica.metadata)
+    out = dict(composed)
+    # The prefix-cache producer must chunk prefixes at the engine's KV block
+    # size; derive it from the first engine's flags (HACK, #179).
+    block_size = _kv_block_size(_engine_args(out[base.workload_key(replica.spec.engines[0])]))
+    selector = {base.LABEL_SERVING: base.serving_label(replica)}
+    out["inference-pool"] = base.wrap_object(provider_config, _inference_pool(name, selector))
+    out[base.ROUTE_KEY] = base.wrap_object(provider_config, _http_route(replica, name))
+    out.update(_epp_objects(name, provider_config, _unified_epp_config_yaml(block_size)))
+    return out
 
 
 def _disaggregated(
@@ -226,10 +301,7 @@ def _disaggregated(
     current tag. Engine images are the user's (#137), so Modelplane can't bundle
     this; it is a deployment prerequisite, not something the composition provides.
     """
-    assert (
-        replica.metadata is not None and replica.metadata.name is not None
-    )  # set on resources read from the API server
-    name = replica.metadata.name
+    name = _name(replica.metadata)
     prefill = next(e for e in replica.spec.engines if e.phase == "Prefill")
     decode = next(e for e in replica.spec.engines if e.phase == "Decode")
 
@@ -248,9 +320,13 @@ def _disaggregated(
     # The EPP's prefix-cache producer must chunk prefixes at the decode engine's
     # KV block size; derive it from the decode engine's flags (HACK, #179).
     block_size = _kv_block_size(_engine_args(out[decode_key]))
-    out["inference-pool"] = base.wrap_object(provider_config, _inference_pool(name))
+    # Select the replica's serving pods by the serving label they already carry,
+    # the same as unified. The phase (role) labels _label_role adds are for the
+    # EPP's prefill/decode filters, not for pool membership.
+    selector = {base.LABEL_SERVING: base.serving_label(replica)}
+    out["inference-pool"] = base.wrap_object(provider_config, _inference_pool(name, selector))
     out[base.ROUTE_KEY] = base.wrap_object(provider_config, _http_route(replica, name))
-    out.update(_epp_objects(name, provider_config, block_size))
+    out.update(_epp_objects(name, provider_config, _disaggregated_epp_config_yaml(block_size)))
     return out
 
 
@@ -358,13 +434,13 @@ def _inject_nixl_plumbing(obj: k8sobjv1alpha1.Object) -> None:
             env.append({"name": "VLLM_NIXL_SIDE_CHANNEL_PORT", "value": _NIXL_SIDE_CHANNEL_PORT})
 
 
-def _inference_pool(name: str) -> dict:
+def _inference_pool(name: str, selector: dict[str, str]) -> dict:
     return {
         "apiVersion": "inference.networking.k8s.io/v1",
         "kind": "InferencePool",
         "metadata": {"name": f"{name}-pool", "namespace": base.REMOTE_NAMESPACE},
         "spec": {
-            "selector": {"matchLabels": {"app": name, _LABEL_INFERENCE_SERVING: "true"}},
+            "selector": {"matchLabels": selector},
             "targetPorts": [{"number": base.ENGINE_PORT}],
             "endpointPickerRef": {"name": f"{name}-epp", "port": {"number": 9002}, "failureMode": "FailOpen"},
         },
@@ -397,11 +473,11 @@ def _http_route(replica: v1alpha1.ModelReplica, name: str) -> dict:
     }
 
 
-def _epp_objects(name: str, provider_config: str, block_size: int) -> dict[str, k8sobjv1alpha1.Object]:
+def _epp_objects(name: str, provider_config: str, config_yaml: str) -> dict[str, k8sobjv1alpha1.Object]:
     """The endpoint picker: ServiceAccount, RBAC, ConfigMap, Deployment, Service.
 
-    block_size is the engine's KV block size, rendered into the prefix-cache
-    producer so its prefix chunking matches the engine.
+    config_yaml is the rendered EndpointPickerConfig the picker runs with; it
+    differs by serving strategy.
     """
     ns = base.REMOTE_NAMESPACE
     epp = f"{name}-epp"
@@ -437,8 +513,13 @@ def _epp_objects(name: str, provider_config: str, block_size: int) -> dict[str, 
         "apiVersion": "v1",
         "kind": "ConfigMap",
         "metadata": {"name": epp, "namespace": ns},
-        "data": {"pd-epp-config.yaml": _epp_config_yaml(block_size)},
+        "data": {_EPP_CONFIG_FILE: config_yaml},
     }
+    # The EPP reads its config once at startup and a mounted ConfigMap update
+    # doesn't re-trigger that read, so a config change alone would leave the
+    # picker on the old config. Stamp a hash of the config on the pod template so
+    # a change rolls the Deployment.
+    config_checksum = hashlib.sha256(config_yaml.encode()).hexdigest()
     deployment = {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -447,7 +528,10 @@ def _epp_objects(name: str, provider_config: str, block_size: int) -> dict[str, 
             "replicas": 1,
             "selector": {"matchLabels": {"app": epp}},
             "template": {
-                "metadata": {"labels": {"app": epp}},
+                "metadata": {
+                    "labels": {"app": epp},
+                    "annotations": {"modelplane.ai/epp-config-checksum": config_checksum},
+                },
                 "spec": {
                     "serviceAccountName": epp,
                     "containers": [
@@ -458,7 +542,7 @@ def _epp_objects(name: str, provider_config: str, block_size: int) -> dict[str, 
                                 f"--pool-name={name}-pool",
                                 f"--pool-namespace={ns}",
                                 "--pool-group=inference.networking.k8s.io",
-                                "--config-file=/config/pd-epp-config.yaml",
+                                f"--config-file=/config/{_EPP_CONFIG_FILE}",
                                 "--grpc-port=9002",
                             ],
                             "ports": [

--- a/functions/compose-model-replica/tests/test_backends.py
+++ b/functions/compose-model-replica/tests/test_backends.py
@@ -15,8 +15,8 @@
 """Tests for compose-model-replica backends.
 
 A backend builds the workload (Deployment or LeaderWorkerSet) and the
-ResourceClaimTemplates for one worker engine; the shared Service and HTTPRoute
-that front a replica's engines are built by base.serving_resources. Manifests are
+ResourceClaimTemplates for one worker engine; the InferencePool, endpoint picker,
+and HTTPRoute that front a replica's engines are built by routing.apply. Manifests are
 asserted with a `Case` table: each case builds an engine's backend and compares
 the composed manifests to a full `want`. Backend selection, serving, and the
 Dynamo stub are dispatch/behaviour tests below the table.
@@ -192,40 +192,6 @@ _CLUSTER = icv1alpha1.InferenceCluster(
 _PC = "cluster-a-pc"
 
 
-def _route(name: str) -> dict:
-    """The replica's HTTPRoute — replica-named, prefix-stripped."""
-    return {
-        "apiVersion": "gateway.networking.k8s.io/v1",
-        "kind": "HTTPRoute",
-        "metadata": {"name": name, "namespace": "default"},
-        "spec": {
-            "parentRefs": [{"name": "inference-gateway", "namespace": "modelplane-system"}],
-            "rules": [
-                {
-                    "matches": [{"path": {"type": "PathPrefix", "value": f"/ml-team/{name}/"}}],
-                    "timeouts": {"request": "0s"},
-                    "filters": [
-                        {
-                            "type": "URLRewrite",
-                            "urlRewrite": {"path": {"type": "ReplacePrefixMatch", "replacePrefixMatch": "/"}},
-                        }
-                    ],
-                    "backendRefs": [{"name": name, "port": 80}],
-                }
-            ],
-        },
-    }
-
-
-def _service(name: str) -> dict:
-    return {
-        "apiVersion": "v1",
-        "kind": "Service",
-        "metadata": {"name": name, "namespace": "default"},
-        "spec": {"selector": {_SERVING: name}, "ports": [{"port": 80, "targetPort": 8000}]},
-    }
-
-
 _NATIVE_WANT = {
     "model-serving-main": {
         "apiVersion": "apps/v1",
@@ -394,14 +360,6 @@ class TestBackendManifests(unittest.TestCase):
                 got = {key: obj.spec.forProvider.manifest for key, obj in out.items()}
                 self.assertEqual(case.want, got, "-want, +got")
 
-    def test_serving_resources(self) -> None:
-        # The shared Service + HTTPRoute front a replica regardless of how many
-        # engines it has, named after the replica.
-        replica = _replica()
-        out = base.serving_resources(replica, _PC)
-        got = {key: obj.spec.forProvider.manifest for key, obj in out.items()}
-        self.assertEqual({"model-service": _service("r"), "model-route": _route("r")}, got)
-
     def test_leader_address_injected_into_gang_engines(self) -> None:
         # Every engine container in a multi-node gang gets
         # MODELPLANE_LEADER_ADDRESS, aliasing LWS_LEADER_ADDRESS, ahead of the
@@ -463,21 +421,6 @@ class TestBackendManifests(unittest.TestCase):
         out_b = native.NativeBackend().build(b, b.spec.engines[0], _PC, base.serving_label(b))
         self.assertEqual(self._names(out_a) & self._names(out_b), set())
 
-    def test_lws_name_differs_from_serving_service_name(self) -> None:
-        # Regression: LWS's controller creates a headless Service named after
-        # the LWS for gang pod DNS - but only if no Service of that name
-        # exists. When the LWS shared the serving Service's name (the replica
-        # name), that headless Service was never created, the followers could
-        # never resolve the leader, and the gang deadlocked. The workload name
-        # must differ from the Service's.
-        engine = _gang_engine(leader_command=_LEADER_CMD, worker_command=_WORKER_CMD)
-        replica = _replica(engines=[engine])
-        workload = llmd.LLMDBackend().build(replica, engine, _PC, base.serving_label(replica))
-        serving = base.serving_resources(replica, _PC)
-        lws_name = workload["model-serving-main"].spec.forProvider.manifest["metadata"]["name"]
-        service_name = serving["model-service"].spec.forProvider.manifest["metadata"]["name"]
-        self.assertNotEqual(lws_name, service_name)
-
     def test_multi_engine_qualifies_workload_names(self) -> None:
         # A replica with two engines names each engine's workload distinctly so
         # they don't collide on the remote cluster.
@@ -508,15 +451,6 @@ class TestBackendManifests(unittest.TestCase):
                         readiness = obj.spec.readiness
                         assert readiness is not None
                         self.assertEqual(readiness.policy, "SuccessfulCreate")
-
-    def test_serving_readiness_policies(self) -> None:
-        replica = _replica()
-        out = base.serving_resources(replica, _PC)
-        service_readiness = out["model-service"].spec.readiness
-        route_readiness = out["model-route"].spec.readiness
-        assert service_readiness is not None and route_readiness is not None
-        self.assertEqual(service_readiness.policy, "SuccessfulCreate")
-        self.assertEqual(route_readiness.policy, "SuccessfulCreate")
 
     def test_multiple_device_requests_single_container_claim(self) -> None:
         # resources.claims is a list-map keyed on name alone, so N device
@@ -776,7 +710,6 @@ class TestDisaggregated(unittest.TestCase):
 
     def test_replaces_unified_service_with_pool_and_epp(self) -> None:
         out = self._apply()
-        self.assertNotIn(base.SERVICE_KEY, out)  # unified Service gone
         self.assertIn("inference-pool", out)
         self.assertIn("epp", out)
         self.assertIn("epp-config", out)
@@ -810,7 +743,7 @@ class TestDisaggregated(unittest.TestCase):
         true default never populates). And it must NOT carry the prepareDataPlugins
         feature gate, which the v0.8.0 EPP image rejects and crashloops on.
         """
-        cfg = self._apply()["epp-config"].spec.forProvider.manifest["data"]["pd-epp-config.yaml"]
+        cfg = self._apply()["epp-config"].spec.forProvider.manifest["data"]["epp-config.yaml"]
         self.assertIn("prefix-based-pd-decider", cfg)
         self.assertIn("nonCachedTokens: 16", cfg)
         self.assertIn("approx-prefix-cache-producer", cfg)
@@ -903,17 +836,66 @@ class TestDisaggregated(unittest.TestCase):
 
 
 class TestUnifiedRouting(unittest.TestCase):
-    """With no serving block (or mode Unified), routing.apply adds a plain
-    Service + HTTPRoute and no InferencePool."""
+    """Unified serving (or no serving block) fronts the pods with an
+    InferencePool + endpoint picker in place of a plain Service, so requests
+    route by prefix cache and load rather than round-robin - one pod or many.
+    Mirrors how fn.py composes engines then calls routing.apply."""
 
-    def test_adds_service_and_route(self) -> None:
-        engine = _standalone_engine(name="main")
+    def _apply(self, copies: int = 1) -> dict[str, k8sobjv1alpha1.Object]:
+        engine = _standalone_engine(copies=copies)
         replica = _replica(engines=[engine])
         composed = native.NativeBackend().build(replica, engine, _PC, base.serving_label(replica))
-        out = routing.apply(composed, replica, _PC)
-        self.assertIn(base.SERVICE_KEY, out)
-        self.assertIn(base.ROUTE_KEY, out)
-        self.assertNotIn("inference-pool", out)
+        return routing.apply(composed, replica, _PC)
+
+    def test_fronts_with_pool_and_epp(self) -> None:
+        out = self._apply()
+        self.assertIn("inference-pool", out)
+        self.assertIn("epp", out)
+        self.assertIn("epp-config", out)
+        pool = out["inference-pool"].spec.forProvider.manifest
+        self.assertEqual(pool["kind"], "InferencePool")
+        self.assertEqual(pool["spec"]["endpointPickerRef"]["name"], "r-epp")
+
+    def test_single_pod_also_pools(self) -> None:
+        """A single serving pod has nothing to pick between, but still gets the
+        pool. Always fronting with one avoids swapping a Service for a pool when a
+        second pod appears - a swap that would drop in-flight requests."""
+        for copies in (1, 2):
+            with self.subTest(copies=copies):
+                out = self._apply(copies=copies)
+                self.assertIn("inference-pool", out)
+                self.assertIn("epp", out)
+
+    def test_pool_selects_pods_by_the_serving_label(self) -> None:
+        """The pool selects the pods by the serving label they already carry, so
+        no relabeling is needed."""
+        pool = self._apply()["inference-pool"].spec.forProvider.manifest
+        self.assertEqual(pool["spec"]["selector"]["matchLabels"], {base.LABEL_SERVING: "r"})
+
+    def test_route_targets_inference_pool(self) -> None:
+        route = self._apply()[base.ROUTE_KEY].spec.forProvider.manifest
+        ref = route["spec"]["rules"][0]["backendRefs"][0]
+        self.assertEqual(ref["kind"], "InferencePool")
+        self.assertEqual(ref["name"], "r-pool")
+
+    def test_epp_config_is_unified_not_disaggregated(self) -> None:
+        """The unified picker scores by prefix cache and queue depth in a single
+        profile, with no prefill/decode split, and still needs the
+        approx-prefix-cache-producer that feeds the prefix-cache scorer."""
+        cfg = self._apply()["epp-config"].spec.forProvider.manifest["data"]["epp-config.yaml"]
+        self.assertIn("prefix-cache-scorer", cfg)
+        self.assertIn("queue-scorer", cfg)
+        self.assertIn("approx-prefix-cache-producer", cfg)
+        self.assertNotIn("prefill", cfg)
+        self.assertNotIn("decider", cfg)
+
+    def test_epp_pod_carries_config_checksum(self) -> None:
+        """The EPP reads its config once at startup, so a config change must roll
+        the pod. The pod template carries a sha256 of the rendered config to drive
+        that rollout."""
+        template = self._apply()["epp"].spec.forProvider.manifest["spec"]["template"]
+        checksum = template["metadata"]["annotations"]["modelplane.ai/epp-config-checksum"]
+        self.assertEqual(len(checksum), 64)
 
 
 class TestKvBlockSize(unittest.TestCase):
@@ -935,7 +917,7 @@ class TestKvBlockSize(unittest.TestCase):
         self.assertEqual(routing._kv_block_size(["--block-size", "auto"]), 16)
 
     def test_rendered_config_uses_block_size(self) -> None:
-        cfg = routing._epp_config_yaml(32)
+        cfg = routing._disaggregated_epp_config_yaml(32)
         self.assertIn("blockSizeTokens: 32", cfg)
         self.assertNotIn("BLOCK_SIZE_TOKENS", cfg)
 

--- a/functions/compose-model-replica/tests/test_fn.py
+++ b/functions/compose-model-replica/tests/test_fn.py
@@ -227,35 +227,6 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                             }
                         ),
                     ),
-                    "model-service": fnv1.Resource(
-                        resource=resource.dict_to_struct(
-                            {
-                                "apiVersion": "kubernetes.m.crossplane.io/v1alpha1",
-                                "kind": "Object",
-                                "spec": {
-                                    "providerConfigRef": {
-                                        "kind": "ClusterProviderConfig",
-                                        "name": "cluster-a-pc",
-                                    },
-                                    "readiness": {"policy": "SuccessfulCreate"},
-                                    "forProvider": {
-                                        "manifest": {
-                                            "apiVersion": "v1",
-                                            "kind": "Service",
-                                            "metadata": {
-                                                "name": "test-replica",
-                                                "namespace": "default",
-                                            },
-                                            "spec": {
-                                                "selector": {"modelplane.ai/serving": "test-replica"},
-                                                "ports": [{"port": 80, "targetPort": 8000}],
-                                            },
-                                        },
-                                    },
-                                },
-                            }
-                        ),
-                    ),
                     "model-route": fnv1.Resource(
                         resource=resource.dict_to_struct(
                             {
@@ -305,7 +276,11 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                                                             },
                                                         ],
                                                         "backendRefs": [
-                                                            {"name": "test-replica", "port": 80},
+                                                            {
+                                                                "group": "inference.networking.k8s.io",
+                                                                "kind": "InferencePool",
+                                                                "name": "test-replica-pool",
+                                                            },
                                                         ],
                                                     },
                                                 ],
@@ -496,14 +471,16 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                 ),
             )
         )
-        # The other three are observed simply by being present; their content
-        # doesn't matter, only that the function can see them.
-        for key in ("model-service", "model-route", "resource-claim-main-standalone"):
+        # The other two are observed simply by being present; their content
+        # doesn't matter, only that the function can see them. (The InferencePool +
+        # endpoint picker resources aren't observed here, so they stay unready and
+        # are excluded from the golden below - test_backends covers their manifests.)
+        for key in ("model-route", "resource-claim-main-standalone"):
             req4.observed.resources[key].CopyFrom(fnv1.Resource(resource=structpb.Struct()))
 
         want4 = fnv1.RunFunctionResponse()
         want4.CopyFrom(want1)
-        for key in ("model-serving-main", "model-service", "model-route", "resource-claim-main-standalone"):
+        for key in ("model-serving-main", "model-route", "resource-claim-main-standalone"):
             want4.desired.resources[key].ready = fnv1.READY_TRUE
         del want4.conditions[:]
         want4.conditions.extend(
@@ -523,11 +500,32 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
             Case(name="observed resources are marked ready", req=req4, want=want4),
         ]
 
+        # Unified routing fronts the serving pods with an InferencePool + endpoint
+        # picker; their manifests are asserted in detail in test_backends. Here we
+        # only check the function wired the whole set in (and dropped the plain
+        # Service), then drop them so the golden covers the dispatch and wiring the
+        # function itself owns.
+        routing_keys = {
+            "inference-pool",
+            "epp",
+            "epp-config",
+            "epp-role",
+            "epp-rolebinding",
+            "epp-serviceaccount",
+            "epp-service",
+        }
         for case in cases:
             with self.subTest(case.name):
                 got = await self.runner.RunFunction(case.req, None)
+                got_dict = json_format.MessageToDict(got)
+                resources = got_dict.get("desired", {}).get("resources", {})
+                if "model-serving-main" in resources:
+                    self.assertLessEqual(routing_keys, set(resources))
+                    self.assertNotIn("model-service", resources)
+                    for key in routing_keys:
+                        resources.pop(key, None)
                 self.assertEqual(
                     json_format.MessageToDict(case.want),
-                    json_format.MessageToDict(got),
+                    got_dict,
                     "-want, +got",
                 )


### PR DESCRIPTION
Fixes #325.

Unified serving fronted a replica's pods with a plain Service, which round-robins: requests spread with no prefix-cache or load awareness, and each pod recomputes prefixes another already holds. Only PrefillDecode serving got the InferencePool and endpoint picker.

This gives Unified serving the same InferencePool and endpoint picker, with a single-profile picker config scoring by prefix cache and queue depth (no prefill/decode split).

Following review, it does so in **every** case rather than only when more than one pod serves the model. The picker is vestigial for a single pod — nothing to pick between — but the alternative is swapping the route's backend from a Service to a pool the moment a second pod appears, which drops in-flight requests. One path holds whether the replica serves from one pod or many. This removes the plain-Service path entirely (`base.serving_resources` and the `SERVICE_KEY` it composed); the pool selects the pods by the serving label they already carry, exactly as the multi-pod path did.

Also addresses the rest of the review:
- `_epp_config_yaml` → `_disaggregated_epp_config_yaml`, matching its `_unified_epp_config_yaml` sibling.
- Reuses the `_name()` helper the other composition functions share, in place of the inline `assert`/`metadata.name` idiom.
- Names the EPP pod annotation `modelplane.ai/epp-config-checksum` so it's clear which config the checksum tracks.

The picker is scoped per replica. Co-located replicas of one model on a cluster keep separate prefix caches; consolidating them into one picker per model per cluster has no owner in the per-replica resource model and belongs with the routing work in #34.

Validated with `nix flake check`: `test-compose-model-replica` (46 tests) and the docs-manifest validation pass. The unified routing tests assert a single serving pod and a multi-pod replica both compose the InferencePool + endpoint picker (ConfigMap, RBAC, Deployment, Service) and an HTTPRoute pointing at the pool, with no plain Service.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
