### PR TITLE
Restructure ModelDeployment spec under a template

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,22 +37,24 @@ metadata:
   namespace: ml-team
 spec:
   replicas: 1
-  engines:
-  - name: qwen
-    members:
-    - role: Standalone
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 1
-          selectors:
-          - cel: device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            args: ["--model=Qwen/Qwen2.5-0.5B-Instruct"]
+  template:
+    spec:
+      engines:
+      - name: qwen
+        members:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 1
+              selectors:
+              - cel: device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                args: ["--model=Qwen/Qwen2.5-0.5B-Instruct"]
 ```
 
 Modelplane schedules the replica onto a cluster with free, compatible GPUs and

--- a/apis/modeldeployments/definition.yaml
+++ b/apis/modeldeployments/definition.yaml
@@ -36,20 +36,7 @@ spec:
         properties:
           spec:
             type: object
-            required: [replicas, engines]
-            # PrefillDecode serving runs one Prefill and one Decode engine, each
-            # marking its phase. Validate the pairing here, where both serving
-            # and the engine list are visible. serving is optional and defaults
-            # to Unified, under which no engine may carry a phase.
-            x-kubernetes-validations:
-            - rule: "!has(self.serving) || self.serving.mode != 'PrefillDecode' || size(self.engines) == 2"
-              message: "PrefillDecode serving requires exactly two engines (one Prefill, one Decode)"
-            - rule: "!has(self.serving) || self.serving.mode != 'PrefillDecode' || self.engines.exists_one(e, has(e.phase) && e.phase == 'Prefill')"
-              message: "PrefillDecode serving requires exactly one engine with phase Prefill"
-            - rule: "!has(self.serving) || self.serving.mode != 'PrefillDecode' || self.engines.exists_one(e, has(e.phase) && e.phase == 'Decode')"
-              message: "PrefillDecode serving requires exactly one engine with phase Decode"
-            - rule: "(has(self.serving) && self.serving.mode == 'PrefillDecode') || !self.engines.exists(e, has(e.phase))"
-              message: "engine phase may only be set when serving.mode is PrefillDecode"
+            required: [replicas, template]
             properties:
               replicas:
                 type: integer
@@ -58,395 +45,452 @@ spec:
                 description: >-
                   How many ModelReplicas to fan out to. Each replica is a
                   complete serving instance scheduled to one InferenceCluster.
-              clusterSelector:
+              template:
                 type: object
+                required: [spec]
                 description: >-
-                  Optional label selector to filter InferenceClusters.
-                  If omitted, all ready clusters are candidates.
+                  Template for the ModelReplicas this deployment fans out to.
+                  Everything but the replica count lives here, mirroring a
+                  Kubernetes Deployment's spec.template.
                 properties:
-                  matchLabels:
+                  metadata:
                     type: object
-                    additionalProperties:
-                      type: string
-              modelCacheRef:
-                type: object
-                required: [name]
-                description: >-
-                  Reference to a ModelCache in the same namespace.
-                  Optional for single-node engines; required for any engine
-                  that spans multiple nodes (a Leader with one or more
-                  Workers), since every pod in the gang mounts it.
-                properties:
-                  name:
-                    type: string
-                    description: ModelCache resource name in the same namespace.
-                    minLength: 1
-              serving:
-                type: object
-                description: >-
-                  How the deployment is served from the cluster edge to its
-                  engines. Unified (the default) fronts the engines with a
-                  Service. PrefillDecode serves prefill and decode from the two
-                  engines marking those phases, with inference-aware routing that
-                  sequences prefill then decode. Omitted means Unified.
-                required: [mode]
-                properties:
-                  mode:
-                    type: string
-                    enum: [Unified, PrefillDecode]
-                    default: Unified
-                    description: >-
-                      Unified serves prefill and decode on one engine.
-                      PrefillDecode splits them across two engines, each marking
-                      its phase as Prefill or Decode.
-              engines:
-                type: array
-                description: >-
-                  A ModelReplica's inference engines. An engine is one serving
-                  unit: a single Standalone pod, or a gang of a Leader and one
-                  or more Workers coordinating across nodes. Modelplane
-                  composes the whole array once per ModelReplica; an engine
-                  composes to a Deployment (Standalone) or a LeaderWorkerSet
-                  (Leader/Worker), but the workload kind is an implementation
-                  detail. Modelplane is unopinionated about the engine itself:
-                  parallelism, quantization, and KV transfer all live in the
-                  members' engine flags, written by the user, never injected by
-                  Modelplane.
-                minItems: 1
-                maxItems: 8
-                x-kubernetes-list-type: map
-                x-kubernetes-list-map-keys: [name]
-                items:
-                  type: object
-                  required: [name, members]
-                  # An engine is exactly one Standalone member, or one Leader
-                  # and one or more Workers. No other combination of roles
-                  # forms a valid serving unit.
-                  x-kubernetes-validations:
-                  - rule: >-
-                      (self.members.size() == 1 && self.members[0].role == 'Standalone')
-                      || (self.members.exists_one(m, m.role == 'Leader')
-                          && self.members.exists(m, m.role == 'Worker')
-                          && !self.members.exists(m, m.role == 'Standalone'))
-                    message: >-
-                      an engine must be either a single Standalone member or one
-                      Leader and one or more Workers
-                  # nodeSelector is the only path to a GPU, so an engine where
-                  # no member carries one would deploy with no devices at all -
-                  # a mistake, not a deployment. A member may omit its own
-                  # selector (a coordinator-only leader claims nothing), but
-                  # some member must claim.
-                  - rule: "self.members.exists(m, has(m.nodeSelector))"
-                    message: >-
-                      at least one member of an engine must carry a nodeSelector
-                      requesting devices
-                  properties:
-                    name:
-                      type: string
-                      description: >-
-                        Identifies the engine within the deployment. Becomes
-                        part of the composed workload names, so it must be a
-                        DNS label.
-                      minLength: 1
-                      maxLength: 63
-                    copies:
-                      type: integer
-                      description: >-
-                        How many identical copies of this engine to run per
-                        ModelReplica. A fixed number, sized once per deployment;
-                        scaling happens by adding ModelReplicas
-                        (spec.replicas), never by varying copies. Maps to the
-                        composed Deployment's or LeaderWorkerSet's replica
-                        count. Defaults to 1.
-                      default: 1
-                      minimum: 1
-                      maximum: 64
-                    phase:
-                      type: string
-                      enum: [Prefill, Decode]
-                      description: >-
-                        The engine's phase in a PrefillDecode deployment,
-                        Prefill or Decode. Set only when serving.mode is
-                        PrefillDecode, where exactly one engine takes each phase.
-                    members:
-                      type: array
-                      description: >-
-                        The engine's pods. Either a single Standalone member,
-                        or one Leader and one or more Workers.
-                      minItems: 1
-                      maxItems: 2
-                      x-kubernetes-list-type: atomic
-                      items:
+                    # Reject malformed labels on the ModelDeployment itself,
+                    # rather than letting them fail when the composed ModelReplica
+                    # and ModelEndpoint are applied (a child error the user can't
+                    # trace back to their input). These mirror Kubernetes label
+                    # syntax: an optional DNS-subdomain prefix plus a name of up
+                    # to 63 chars, a value of up to 63 chars, both from
+                    # [A-Za-z0-9._-] and edged by alphanumerics.
+                    x-kubernetes-validations:
+                    - rule: "!has(self.labels) || self.labels.all(k, !k.startsWith('modelplane.ai/'))"
+                      message: "template.metadata.labels keys must not use the reserved modelplane.ai/ prefix"
+                    - rule: "!has(self.labels) || self.labels.all(k, k.matches('^([a-z0-9]([-a-z0-9.]{0,251}[a-z0-9])?/)?[A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?$'))"
+                      message: "template.metadata.labels keys must be valid Kubernetes label keys"
+                    - rule: "!has(self.labels) || self.labels.all(k, self.labels[k].matches('^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'))"
+                      message: "template.metadata.labels values must be valid Kubernetes label values"
+                    properties:
+                      labels:
                         type: object
-                        required: [template]
-                        # worker is meaningful only for a Worker member: a
-                        # Standalone and a Leader are always exactly one pod on
-                        # one node.
-                        x-kubernetes-validations:
-                        - rule: "!has(self.worker) || self.role == 'Worker'"
-                          message: "worker may only be set on a Worker member"
+                        description: >-
+                          Labels to set on the ModelReplicas and ModelEndpoints
+                          this deployment composes, alongside the labels
+                          Modelplane manages. Use them to organize and select
+                          your own resources (kubectl get modelreplica -l
+                          tier=prod) or to route to a subset of endpoints from a
+                          ModelService. Keys under the modelplane.ai/ prefix are
+                          reserved.
+                        maxProperties: 32
+                        additionalProperties:
+                          type: string
+                          maxLength: 63
+                  spec:
+                    type: object
+                    required: [engines]
+                    # PrefillDecode serving runs one Prefill and one Decode
+                    # engine, each marking its phase. Validate the pairing here,
+                    # where both serving and the engine list are visible. serving
+                    # is optional and defaults to Unified, under which no engine
+                    # may carry a phase.
+                    x-kubernetes-validations:
+                    - rule: "!has(self.serving) || self.serving.mode != 'PrefillDecode' || size(self.engines) == 2"
+                      message: "PrefillDecode serving requires exactly two engines (one Prefill, one Decode)"
+                    - rule: "!has(self.serving) || self.serving.mode != 'PrefillDecode' || self.engines.exists_one(e, has(e.phase) && e.phase == 'Prefill')"
+                      message: "PrefillDecode serving requires exactly one engine with phase Prefill"
+                    - rule: "!has(self.serving) || self.serving.mode != 'PrefillDecode' || self.engines.exists_one(e, has(e.phase) && e.phase == 'Decode')"
+                      message: "PrefillDecode serving requires exactly one engine with phase Decode"
+                    - rule: "(has(self.serving) && self.serving.mode == 'PrefillDecode') || !self.engines.exists(e, has(e.phase))"
+                      message: "engine phase may only be set when serving.mode is PrefillDecode"
+                    properties:
+                      clusterSelector:
+                        type: object
+                        description: >-
+                          Optional label selector to filter InferenceClusters.
+                          If omitted, all ready clusters are candidates.
                         properties:
-                          role:
+                          matchLabels:
+                            type: object
+                            additionalProperties:
+                              type: string
+                      modelCacheRef:
+                        type: object
+                        required: [name]
+                        description: >-
+                          Reference to a ModelCache in the same namespace.
+                          Optional for single-node engines; required for any engine
+                          that spans multiple nodes (a Leader with one or more
+                          Workers), since every pod in the gang mounts it.
+                        properties:
+                          name:
                             type: string
+                            description: ModelCache resource name in the same namespace.
+                            minLength: 1
+                      serving:
+                        type: object
+                        description: >-
+                          How the deployment is served from the cluster edge to its
+                          engines. Unified (the default) fronts the engines with a
+                          Service. PrefillDecode serves prefill and decode from the two
+                          engines marking those phases, with inference-aware routing that
+                          sequences prefill then decode. Omitted means Unified.
+                        required: [mode]
+                        properties:
+                          mode:
+                            type: string
+                            enum: [Unified, PrefillDecode]
+                            default: Unified
                             description: >-
-                              The member's role in the engine. Standalone is a
-                              lone pod; a Leader coordinates and serves while its
-                              Workers join it. Defaults to Standalone.
-                            enum: [Standalone, Leader, Worker]
-                            default: Standalone
-                          nodeSelector:
-                            type: object
-                            description: >-
-                              The per-node device request for this member's
-                              pods: what devices each pod needs from its node.
-                              The scheduler matches it against a candidate
-                              pool's InferenceClass devices (surfaced on
-                              InferenceCluster status.gpuPools) and places the
-                              member on a pool that satisfies it, preferring
-                              one pool for the whole engine and splitting
-                              members across pools only when no pool satisfies
-                              them all. claim: DRA requests also become
-                              DeviceRequests in the ResourceClaim the member's
-                              pods bind GPUs through. A GPU request's count is
-                              the GPUs per node. Omitted, the member claims no
-                              devices and schedules onto its engine's pool - a
-                              coordinator-only leader. At least one member per
-                              engine must carry a nodeSelector, and at least
-                              one member's requests must resolve to a claimable
-                              (claim: DRA) device; an engine that
-                              matches only synthetic devices leaves its pods
-                              nothing to claim, so the scheduler treats such a
-                              pool as ineligible and the deployment reports
-                              InsufficientCapacity.
-                            required: [devices]
-                            properties:
-                              devices:
-                                type: array
-                                description: >-
-                                  Device requests. A pool matches a request when
-                                  it has a device whose count covers the request
-                                  and whose driver, attributes, and capacity
-                                  satisfy every selector.
-                                minItems: 1
-                                maxItems: 16
-                                x-kubernetes-list-type: map
-                                x-kubernetes-list-map-keys: [name]
-                                items:
-                                  type: object
-                                  required: [name, selectors]
-                                  properties:
-                                    name:
-                                      type: string
-                                      description: >-
-                                        Name of this request. Mirrors a DRA
-                                        DeviceRequest name; carried through to
-                                        the ResourceClaim.
-                                      minLength: 1
-                                      maxLength: 63
-                                    count:
-                                      type: integer
-                                      description: >-
-                                        How many matching devices a node must
-                                        have. For a GPU request this is the
-                                        per-node GPU count.
-                                      default: 1
-                                      minimum: 1
-                                      maximum: 64
-                                    selectors:
-                                      type: array
-                                      description: >-
-                                        Selectors a device must satisfy, all
-                                        ANDed. Each is a one-of; today only cel
-                                        is supported.
-                                      minItems: 1
-                                      maxItems: 8
-                                      x-kubernetes-list-type: atomic
-                                      items:
-                                        type: object
-                                        # A selector must carry at least one
-                                        # selector kind (today only cel). Without
-                                        # this an empty {} selector would match
-                                        # every device, and since nodeSelector is
-                                        # the only path to a GPU that silently
-                                        # claims an arbitrary one.
-                                        minProperties: 1
-                                        properties:
-                                          cel:
-                                            type: string
-                                            description: >-
-                                              A DRA CEL expression evaluated
-                                              against one device. Reads
-                                              device.driver,
-                                              device.attributes["<driver>"].<name>
-                                              (typed), and
-                                              device.capacity["<driver>"].<name>
-                                              (a Quantity), with quantity() and
-                                              semver() helpers, e.g.
-                                              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("141Gi")) >= 0.
-                                            minLength: 1
-                                            maxLength: 10240
-                          # This object has no schema default on purpose: the
-                          # apiserver applies defaults before CEL validation, so
-                          # defaulting it would inject it onto Standalone and
-                          # Leader members and trip the rule that forbids it
-                          # there.
-                          worker:
-                            type: object
-                            description: >-
-                              Settings for a Worker member. Valid only on a
-                              member whose role is Worker.
-                            required: [nodes]
-                            properties:
-                              nodes:
-                                type: integer
-                                description: >-
-                                  How many nodes this member spans - how big the
-                                  engine is. Each node runs one worker pod, so
-                                  the engine's gang spans 1 (the Leader) plus
-                                  this many worker pods. Defaults to 1.
-                                minimum: 1
-                                maximum: 63
-                          template:
-                            type: object
-                            description: >-
-                              Pod template for this member's engine pods. A
-                              curated subset of PodTemplateSpec.
-                            properties:
-                              metadata:
+                              Unified serves prefill and decode on one engine.
+                              PrefillDecode splits them across two engines, each marking
+                              its phase as Prefill or Decode.
+                      engines:
+                        type: array
+                        description: >-
+                          A ModelReplica's inference engines. An engine is one serving
+                          unit: a single Standalone pod, or a gang of a Leader and one
+                          or more Workers coordinating across nodes. Modelplane
+                          composes the whole array once per ModelReplica; an engine
+                          composes to a Deployment (Standalone) or a LeaderWorkerSet
+                          (Leader/Worker), but the workload kind is an implementation
+                          detail. Modelplane is unopinionated about the engine itself:
+                          parallelism, quantization, and KV transfer all live in the
+                          members' engine flags, written by the user, never injected by
+                          Modelplane.
+                        minItems: 1
+                        maxItems: 8
+                        x-kubernetes-list-type: map
+                        x-kubernetes-list-map-keys: [name]
+                        items:
+                          type: object
+                          required: [name, members]
+                          # An engine is exactly one Standalone member, or one Leader
+                          # and one or more Workers. No other combination of roles
+                          # forms a valid serving unit.
+                          x-kubernetes-validations:
+                          - rule: >-
+                              (self.members.size() == 1 && self.members[0].role == 'Standalone')
+                              || (self.members.exists_one(m, m.role == 'Leader')
+                                  && self.members.exists(m, m.role == 'Worker')
+                                  && !self.members.exists(m, m.role == 'Standalone'))
+                            message: >-
+                              an engine must be either a single Standalone member or one
+                              Leader and one or more Workers
+                          # nodeSelector is the only path to a GPU, so an engine where
+                          # no member carries one would deploy with no devices at all -
+                          # a mistake, not a deployment. A member may omit its own
+                          # selector (a coordinator-only leader claims nothing), but
+                          # some member must claim.
+                          - rule: "self.members.exists(m, has(m.nodeSelector))"
+                            message: >-
+                              at least one member of an engine must carry a nodeSelector
+                              requesting devices
+                          properties:
+                            name:
+                              type: string
+                              description: >-
+                                Identifies the engine within the deployment. Becomes
+                                part of the composed workload names, so it must be a
+                                DNS label.
+                              minLength: 1
+                              maxLength: 63
+                            copies:
+                              type: integer
+                              description: >-
+                                How many identical copies of this engine to run per
+                                ModelReplica. A fixed number, sized once per deployment;
+                                scaling happens by adding ModelReplicas
+                                (spec.replicas), never by varying copies. Maps to the
+                                composed Deployment's or LeaderWorkerSet's replica
+                                count. Defaults to 1.
+                              default: 1
+                              minimum: 1
+                              maximum: 64
+                            phase:
+                              type: string
+                              enum: [Prefill, Decode]
+                              description: >-
+                                The engine's phase in a PrefillDecode deployment,
+                                Prefill or Decode. Set only when serving.mode is
+                                PrefillDecode, where exactly one engine takes each phase.
+                            members:
+                              type: array
+                              description: >-
+                                The engine's pods. Either a single Standalone member,
+                                or one Leader and one or more Workers.
+                              minItems: 1
+                              maxItems: 2
+                              x-kubernetes-list-type: atomic
+                              items:
                                 type: object
-                                description: >-
-                                  Metadata applied to the member's pods. Useful
-                                  for labels and annotations that control
-                                  cluster-level features like service mesh
-                                  injection.
+                                required: [template]
+                                # worker is meaningful only for a Worker member: a
+                                # Standalone and a Leader are always exactly one pod on
+                                # one node.
+                                x-kubernetes-validations:
+                                - rule: "!has(self.worker) || self.role == 'Worker'"
+                                  message: "worker may only be set on a Worker member"
                                 properties:
-                                  labels:
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                                  annotations:
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                              spec:
-                                type: object
-                                required: [containers]
-                                description: >-
-                                  Pod spec for this member's engine pods.
-                                properties:
-                                  containers:
-                                    type: array
-                                    minItems: 1
-                                    maxItems: 1
+                                  role:
+                                    type: string
                                     description: >-
-                                      Containers for the engine pod. v0.1 supports
-                                      a single container, which must be named
-                                      "engine" (the inference engine). Sidecar /
-                                      multi-container support is tracked
-                                      separately.
-                                    x-kubernetes-validations:
-                                    - rule: "self.exists_one(c, c.name == 'engine')"
-                                      message: "the single container must be named 'engine'"
-                                    items:
-                                      type: object
-                                      required: [name, image]
-                                      properties:
-                                        name:
-                                          type: string
-                                          minLength: 1
-                                          description: >-
-                                            Container name. The container named
-                                            "engine" is the inference engine.
-                                        image:
-                                          type: string
-                                          minLength: 1
-                                          description: Container image.
-                                        command:
-                                          type: array
-                                          description: >-
-                                            Container entrypoint override, passed
-                                            through verbatim. For a Leader or
-                                            Worker, the command owns cross-node
-                                            coordination and addresses the leader
-                                            through $(MODELPLANE_LEADER_ADDRESS),
-                                            which Modelplane injects into every
-                                            engine container.
-                                          items:
-                                            type: string
-                                        args:
-                                          type: array
-                                          description: >-
-                                            Container args, passed through to the
-                                            serving engine. Includes the model
-                                            identifier (e.g. --model=...) and any
-                                            parallelism flags.
-                                          items:
-                                            type: string
-                                        env:
-                                          type: array
-                                          description: >-
-                                            Environment variables. Supports
-                                            valueFrom.secretKeyRef /
-                                            configMapKeyRef for secrets and
-                                            config (like HF_TOKEN), and
-                                            valueFrom.fieldRef for pod fields
-                                            (e.g. status.podIP for vLLM's
-                                            VLLM_HOST_IP on multi-NIC nodes).
-                                          items:
-                                            type: object
-                                            required: [name]
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                              valueFrom:
+                                      The member's role in the engine. Standalone is a
+                                      lone pod; a Leader coordinates and serves while its
+                                      Workers join it. Defaults to Standalone.
+                                    enum: [Standalone, Leader, Worker]
+                                    default: Standalone
+                                  nodeSelector:
+                                    type: object
+                                    description: >-
+                                      The per-node device request for this member's
+                                      pods: what devices each pod needs from its node.
+                                      The scheduler matches it against a candidate
+                                      pool's InferenceClass devices (surfaced on
+                                      InferenceCluster status.gpuPools) and places the
+                                      member on a pool that satisfies it, preferring
+                                      one pool for the whole engine and splitting
+                                      members across pools only when no pool satisfies
+                                      them all. claim: DRA requests also become
+                                      DeviceRequests in the ResourceClaim the member's
+                                      pods bind GPUs through. A GPU request's count is
+                                      the GPUs per node. Omitted, the member claims no
+                                      devices and schedules onto its engine's pool - a
+                                      coordinator-only leader. At least one member per
+                                      engine must carry a nodeSelector, and at least
+                                      one member's requests must resolve to a claimable
+                                      (claim: DRA) device; an engine that
+                                      matches only synthetic devices leaves its pods
+                                      nothing to claim, so the scheduler treats such a
+                                      pool as ineligible and the deployment reports
+                                      InsufficientCapacity.
+                                    required: [devices]
+                                    properties:
+                                      devices:
+                                        type: array
+                                        description: >-
+                                          Device requests. A pool matches a request when
+                                          it has a device whose count covers the request
+                                          and whose driver, attributes, and capacity
+                                          satisfy every selector.
+                                        minItems: 1
+                                        maxItems: 16
+                                        x-kubernetes-list-type: map
+                                        x-kubernetes-list-map-keys: [name]
+                                        items:
+                                          type: object
+                                          required: [name, selectors]
+                                          properties:
+                                            name:
+                                              type: string
+                                              description: >-
+                                                Name of this request. Mirrors a DRA
+                                                DeviceRequest name; carried through to
+                                                the ResourceClaim.
+                                              minLength: 1
+                                              maxLength: 63
+                                            count:
+                                              type: integer
+                                              description: >-
+                                                How many matching devices a node must
+                                                have. For a GPU request this is the
+                                                per-node GPU count.
+                                              default: 1
+                                              minimum: 1
+                                              maximum: 64
+                                            selectors:
+                                              type: array
+                                              description: >-
+                                                Selectors a device must satisfy, all
+                                                ANDed. Each is a one-of; today only cel
+                                                is supported.
+                                              minItems: 1
+                                              maxItems: 8
+                                              x-kubernetes-list-type: atomic
+                                              items:
                                                 type: object
+                                                # A selector must carry at least one
+                                                # selector kind (today only cel). Without
+                                                # this an empty {} selector would match
+                                                # every device, and since nodeSelector is
+                                                # the only path to a GPU that silently
+                                                # claims an arbitrary one.
+                                                minProperties: 1
                                                 properties:
-                                                  secretKeyRef:
-                                                    type: object
-                                                    required: [name, key]
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      key:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                  configMapKeyRef:
-                                                    type: object
-                                                    required: [name, key]
-                                                    properties:
-                                                      name:
-                                                        type: string
-                                                      key:
-                                                        type: string
-                                                      optional:
-                                                        type: boolean
-                                                  fieldRef:
-                                                    type: object
+                                                  cel:
+                                                    type: string
                                                     description: >-
-                                                      Reference a pod field via
-                                                      the downward API, e.g.
-                                                      status.podIP, metadata.name,
-                                                      or metadata.namespace.
-                                                    required: [fieldPath]
-                                                    properties:
-                                                      fieldPath:
-                                                        type: string
-                                                      apiVersion:
-                                                        type: string
-                                  imagePullSecrets:
-                                    type: array
+                                                      A DRA CEL expression evaluated
+                                                      against one device. Reads
+                                                      device.driver,
+                                                      device.attributes["<driver>"].<name>
+                                                      (typed), and
+                                                      device.capacity["<driver>"].<name>
+                                                      (a Quantity), with quantity() and
+                                                      semver() helpers, e.g.
+                                                      device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("141Gi")) >= 0.
+                                                    minLength: 1
+                                                    maxLength: 10240
+                                  # This object has no schema default on purpose: the
+                                  # apiserver applies defaults before CEL validation, so
+                                  # defaulting it would inject it onto Standalone and
+                                  # Leader members and trip the rule that forbids it
+                                  # there.
+                                  worker:
+                                    type: object
                                     description: >-
-                                      Image pull secrets for private registries
-                                      (NGC etc.).
-                                    items:
-                                      type: object
-                                      required: [name]
-                                      properties:
-                                        name:
-                                          type: string
+                                      Settings for a Worker member. Valid only on a
+                                      member whose role is Worker.
+                                    required: [nodes]
+                                    properties:
+                                      nodes:
+                                        type: integer
+                                        description: >-
+                                          How many nodes this member spans - how big the
+                                          engine is. Each node runs one worker pod, so
+                                          the engine's gang spans 1 (the Leader) plus
+                                          this many worker pods. Defaults to 1.
+                                        minimum: 1
+                                        maximum: 63
+                                  template:
+                                    type: object
+                                    description: >-
+                                      Pod template for this member's engine pods. A
+                                      curated subset of PodTemplateSpec.
+                                    properties:
+                                      metadata:
+                                        type: object
+                                        description: >-
+                                          Metadata applied to the member's pods. Useful
+                                          for labels and annotations that control
+                                          cluster-level features like service mesh
+                                          injection.
+                                        properties:
+                                          labels:
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          annotations:
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        type: object
+                                        required: [containers]
+                                        description: >-
+                                          Pod spec for this member's engine pods.
+                                        properties:
+                                          containers:
+                                            type: array
+                                            minItems: 1
+                                            maxItems: 1
+                                            description: >-
+                                              Containers for the engine pod. v0.1 supports
+                                              a single container, which must be named
+                                              "engine" (the inference engine). Sidecar /
+                                              multi-container support is tracked
+                                              separately.
+                                            x-kubernetes-validations:
+                                            - rule: "self.exists_one(c, c.name == 'engine')"
+                                              message: "the single container must be named 'engine'"
+                                            items:
+                                              type: object
+                                              required: [name, image]
+                                              properties:
+                                                name:
+                                                  type: string
+                                                  minLength: 1
+                                                  description: >-
+                                                    Container name. The container named
+                                                    "engine" is the inference engine.
+                                                image:
+                                                  type: string
+                                                  minLength: 1
+                                                  description: Container image.
+                                                command:
+                                                  type: array
+                                                  description: >-
+                                                    Container entrypoint override, passed
+                                                    through verbatim. For a Leader or
+                                                    Worker, the command owns cross-node
+                                                    coordination and addresses the leader
+                                                    through $(MODELPLANE_LEADER_ADDRESS),
+                                                    which Modelplane injects into every
+                                                    engine container.
+                                                  items:
+                                                    type: string
+                                                args:
+                                                  type: array
+                                                  description: >-
+                                                    Container args, passed through to the
+                                                    serving engine. Includes the model
+                                                    identifier (e.g. --model=...) and any
+                                                    parallelism flags.
+                                                  items:
+                                                    type: string
+                                                env:
+                                                  type: array
+                                                  description: >-
+                                                    Environment variables. Supports
+                                                    valueFrom.secretKeyRef /
+                                                    configMapKeyRef for secrets and
+                                                    config (like HF_TOKEN), and
+                                                    valueFrom.fieldRef for pod fields
+                                                    (e.g. status.podIP for vLLM's
+                                                    VLLM_HOST_IP on multi-NIC nodes).
+                                                  items:
+                                                    type: object
+                                                    required: [name]
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                      valueFrom:
+                                                        type: object
+                                                        properties:
+                                                          secretKeyRef:
+                                                            type: object
+                                                            required: [name, key]
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              key:
+                                                                type: string
+                                                              optional:
+                                                                type: boolean
+                                                          configMapKeyRef:
+                                                            type: object
+                                                            required: [name, key]
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              key:
+                                                                type: string
+                                                              optional:
+                                                                type: boolean
+                                                          fieldRef:
+                                                            type: object
+                                                            description: >-
+                                                              Reference a pod field via
+                                                              the downward API, e.g.
+                                                              status.podIP, metadata.name,
+                                                              or metadata.namespace.
+                                                            required: [fieldPath]
+                                                            properties:
+                                                              fieldPath:
+                                                                type: string
+                                                              apiVersion:
+                                                                type: string
+                                          imagePullSecrets:
+                                            type: array
+                                            description: >-
+                                              Image pull secrets for private registries
+                                              (NGC etc.).
+                                            items:
+                                              type: object
+                                              required: [name]
+                                              properties:
+                                                name:
+                                                  type: string
           status:
             type: object
             properties:

--- a/docs/content/models/model-cache.md
+++ b/docs/content/models/model-cache.md
@@ -7,9 +7,10 @@ description: Stage model weights on cluster storage before serving.
 **API:** [`modelplane.ai/v1alpha1` · ModelCache]({{< ref "/reference/modelcaches" >}})
 
 A `ModelCache` stages a model's weights on shared workload-cluster storage,
-fetched once from the configured source rather than downloaded again on every pod
-start. `ModelDeployments` reference a cache via `spec.modelCacheRef.name`, and
-Modelplane mounts it at `/mnt/models` in every serving pod, shared across the
+fetched once from the configured source rather than downloaded again on every
+pod start. `ModelDeployments` reference a cache via
+`spec.template.spec.modelCacheRef.name`, and Modelplane mounts it at
+`/mnt/models` in every serving pod, shared across the
 pods of a multi-node engine. The engine reads weights locally from the mount.
 
 `ModelCache` is recommended for multi-node deployments and optional for

--- a/docs/content/models/model-deployment.md
+++ b/docs/content/models/model-deployment.md
@@ -15,13 +15,17 @@ its flags, and Modelplane shapes a serving topology around it. The engine flags
 you write carry parallelism, quantization, and KV transfer, never injected by
 Modelplane.
 
-A deployment's `spec.engines` describes its topology through two choices:
+A deployment's replica shape lives under `spec.template` (mirroring a
+Kubernetes Deployment): the replica count is `spec.replicas`, labels for the
+composed ModelReplicas and ModelEndpoints go on `spec.template.metadata.labels`,
+and everything else lives in `spec.template.spec`. Its
+`spec.template.spec.engines` array describes the topology through two choices:
 
 - **One pod or a gang**: whether an engine is a single `Standalone` pod or a
   `Leader` with one or more `Worker` pods coordinating across nodes.
-- **Unified or disaggregated**: whether `spec.serving.mode` keeps prefill and
-  decode together (`Unified`, the default) or splits them across two engines
-  (`PrefillDecode`).
+- **Unified or disaggregated**: whether `spec.template.spec.serving.mode` keeps
+  prefill and decode together (`Unified`, the default) or splits them across two
+  engines (`PrefillDecode`).
 
 How many of each to run is a separate question, covered in
 [Sizing a deployment](#sizing-a-deployment).
@@ -49,8 +53,8 @@ node. The pods serve the model together; how the model splits across them
 (tensor, pipeline, data, or expert parallelism) is up to your engine flags.
 
 A gang should use a [`ModelCache`]({{< ref "model-cache.md" >}}) via
-`spec.modelCacheRef`, so every pod mounts the same weights instead of each
-pulling its own.
+`spec.template.spec.modelCacheRef`, so every pod mounts the same weights instead
+of each pulling its own.
 
 ```yaml {nocopy=true}
 modelCacheRef:
@@ -72,10 +76,10 @@ engine binds the right interface instead of guessing it.
 
 The prefill and decode phases have opposite hardware profiles, and on one engine
 a prefill burst stalls the decodes already running. Set
-`spec.serving.mode: PrefillDecode` to run them as two engines, one marking
-`phase: Prefill` and the other `phase: Decode`. Modelplane fronts the pair with
-inference-aware routing that sequences prefill then decode, moving the KV cache
-between them. Each phase can sit on the GPU class that suits it.
+`spec.template.spec.serving.mode: PrefillDecode` to run them as two engines, one
+marking `phase: Prefill` and the other `phase: Decode`. Modelplane fronts the
+pair with inference-aware routing that sequences prefill then decode, moving the
+KV cache between them. Each phase can sit on the GPU class that suits it.
 
 ```yaml {nocopy=true}
 serving:

--- a/docs/manifests/concepts/model-deployment-multinode.yaml
+++ b/docs/manifests/concepts/model-deployment-multinode.yaml
@@ -21,62 +21,64 @@ metadata:
   namespace: ml-team
 spec:
   replicas: 1
-  modelCacheRef:
-    name: qwen3-coder
-  engines:
-  - name: qwen3-coder
-    members:
-    - role: Leader
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 8
-          selectors:
-          - cel: |
-              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("120Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            command:
-            - /bin/sh
-            - -c
-            - >-
-              exec vllm serve /mnt/models
-              --served-model-name=qwen3-coder
-              --tensor-parallel-size=8
-              --pipeline-parallel-size=2
-              --distributed-executor-backend=mp
-              --nnodes=2 --node-rank=0
-              --master-addr=$(MODELPLANE_LEADER_ADDRESS)
-              --max-model-len=32768
-              --port=8000
-    - role: Worker
-      worker:
-        nodes: 1
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 8
-          selectors:
-          - cel: |
-              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("120Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            command:
-            - /bin/sh
-            - -c
-            - >-
-              exec vllm serve /mnt/models
-              --served-model-name=qwen3-coder
-              --tensor-parallel-size=8
-              --pipeline-parallel-size=2
-              --distributed-executor-backend=mp
-              --nnodes=2 --node-rank=1
-              --master-addr=$(MODELPLANE_LEADER_ADDRESS)
-              --headless
-              --max-model-len=32768
+  template:
+    spec:
+      modelCacheRef:
+        name: qwen3-coder
+      engines:
+      - name: qwen3-coder
+        members:
+        - role: Leader
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 8
+              selectors:
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("120Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                command:
+                - /bin/sh
+                - -c
+                - >-
+                  exec vllm serve /mnt/models
+                  --served-model-name=qwen3-coder
+                  --tensor-parallel-size=8
+                  --pipeline-parallel-size=2
+                  --distributed-executor-backend=mp
+                  --nnodes=2 --node-rank=0
+                  --master-addr=$(MODELPLANE_LEADER_ADDRESS)
+                  --max-model-len=32768
+                  --port=8000
+        - role: Worker
+          worker:
+            nodes: 1
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 8
+              selectors:
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("120Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                command:
+                - /bin/sh
+                - -c
+                - >-
+                  exec vllm serve /mnt/models
+                  --served-model-name=qwen3-coder
+                  --tensor-parallel-size=8
+                  --pipeline-parallel-size=2
+                  --distributed-executor-backend=mp
+                  --nnodes=2 --node-rank=1
+                  --master-addr=$(MODELPLANE_LEADER_ADDRESS)
+                  --headless
+                  --max-model-len=32768

--- a/docs/manifests/concepts/model-deployment.yaml
+++ b/docs/manifests/concepts/model-deployment.yaml
@@ -23,13 +23,15 @@ spec:
   # Engines are an array of inference engines. This model is one engine, one
   # Standalone member, one pod - the simplest shape. The engine composes to a
   # Deployment fronted by a Service.
-  engines:
-  - name: qwen3-8b
-    members:
+  template:
+    spec:
+      engines:
+      - name: qwen3-8b
+        members:
     # A Standalone member is a single self-contained engine pod. Its template
     # carries the container named "engine" - the inference engine; its image,
     # command, and args pass through verbatim.
-    - role: Standalone
+        - role: Standalone
       # The member's per-node device request: a list of DRA device requests
       # describing what each of the member's pods needs from its node. The
       # scheduler matches each against a candidate pool's InferenceClass
@@ -38,27 +40,27 @@ spec:
       # semver() are helpers. claim: DRA devices also become requests in the
       # DRA ResourceClaim the serving pods claim GPUs through, so an engine
       # must declare the GPUs it needs.
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 1
-          selectors:
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 1
+              selectors:
           # Qwen3-8B fits comfortably on an L4; 20Gi selects one without
           # over-constraining. A larger model would ask for more memory or a
           # specific architecture here. This CEL is real DRA CEL: the scheduler
           # matches it against the pool's declared device, and DRA matches it
           # again against the GPU's ResourceSlice when it binds the claim.
-          - cel: |
-              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            args:
-            - "--model=Qwen/Qwen3-8B"
-            - "--served-model-name=qwen"
-            - "--reasoning-parser=qwen3"
-            - "--default-chat-template-kwargs={\"enable_thinking\": false}"
-            - "--enable-auto-tool-choice"
-            - "--tool-call-parser=hermes"
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                args:
+                - "--model=Qwen/Qwen3-8B"
+                - "--served-model-name=qwen"
+                - "--reasoning-parser=qwen3"
+                - "--default-chat-template-kwargs={\"enable_thinking\": false}"
+                - "--enable-auto-tool-choice"
+                - "--tool-call-parser=hermes"

--- a/docs/manifests/examples/collecting-engine-metrics/model-deployment.yaml
+++ b/docs/manifests/examples/collecting-engine-metrics/model-deployment.yaml
@@ -22,29 +22,31 @@ metadata:
 spec:
   # One replica, matched to any compatible InferenceCluster by device capacity.
   replicas: 1
-  engines:
-  - name: qwen2-5-0-5b
-    members:
+  template:
+    spec:
+      engines:
+      - name: qwen2-5-0-5b
+        members:
     # A single self-contained vLLM pod. The container named "engine" is the
     # inference server; its image and args pass through verbatim.
-    - role: Standalone
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 1
-          selectors:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 1
+              selectors:
           # The model needs almost no VRAM; >=20Gi simply pins it to the L4 pool
           # this example provisions (the L4 reports ~23Gi). DRA evaluates this CEL
           # against the InferenceClass device, then against the GPU's
           # ResourceSlice when it binds the claim.
-          - cel: |
-              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            args:
-            - "--model=Qwen/Qwen2.5-0.5B-Instruct"
-            - "--served-model-name=qwen2.5-0.5b"
-            - "--max-model-len=16384"
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                args:
+                - "--model=Qwen/Qwen2.5-0.5B-Instruct"
+                - "--served-model-name=qwen2.5-0.5b"
+                - "--max-model-len=16384"

--- a/docs/manifests/examples/glm-4.5-air/model-deployment.yaml
+++ b/docs/manifests/examples/glm-4.5-air/model-deployment.yaml
@@ -16,33 +16,35 @@ metadata:
   namespace: ml-team
 spec:
   replicas: 1
-  engines:
-  - name: glm
-    members:
-    - role: Standalone
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 1
-          selectors:
-          - cel: |
-              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("35Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: ghcr.io/ggml-org/llama.cpp:server-cuda
-            args:
-            - "-hf"
-            - "unsloth/GLM-4.5-Air-GGUF:IQ4_XS"
-            - "--host"
-            - "0.0.0.0"
-            - "--port"
-            - "8000"
-            - "-ngl"
-            - "999"
-            - "--n-cpu-moe"
-            - "99"
-            - "--jinja"
-            - "-c"
-            - "8192"
+  template:
+    spec:
+      engines:
+      - name: glm
+        members:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 1
+              selectors:
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("35Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: ghcr.io/ggml-org/llama.cpp:server-cuda
+                args:
+                - "-hf"
+                - "unsloth/GLM-4.5-Air-GGUF:IQ4_XS"
+                - "--host"
+                - "0.0.0.0"
+                - "--port"
+                - "8000"
+                - "-ngl"
+                - "999"
+                - "--n-cpu-moe"
+                - "99"
+                - "--jinja"
+                - "-c"
+                - "8192"

--- a/docs/manifests/examples/kimi-k2/model-deployment.yaml
+++ b/docs/manifests/examples/kimi-k2/model-deployment.yaml
@@ -25,94 +25,96 @@ metadata:
   namespace: ml-team
 spec:
   replicas: 1
-  modelCacheRef:
-    name: kimi-k2
-  serving:
-    mode: PrefillDecode            # the two engines below are one P/D pair
-  engines:
-  - name: kimi-prefill
-    phase: Prefill
-    members:
-    - role: Standalone
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 8
-          selectors:
-          - cel: |
-              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("130Gi")) >= 0
-        - name: efa
-          count: 16
-          selectors:
-          - cel: |
-              device.driver == "dra.net"
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            command: ["vllm", "serve", "/mnt/models"]
-            args:
-            - --served-model-name=kimi-k2
-            - --quantization=compressed-tensors
-            - --tensor-parallel-size=1
-            - --data-parallel-size=8
-            - --enable-expert-parallel
-            - --block-size=64
-            - --max-model-len=131072
-            - --trust-remote-code
-            - --tool-call-parser=kimi_k2
-            - --enable-auto-tool-choice
-            - --load-format=runai_streamer
-            - --model-loader-extra-config={"concurrency":16,"distributed":true}
-            - --tokenizer=moonshotai/Kimi-K2-Instruct
-            - --override-generation-config={"eos_token_id":163586}
-            - --port=8000
-            - --kv-transfer-config={"kv_connector":"NixlConnector","kv_role":"kv_producer"}
-            env:
-            - name: HF_TOKEN
-              valueFrom:
-                secretKeyRef: { name: hf-token, key: HF_TOKEN }
-  - name: kimi-decode
-    phase: Decode
-    members:
-    - role: Standalone
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 8
-          selectors:
-          - cel: |
-              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("130Gi")) >= 0
-        - name: efa
-          count: 16
-          selectors:
-          - cel: |
-              device.driver == "dra.net"
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            command: ["vllm", "serve", "/mnt/models"]
-            args:
-            - --served-model-name=kimi-k2
-            - --quantization=compressed-tensors
-            - --tensor-parallel-size=1
-            - --data-parallel-size=8
-            - --enable-expert-parallel
-            - --block-size=64
-            - --max-model-len=131072
-            - --trust-remote-code
-            - --tool-call-parser=kimi_k2
-            - --enable-auto-tool-choice
-            - --load-format=runai_streamer
-            - --model-loader-extra-config={"concurrency":16,"distributed":true}
-            - --tokenizer=moonshotai/Kimi-K2-Instruct
-            - --override-generation-config={"eos_token_id":163586}
-            - --port=8001                                      # pd-sidecar owns 8000
-            - --kv-transfer-config={"kv_connector":"NixlConnector","kv_role":"kv_consumer"}
-            env:
-            - name: HF_TOKEN
-              valueFrom:
-                secretKeyRef: { name: hf-token, key: HF_TOKEN }
+  template:
+    spec:
+      modelCacheRef:
+        name: kimi-k2
+      serving:
+        mode: PrefillDecode        # the two engines below are one P/D pair
+      engines:
+      - name: kimi-prefill
+        phase: Prefill
+        members:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 8
+              selectors:
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("130Gi")) >= 0
+            - name: efa
+              count: 16
+              selectors:
+              - cel: |
+                  device.driver == "dra.net"
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                command: ["vllm", "serve", "/mnt/models"]
+                args:
+                - --served-model-name=kimi-k2
+                - --quantization=compressed-tensors
+                - --tensor-parallel-size=1
+                - --data-parallel-size=8
+                - --enable-expert-parallel
+                - --block-size=64
+                - --max-model-len=131072
+                - --trust-remote-code
+                - --tool-call-parser=kimi_k2
+                - --enable-auto-tool-choice
+                - --load-format=runai_streamer
+                - --model-loader-extra-config={"concurrency":16,"distributed":true}
+                - --tokenizer=moonshotai/Kimi-K2-Instruct
+                - --override-generation-config={"eos_token_id":163586}
+                - --port=8000
+                - --kv-transfer-config={"kv_connector":"NixlConnector","kv_role":"kv_producer"}
+                env:
+                - name: HF_TOKEN
+                  valueFrom:
+                    secretKeyRef: {name: hf-token, key: HF_TOKEN}
+      - name: kimi-decode
+        phase: Decode
+        members:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 8
+              selectors:
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("130Gi")) >= 0
+            - name: efa
+              count: 16
+              selectors:
+              - cel: |
+                  device.driver == "dra.net"
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                command: ["vllm", "serve", "/mnt/models"]
+                args:
+                - --served-model-name=kimi-k2
+                - --quantization=compressed-tensors
+                - --tensor-parallel-size=1
+                - --data-parallel-size=8
+                - --enable-expert-parallel
+                - --block-size=64
+                - --max-model-len=131072
+                - --trust-remote-code
+                - --tool-call-parser=kimi_k2
+                - --enable-auto-tool-choice
+                - --load-format=runai_streamer
+                - --model-loader-extra-config={"concurrency":16,"distributed":true}
+                - --tokenizer=moonshotai/Kimi-K2-Instruct
+                - --override-generation-config={"eos_token_id":163586}
+                - --port=8001                                  # pd-sidecar owns 8000
+                - --kv-transfer-config={"kv_connector":"NixlConnector","kv_role":"kv_consumer"}
+                env:
+                - name: HF_TOKEN
+                  valueFrom:
+                    secretKeyRef: {name: hf-token, key: HF_TOKEN}

--- a/docs/manifests/examples/llama-3.1-8b/model-deployment.yaml
+++ b/docs/manifests/examples/llama-3.1-8b/model-deployment.yaml
@@ -21,31 +21,33 @@ metadata:
 spec:
   # One replica, matched to any compatible InferenceCluster by device capacity.
   replicas: 1
-  engines:
-  - name: llama
-    members:
+  template:
+    spec:
+      engines:
+      - name: llama
+        members:
     # A single self-contained vLLM pod. The container named "engine" is the
     # inference server; its image and args pass through verbatim.
-    - role: Standalone
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 1
-          selectors:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 1
+              selectors:
           # An 8B model needs most of an L4. >=20Gi selects the L4 (which
           # reports ~23Gi) without over-constraining. DRA evaluates this CEL
           # against the InferenceClass device, then against the GPU's
           # ResourceSlice when it binds the claim.
-          - cel: |
-              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.7.3
-            args:
-            - "--model=NousResearch/Meta-Llama-3.1-8B-Instruct"
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.7.3
+                args:
+                - "--model=NousResearch/Meta-Llama-3.1-8B-Instruct"
             # The id clients pass as "model" in OpenAI requests.
-            - "--served-model-name=llama-3.1-8b"
+                - "--served-model-name=llama-3.1-8b"
             # Cap the context so the KV cache fits beside the weights on the L4.
-            - "--max-model-len=8192"
+                - "--max-model-len=8192"

--- a/docs/manifests/examples/qwen3-8b-speculative-decoding/model-deployment.yaml
+++ b/docs/manifests/examples/qwen3-8b-speculative-decoding/model-deployment.yaml
@@ -35,35 +35,37 @@ metadata:
 spec:
   # One replica, matched to any compatible InferenceCluster by device capacity.
   replicas: 1
-  engines:
-  - name: qwen3-8b-spec
-    members:
+  template:
+    spec:
+      engines:
+      - name: qwen3-8b-spec
+        members:
     # A single self-contained vLLM pod. The container named "engine" is the
     # inference server; its image and args pass through verbatim.
-    - role: Standalone
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 1
-          selectors:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 1
+              selectors:
           # An 8B model needs most of an L4. >=20Gi selects the L4 (which reports
           # ~23Gi) without over-constraining. DRA evaluates this CEL against the
           # InferenceClass device, then against the GPU's ResourceSlice on bind.
-          - cel: |
-              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            args:
-            - "--model=Qwen/Qwen3-8B"
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                args:
+                - "--model=Qwen/Qwen3-8B"
             # The id clients pass as "model" in OpenAI requests.
-            - "--served-model-name=qwen3-8b-spec"
+                - "--served-model-name=qwen3-8b-spec"
             # Cap the context so the KV cache fits beside the weights on the L4.
-            - "--max-model-len=16384"
-            - "--gpu-memory-utilization=0.92"
+                - "--max-model-len=16384"
+                - "--gpu-memory-utilization=0.92"
             # Enable n-gram speculative decoding (no draft model, no cache).
-            - "--speculative-config={\"method\": \"ngram\", \"num_speculative_tokens\": 5, \"prompt_lookup_max\": 4, \"prompt_lookup_min\": 2}"
+                - "--speculative-config={\"method\": \"ngram\", \"num_speculative_tokens\": 5, \"prompt_lookup_max\": 4, \"prompt_lookup_min\": 2}"
             # Thinking off, so output copies the prompt and prompt-lookup pays off.
-            - "--default-chat-template-kwargs={\"enable_thinking\": false}"
+                - "--default-chat-template-kwargs={\"enable_thinking\": false}"

--- a/docs/manifests/examples/qwen3-8b/model-deployment.yaml
+++ b/docs/manifests/examples/qwen3-8b/model-deployment.yaml
@@ -23,31 +23,33 @@ metadata:
   namespace: ml-team
 spec:
   replicas: 1
-  clusterSelector:
-    matchLabels:
-      modelplane.ai/region: us
-  engines:
-  - name: qwen3-8b
-    members:
-    - role: Standalone
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 1
-          selectors:
-          - cel: |
-              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            args:
-            - "--model=Qwen/Qwen3-8B"
-            - "--served-model-name=qwen"
-            - "--max-model-len=16384"
-            - "--gpu-memory-utilization=0.92"
-            - "--reasoning-parser=qwen3"
-            - "--default-chat-template-kwargs={\"enable_thinking\": false}"
-            - "--enable-auto-tool-choice"
-            - "--tool-call-parser=hermes"
+  template:
+    spec:
+      clusterSelector:
+        matchLabels:
+          modelplane.ai/region: us
+      engines:
+      - name: qwen3-8b
+        members:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 1
+              selectors:
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                args:
+                - "--model=Qwen/Qwen3-8B"
+                - "--served-model-name=qwen"
+                - "--max-model-len=16384"
+                - "--gpu-memory-utilization=0.92"
+                - "--reasoning-parser=qwen3"
+                - "--default-chat-template-kwargs={\"enable_thinking\": false}"
+                - "--enable-auto-tool-choice"
+                - "--tool-call-parser=hermes"

--- a/docs/manifests/examples/qwen3-coder/model-deployment-fp8.yaml
+++ b/docs/manifests/examples/qwen3-coder/model-deployment-fp8.yaml
@@ -23,37 +23,39 @@ metadata:
   namespace: ml-team
 spec:
   replicas: 1
-  clusterSelector:
-    matchLabels:
-      modelplane.ai/region: us
-  engines:
-  - name: qwen3-coder-sgl
-    members:
-    - role: Standalone
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 8
-          selectors:
-          - cel: |
-              device.driver == "gpu.nvidia.com" && device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("120Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: lmsysorg/sglang:v0.5.10.post1-runtime
-            command:
-            - /bin/sh
-            - -c
-            - >-
-              exec python3 -m sglang.launch_server
-              --model-path Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8
-              --served-model-name qwen3-coder
-              --tp-size 8
-              --ep-size 8
-              --context-length 32768
-              --page-size 32
-              --trust-remote-code
-              --tool-call-parser qwen3_coder
-              --host 0.0.0.0
-              --port 8000
+  template:
+    spec:
+      clusterSelector:
+        matchLabels:
+          modelplane.ai/region: us
+      engines:
+      - name: qwen3-coder-sgl
+        members:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 8
+              selectors:
+              - cel: |
+                  device.driver == "gpu.nvidia.com" && device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("120Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: lmsysorg/sglang:v0.5.10.post1-runtime
+                command:
+                - /bin/sh
+                - -c
+                - >-
+                  exec python3 -m sglang.launch_server
+                  --model-path Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8
+                  --served-model-name qwen3-coder
+                  --tp-size 8
+                  --ep-size 8
+                  --context-length 32768
+                  --page-size 32
+                  --trust-remote-code
+                  --tool-call-parser qwen3_coder
+                  --host 0.0.0.0
+                  --port 8000

--- a/docs/manifests/examples/qwen3-coder/model-deployment.yaml
+++ b/docs/manifests/examples/qwen3-coder/model-deployment.yaml
@@ -28,89 +28,91 @@ metadata:
   namespace: ml-team
 spec:
   replicas: 1
-  clusterSelector:
-    matchLabels:
-      modelplane.ai/region: us
-  modelCacheRef:
-    name: qwen3-coder
-  engines:
-  - name: qwen3-coder
-    members:
-    - role: Leader
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 8
-          selectors:
-          - cel: |
-              device.driver == "gpu.nvidia.com" && device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("120Gi")) >= 0
-        - name: efa
-          count: 16
-          selectors:
-          - cel: |
-              device.driver == "dra.net"
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            env:
-            - name: NCCL_DEBUG
-              value: "INFO"
-            - name: FI_PROVIDER
-              value: "efa"
-            command:
-            - /bin/sh
-            - -c
-            - >-
-              exec vllm serve /mnt/models
-              --served-model-name=qwen3-coder
-              --tensor-parallel-size=8
-              --pipeline-parallel-size=2
-              --distributed-executor-backend=mp
-              --nnodes=2 --node-rank=0
-              --master-addr=$(MODELPLANE_LEADER_ADDRESS)
-              --max-model-len=32768
-              --gpu-memory-utilization=0.92
-              --enable-auto-tool-choice
-              --tool-call-parser=qwen3_xml
-              --port=8000
-    - role: Worker
-      worker:
-        nodes: 1
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 8
-          selectors:
-          - cel: |
-              device.driver == "gpu.nvidia.com" && device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("120Gi")) >= 0
-        - name: efa
-          count: 16
-          selectors:
-          - cel: |
-              device.driver == "dra.net"
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            env:
-            - name: NCCL_DEBUG
-              value: "INFO"
-            - name: FI_PROVIDER
-              value: "efa"
-            command:
-            - /bin/sh
-            - -c
-            - >-
-              exec vllm serve /mnt/models
-              --served-model-name=qwen3-coder
-              --tensor-parallel-size=8
-              --pipeline-parallel-size=2
-              --distributed-executor-backend=mp
-              --nnodes=2 --node-rank=1
-              --master-addr=$(MODELPLANE_LEADER_ADDRESS)
-              --headless
-              --max-model-len=32768
-              --gpu-memory-utilization=0.92
+  template:
+    spec:
+      clusterSelector:
+        matchLabels:
+          modelplane.ai/region: us
+      modelCacheRef:
+        name: qwen3-coder
+      engines:
+      - name: qwen3-coder
+        members:
+        - role: Leader
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 8
+              selectors:
+              - cel: |
+                  device.driver == "gpu.nvidia.com" && device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("120Gi")) >= 0
+            - name: efa
+              count: 16
+              selectors:
+              - cel: |
+                  device.driver == "dra.net"
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                env:
+                - name: NCCL_DEBUG
+                  value: "INFO"
+                - name: FI_PROVIDER
+                  value: "efa"
+                command:
+                - /bin/sh
+                - -c
+                - >-
+                  exec vllm serve /mnt/models
+                  --served-model-name=qwen3-coder
+                  --tensor-parallel-size=8
+                  --pipeline-parallel-size=2
+                  --distributed-executor-backend=mp
+                  --nnodes=2 --node-rank=0
+                  --master-addr=$(MODELPLANE_LEADER_ADDRESS)
+                  --max-model-len=32768
+                  --gpu-memory-utilization=0.92
+                  --enable-auto-tool-choice
+                  --tool-call-parser=qwen3_xml
+                  --port=8000
+        - role: Worker
+          worker:
+            nodes: 1
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 8
+              selectors:
+              - cel: |
+                  device.driver == "gpu.nvidia.com" && device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("120Gi")) >= 0
+            - name: efa
+              count: 16
+              selectors:
+              - cel: |
+                  device.driver == "dra.net"
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                env:
+                - name: NCCL_DEBUG
+                  value: "INFO"
+                - name: FI_PROVIDER
+                  value: "efa"
+                command:
+                - /bin/sh
+                - -c
+                - >-
+                  exec vllm serve /mnt/models
+                  --served-model-name=qwen3-coder
+                  --tensor-parallel-size=8
+                  --pipeline-parallel-size=2
+                  --distributed-executor-backend=mp
+                  --nnodes=2 --node-rank=1
+                  --master-addr=$(MODELPLANE_LEADER_ADDRESS)
+                  --headless
+                  --max-model-len=32768
+                  --gpu-memory-utilization=0.92

--- a/docs/manifests/getting-started/eks/model-deployment-west.yaml
+++ b/docs/manifests/getting-started/eks/model-deployment-west.yaml
@@ -10,26 +10,28 @@ spec:
   replicas: 1
   # clusterSelector filters which InferenceClusters this deployment can land on.
   # This pins the replica to the us-west cluster you added in "Scale the fleet".
-  clusterSelector:
-    matchLabels:
-      modelplane.ai/region: us-west
-  engines:
-  - name: qwen
-    members:
-    - role: Standalone
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 1
-          selectors:
+  template:
+    spec:
+      clusterSelector:
+        matchLabels:
+          modelplane.ai/region: us-west
+      engines:
+      - name: qwen
+        members:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 1
+              selectors:
           # L40S (46068Mi) qualifies; L4 (23034Mi) does not.
-          - cel: |
-              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("40Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            args:
-            - --model=Qwen/Qwen2.5-0.5B-Instruct
-            - --dtype=half
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("40Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                args:
+                - --model=Qwen/Qwen2.5-0.5B-Instruct
+                - --dtype=half

--- a/docs/manifests/getting-started/eks/model-deployment.yaml
+++ b/docs/manifests/getting-started/eks/model-deployment.yaml
@@ -5,24 +5,26 @@ metadata:
   namespace: ml-team
 spec:
   replicas: 1
-  engines:
-  - name: qwen
-    members:
-    - role: Standalone
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 1
-          selectors:
+  template:
+    spec:
+      engines:
+      - name: qwen
+        members:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 1
+              selectors:
           # Any L4 satisfies >= 20Gi. The selector matches against the capacity
           # declared in the InferenceClass, not the pod's resource requests.
-          - cel: |
-              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            args:
-            - --model=Qwen/Qwen2.5-0.5B-Instruct
-            - --dtype=half
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                args:
+                - --model=Qwen/Qwen2.5-0.5B-Instruct
+                - --dtype=half

--- a/docs/manifests/getting-started/gke/model-deployment-west.yaml
+++ b/docs/manifests/getting-started/gke/model-deployment-west.yaml
@@ -10,27 +10,29 @@ spec:
   replicas: 1
   # clusterSelector filters which InferenceClusters this deployment can land on.
   # This pins the replica to the us-west cluster you added in "Scale the fleet".
-  clusterSelector:
-    matchLabels:
-      modelplane.ai/region: us-west
-  engines:
-  - name: qwen
-    members:
-    - role: Standalone
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 1
-          selectors:
+  template:
+    spec:
+      clusterSelector:
+        matchLabels:
+          modelplane.ai/region: us-west
+      engines:
+      - name: qwen
+        members:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 1
+              selectors:
           # A100 40GB (40960Mi) qualifies; L4 (23034Mi) does not.
           # Threshold at 35Gi not 40Gi to avoid the boundary on A100's exact reported VRAM.
-          - cel: |
-              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("35Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            args:
-            - --model=Qwen/Qwen2.5-0.5B-Instruct
-            - --dtype=half
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("35Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                args:
+                - --model=Qwen/Qwen2.5-0.5B-Instruct
+                - --dtype=half

--- a/docs/manifests/getting-started/gke/model-deployment.yaml
+++ b/docs/manifests/getting-started/gke/model-deployment.yaml
@@ -5,24 +5,26 @@ metadata:
   namespace: ml-team
 spec:
   replicas: 1
-  engines:
-  - name: qwen
-    members:
-    - role: Standalone
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 1
-          selectors:
+  template:
+    spec:
+      engines:
+      - name: qwen
+        members:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 1
+              selectors:
           # Any L4 satisfies >= 20Gi. The selector matches against the capacity
           # declared in the InferenceClass, not the pod's resource requests.
-          - cel: |
-              device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            args:
-            - --model=Qwen/Qwen2.5-0.5B-Instruct
-            - --dtype=half
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                args:
+                - --model=Qwen/Qwen2.5-0.5B-Instruct
+                - --dtype=half

--- a/docs/manifests/overview/model-deployment.yaml
+++ b/docs/manifests/overview/model-deployment.yaml
@@ -5,19 +5,21 @@ metadata:
   namespace: ml-team
 spec:
   replicas: 1
-  engines:
-  - name: qwen
-    members:
-    - role: Standalone
-      nodeSelector:
-        devices:
-        - name: gpu
-          count: 1
-          selectors:
-          - cel: device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
-      template:
-        spec:
-          containers:
-          - name: engine
-            image: vllm/vllm-openai:v0.23.0
-            args: ["--model=Qwen/Qwen2.5-0.5B-Instruct"]
+  template:
+    spec:
+      engines:
+      - name: qwen
+        members:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 1
+              selectors:
+              - cel: device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                args: ["--model=Qwen/Qwen2.5-0.5B-Instruct"]

--- a/docs/manifests/reference/modeldeployments.yaml
+++ b/docs/manifests/reference/modeldeployments.yaml
@@ -5,21 +5,23 @@ metadata:
   namespace: ml-team
 spec:
   replicas: 2
-  engines:
-    - name: qwen3-8b
-      members:
+  template:
+    spec:
+      engines:
+      - name: qwen3-8b
+        members:
         - role: Standalone
           nodeSelector:
             devices:
-              - name: gpu
-                count: 1
-                selectors:
-                  - cel: |
-                      device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
+            - name: gpu
+              count: 1
+              selectors:
+              - cel: |
+                  device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("20Gi")) >= 0
           template:
             spec:
               containers:
-                - name: engine
-                  image: vllm/vllm-openai:v0.23.0
-                  args:
-                    - --model=Qwen/Qwen3-8B
+              - name: engine
+                image: vllm/vllm-openai:v0.23.0
+                args:
+                - --model=Qwen/Qwen3-8B

--- a/functions/compose-model-deployment/function/fn.py
+++ b/functions/compose-model-deployment/function/fn.py
@@ -200,11 +200,11 @@ class Composer:
         # never staged to, where its PVC wouldn't exist and the pod would be
         # stuck on a volume mount (#186).
         clusters_match_labels = None
-        if self.xr.spec.clusterSelector and self.xr.spec.clusterSelector.matchLabels:
-            clusters_match_labels = dict(self.xr.spec.clusterSelector.matchLabels)
+        if self.xr.spec.template.spec.clusterSelector and self.xr.spec.template.spec.clusterSelector.matchLabels:
+            clusters_match_labels = dict(self.xr.spec.template.spec.clusterSelector.matchLabels)
 
-        if self.xr.spec.modelCacheRef:
-            resolution, cache_match_labels = self.resolve_cache_footprint(self.xr.spec.modelCacheRef)
+        if self.xr.spec.template.spec.modelCacheRef:
+            resolution, cache_match_labels = self.resolve_cache_footprint(self.xr.spec.template.spec.modelCacheRef)
             if resolution is Resolution.PRESENT:
                 # The cache resolved, so its footprint is known; merge its labels
                 # so new replicas land only where it stages. Empty labels (the
@@ -350,6 +350,20 @@ class Composer:
 
         return matched
 
+    def _child_labels(self, cluster_info: scheduling.Candidate) -> dict[str, str]:
+        """Labels for a composed ModelReplica or ModelEndpoint.
+
+        The user's template labels first, then the labels Modelplane manages, so
+        a managed key always wins over a colliding one (the XRD also rejects
+        template labels under the modelplane.ai/ prefix).
+        """
+        metadata = self.xr.spec.template.metadata
+        labels = dict((metadata.labels if metadata else None) or {})
+        labels[_LABEL_DEPLOYMENT] = _name(self.xr.metadata)
+        labels[_LABEL_CLUSTER] = cluster_info.name
+        labels[_LABEL_INDEX] = str(cluster_info.index)
+        return labels
+
     def compose_replicas(self, matched: list[scheduling.Candidate]) -> None:
         """Compose a ModelReplica per matched cluster.
 
@@ -361,7 +375,7 @@ class Composer:
         """
         # Index the deployment's engines by name so each placement (keyed by
         # engine name) can be joined with its template and member shape.
-        engines_by_name = {e.name: e for e in self.xr.spec.engines}
+        engines_by_name = {e.name: e for e in self.xr.spec.template.spec.engines}
 
         for cluster_info in matched:
             replica_key = name.replica_key(cluster_info)
@@ -370,24 +384,22 @@ class Composer:
                 metadata=metav1.ObjectMeta(
                     name=name.replica(_name(self.xr.metadata), cluster_info),
                     namespace=_namespace(self.xr.metadata),
-                    labels={
-                        _LABEL_DEPLOYMENT: _name(self.xr.metadata),
-                        _LABEL_CLUSTER: cluster_info.name,
-                        _LABEL_INDEX: str(cluster_info.index),
-                    },
+                    labels=self._child_labels(cluster_info),
                 ),
                 spec=mrv1alpha1.SpecModel(
                     clusterName=cluster_info.name,
                     engines=[self._replica_engine(engines_by_name[ep.name], ep) for ep in cluster_info.engines],
                 ),
             )
-            if self.xr.spec.modelCacheRef:
-                replica.spec.modelCacheRef = mrv1alpha1.ModelCacheRef(name=self.xr.spec.modelCacheRef.name)
+            if self.xr.spec.template.spec.modelCacheRef:
+                replica.spec.modelCacheRef = mrv1alpha1.ModelCacheRef(
+                    name=self.xr.spec.template.spec.modelCacheRef.name
+                )
             # The replica backend reads serving to pick unified vs. disaggregated
             # routing; copy it down unchanged.
-            if self.xr.spec.serving:
+            if self.xr.spec.template.spec.serving:
                 replica.spec.serving = mrv1alpha1.Serving.model_validate(
-                    self.xr.spec.serving.model_dump(exclude_unset=True)
+                    self.xr.spec.template.spec.serving.model_dump(exclude_unset=True)
                 )
             resource.update(self.rsp.desired.resources[replica_key], replica)
 
@@ -487,11 +499,7 @@ class Composer:
                     metadata=metav1.ObjectMeta(
                         name=replica_name,
                         namespace=_namespace(self.xr.metadata),
-                        labels={
-                            _LABEL_DEPLOYMENT: _name(self.xr.metadata),
-                            _LABEL_CLUSTER: cluster_info.name,
-                            _LABEL_INDEX: str(cluster_info.index),
-                        },
+                        labels=self._child_labels(cluster_info),
                     ),
                     spec=mev1alpha1.Spec(
                         url=url,

--- a/functions/compose-model-deployment/function/scheduling.py
+++ b/functions/compose-model-deployment/function/scheduling.py
@@ -291,7 +291,7 @@ def compile_engines(deployment: mdv1alpha1.ModelDeployment) -> list[_CompiledEng
     malformed expression.
     """
     engines = []
-    for engine in deployment.spec.engines:
+    for engine in deployment.spec.template.spec.engines:
         copies = int(engine.copies or 1)
         members = [
             _CompiledMember(

--- a/functions/compose-model-deployment/tests/test_fn.py
+++ b/functions/compose-model-deployment/tests/test_fn.py
@@ -136,7 +136,10 @@ _PD_REPLICA_ENGINES = [
 # A one-replica deployment requesting a single GPU. Reused across most cases.
 _XR = v1alpha1.ModelDeployment(
     metadata=metav1.ObjectMeta(name="my-model", namespace="ml-team"),
-    spec=v1alpha1.SpecModel(replicas=1, engines=[_ENGINE]),
+    spec=v1alpha1.SpecModel1(
+        replicas=1,
+        template=v1alpha1.TemplateModel(spec=v1alpha1.SpecModel(engines=[_ENGINE])),
+    ),
 ).model_dump(exclude_none=True, mode="json")
 
 
@@ -374,10 +377,14 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
         # A deployment that sets spec.modelCacheRef.
         xr_cached = v1alpha1.ModelDeployment(
             metadata=metav1.ObjectMeta(name="my-model", namespace="ml-team"),
-            spec=v1alpha1.SpecModel(
+            spec=v1alpha1.SpecModel1(
                 replicas=1,
-                modelCacheRef=v1alpha1.ModelCacheRef(name="qwen"),
-                engines=[_ENGINE],
+                template=v1alpha1.TemplateModel(
+                    spec=v1alpha1.SpecModel(
+                        modelCacheRef=v1alpha1.ModelCacheRef(name="qwen"),
+                        engines=[_ENGINE],
+                    )
+                ),
             ),
         ).model_dump(exclude_none=True, mode="json")
 
@@ -385,30 +392,41 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
         # scheduler intersects it with the cache's footprint.
         xr_cached_selector = v1alpha1.ModelDeployment(
             metadata=metav1.ObjectMeta(name="my-model", namespace="ml-team"),
-            spec=v1alpha1.SpecModel(
+            spec=v1alpha1.SpecModel1(
                 replicas=1,
-                clusterSelector=v1alpha1.ClusterSelector(matchLabels={"region": "us-east"}),
-                modelCacheRef=v1alpha1.ModelCacheRef(name="qwen"),
-                engines=[_ENGINE],
+                template=v1alpha1.TemplateModel(
+                    spec=v1alpha1.SpecModel(
+                        clusterSelector=v1alpha1.ClusterSelector(matchLabels={"region": "us-east"}),
+                        modelCacheRef=v1alpha1.ModelCacheRef(name="qwen"),
+                        engines=[_ENGINE],
+                    )
+                ),
             ),
         ).model_dump(exclude_none=True, mode="json")
 
         # A two-replica deployment (no container args) for the co-location case.
         xr_two = v1alpha1.ModelDeployment(
             metadata=metav1.ObjectMeta(name="my-model", namespace="ml-team"),
-            spec=v1alpha1.SpecModel(replicas=2, engines=[_ENGINE_NO_ARGS]),
+            spec=v1alpha1.SpecModel1(
+                replicas=2,
+                template=v1alpha1.TemplateModel(spec=v1alpha1.SpecModel(engines=[_ENGINE_NO_ARGS])),
+            ),
         ).model_dump(exclude_none=True, mode="json")
 
         # A disaggregated (PrefillDecode) deployment: a Prefill and a Decode engine.
         xr_pd = v1alpha1.ModelDeployment(
             metadata=metav1.ObjectMeta(name="my-model", namespace="ml-team"),
-            spec=v1alpha1.SpecModel(
+            spec=v1alpha1.SpecModel1(
                 replicas=1,
-                serving=v1alpha1.Serving(mode="PrefillDecode"),
-                engines=[
-                    _ENGINE.model_copy(update={"name": "prefill", "phase": "Prefill"}),
-                    _ENGINE.model_copy(update={"name": "decode", "phase": "Decode"}),
-                ],
+                template=v1alpha1.TemplateModel(
+                    spec=v1alpha1.SpecModel(
+                        serving=v1alpha1.Serving(mode="PrefillDecode"),
+                        engines=[
+                            _ENGINE.model_copy(update={"name": "prefill", "phase": "Prefill"}),
+                            _ENGINE.model_copy(update={"name": "decode", "phase": "Decode"}),
+                        ],
+                    )
+                ),
             ),
         ).model_dump(exclude_none=True, mode="json")
 
@@ -1228,6 +1246,72 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                     json_format.MessageToDict(got),
                     "-want, +got",
                 )
+
+
+def _composed(resp: fnv1.RunFunctionResponse, kind: str) -> list[dict]:
+    """Composed desired resources of the given kind, as dicts."""
+    result = []
+    for r in resp.desired.resources.values():
+        d = resource.struct_to_dict(r.resource)
+        if d.get("kind") == kind:
+            result.append(d)
+    return result
+
+
+class TestTemplateLabels(unittest.IsolatedAsyncioTestCase):
+    """spec.template.metadata.labels land on the composed ModelReplicas and
+    ModelEndpoints, alongside the labels Modelplane manages."""
+
+    async def test_stamped_on_replica_and_endpoint(self) -> None:
+        xr = v1alpha1.ModelDeployment(
+            metadata=metav1.ObjectMeta(name="my-model", namespace="ml-team"),
+            spec=v1alpha1.SpecModel1(
+                replicas=1,
+                template=v1alpha1.TemplateModel(
+                    metadata=v1alpha1.Metadata(labels={"tier": "prod", "team": "search"}),
+                    spec=v1alpha1.SpecModel(engines=[_ENGINE]),
+                ),
+            ),
+        ).model_dump(exclude_none=True, mode="json")
+        # An observed, Ready replica lets the endpoint compose this reconcile.
+        req = _req(
+            xr,
+            clusters=[_CLUSTER_A],
+            replicas=[_EXISTING_REPLICA],
+            observed={"replica-cluster-a-0": _replica_status(_EXISTING_REPLICA, ready=True)},
+        )
+        got = await fn.FunctionRunner().RunFunction(req, None)
+
+        composed = _composed(got, "ModelReplica") + _composed(got, "ModelEndpoint")
+        self.assertEqual(len(composed), 2, "expected one ModelReplica and one ModelEndpoint")
+        for obj in composed:
+            labels = obj["metadata"]["labels"]
+            self.assertEqual(labels.get("tier"), "prod")
+            self.assertEqual(labels.get("team"), "search")
+            self.assertEqual(labels.get("modelplane.ai/deployment"), "my-model")
+            self.assertEqual(labels.get("modelplane.ai/cluster"), "cluster-a")
+            self.assertEqual(labels.get("modelplane.ai/replica-index"), "0")
+
+    async def test_managed_labels_win_a_collision(self) -> None:
+        """The XRD's CEL rejects a template label under the modelplane.ai/ prefix,
+        but the invariant lives in the function too: managed labels are stamped
+        last, so a colliding label can't override them even if that CEL rule is
+        relaxed or the function is reused elsewhere."""
+        xr = v1alpha1.ModelDeployment(
+            metadata=metav1.ObjectMeta(name="my-model", namespace="ml-team"),
+            spec=v1alpha1.SpecModel1(
+                replicas=1,
+                template=v1alpha1.TemplateModel(
+                    metadata=v1alpha1.Metadata(labels={"modelplane.ai/cluster": "wrong", "tier": "prod"}),
+                    spec=v1alpha1.SpecModel(engines=[_ENGINE]),
+                ),
+            ),
+        ).model_dump(exclude_none=True, mode="json")
+        got = await fn.FunctionRunner().RunFunction(_req(xr, clusters=[_CLUSTER_A]), None)
+
+        replica = _composed(got, "ModelReplica")[0]
+        self.assertEqual(replica["metadata"]["labels"]["modelplane.ai/cluster"], "cluster-a")
+        self.assertEqual(replica["metadata"]["labels"]["tier"], "prod")
 
 
 class TestResolveRequired(unittest.TestCase):

--- a/functions/compose-model-deployment/tests/test_scheduling.py
+++ b/functions/compose-model-deployment/tests/test_scheduling.py
@@ -127,7 +127,10 @@ def _deployment(
         engines = [_engine(copies=count, pipeline=pipeline, requests=requests)]
     return mdv1alpha1.ModelDeployment(
         metadata=metav1.ObjectMeta(name=name, namespace="ml-team"),
-        spec=mdv1alpha1.SpecModel(replicas=replicas, engines=engines),
+        spec=mdv1alpha1.SpecModel1(
+            replicas=replicas,
+            template=mdv1alpha1.TemplateModel(spec=mdv1alpha1.SpecModel(engines=engines)),
+        ),
     )
 
 

--- a/schemas/python/models/ai/modelplane/modeldeployment/v1alpha1.py
+++ b/schemas/python/models/ai/modelplane/modeldeployment/v1alpha1.py
@@ -10,10 +10,6 @@ from pydantic import AwareDatetime, BaseModel, Field, conint, constr
 from ....io.k8s.apimachinery.pkg.apis.meta import v1
 
 
-class ClusterSelector(BaseModel):
-    matchLabels: dict[str, str] | None = None
-
-
 class CompositionRef(BaseModel):
     name: str
 
@@ -45,6 +41,17 @@ class Crossplane(BaseModel):
     resourceRefs: list[ResourceRef] | None = None
 
 
+class Metadata(BaseModel):
+    labels: dict[str, constr(max_length=63)] | None = Field(None, max_length=32)
+    """
+    Labels to set on the ModelReplicas and ModelEndpoints this deployment composes, alongside the labels Modelplane manages. Use them to organize and select your own resources (kubectl get modelreplica -l tier=prod) or to route to a subset of endpoints from a ModelService. Keys under the modelplane.ai/ prefix are reserved.
+    """
+
+
+class ClusterSelector(BaseModel):
+    matchLabels: dict[str, str] | None = None
+
+
 class Selector(BaseModel):
     cel: constr(min_length=1, max_length=10240) | None = None
     """
@@ -74,7 +81,7 @@ class NodeSelector(BaseModel):
     """
 
 
-class Metadata(BaseModel):
+class MetadataModel(BaseModel):
     annotations: dict[str, str] | None = None
     labels: dict[str, str] | None = None
 
@@ -150,7 +157,7 @@ class Spec(BaseModel):
 
 
 class Template(BaseModel):
-    metadata: Metadata | None = None
+    metadata: MetadataModel | None = None
     """
     Metadata applied to the member's pods. Useful for labels and annotations that control cluster-level features like service mesh injection.
     """
@@ -224,10 +231,6 @@ class SpecModel(BaseModel):
     """
     Optional label selector to filter InferenceClusters. If omitted, all ready clusters are candidates.
     """
-    crossplane: Crossplane | None = None
-    """
-    Configures how Crossplane will reconcile this composite resource
-    """
     engines: list[Engine] = Field(..., max_length=8, min_length=1)
     """
     A ModelReplica's inference engines. An engine is one serving unit: a single Standalone pod, or a gang of a Leader and one or more Workers coordinating across nodes. Modelplane composes the whole array once per ModelReplica; an engine composes to a Deployment (Standalone) or a LeaderWorkerSet (Leader/Worker), but the workload kind is an implementation detail. Modelplane is unopinionated about the engine itself: parallelism, quantization, and KV transfer all live in the members' engine flags, written by the user, never injected by Modelplane.
@@ -236,13 +239,29 @@ class SpecModel(BaseModel):
     """
     Reference to a ModelCache in the same namespace. Optional for single-node engines; required for any engine that spans multiple nodes (a Leader with one or more Workers), since every pod in the gang mounts it.
     """
+    serving: Serving | None = None
+    """
+    How the deployment is served from the cluster edge to its engines. Unified (the default) fronts the engines with a Service. PrefillDecode serves prefill and decode from the two engines marking those phases, with inference-aware routing that sequences prefill then decode. Omitted means Unified.
+    """
+
+
+class TemplateModel(BaseModel):
+    metadata: Metadata | None = None
+    spec: SpecModel
+
+
+class SpecModel1(BaseModel):
+    crossplane: Crossplane | None = None
+    """
+    Configures how Crossplane will reconcile this composite resource
+    """
     replicas: conint(ge=1, le=10)
     """
     How many ModelReplicas to fan out to. Each replica is a complete serving instance scheduled to one InferenceCluster.
     """
-    serving: Serving | None = None
+    template: TemplateModel
     """
-    How the deployment is served from the cluster edge to its engines. Unified (the default) fronts the engines with a Service. PrefillDecode serves prefill and decode from the two engines marking those phases, with inference-aware routing that sequences prefill then decode. Omitted means Unified.
+    Template for the ModelReplicas this deployment fans out to. Everything but the replica count lives here, mirroring a Kubernetes Deployment's spec.template.
     """
 
 
@@ -281,7 +300,7 @@ class ModelDeployment(BaseModel):
     """
     Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
     """
-    spec: SpecModel
+    spec: SpecModel1
     status: Status | None = None
 
 


### PR DESCRIPTION
Fixes #257.

Setting your own labels on a deployment's ModelReplicas and ModelEndpoints had no home on the API. Rather than a one-off field, this adopts the Deployment-style shape from the discussion on this PR: everything but `spec.replicas` moves under `spec.template`, with the replica shape in `spec.template.spec` and labels in `spec.template.metadata.labels`, which apply to the composed replicas and their endpoints.

Before:

```yaml
spec:
  replicas: 1
  engines: [...]
```

After:

```yaml
spec:
  replicas: 1
  template:
    metadata:
      labels: {tier: prod, team: search}
    spec:
      engines: [...]
```

The shape leaves room to template annotations and, later, the ModelEndpoint spec, with a path to split replica and model templates if we need it. It's a breaking change, taken now while pre-v0.1 to land a cleaner API before v1beta1.

Labels are validated on the ModelDeployment itself — Kubernetes label syntax, no reserved `modelplane.ai/` prefix, bounded count (`maxProperties: 32`) and length (`maxLength: 63`) — so a malformed label is rejected on the resource the user wrote rather than failing when the composed child is applied. Verified on a dev cluster: `"my label!"` and a 300-char value are rejected on the ModelDeployment.

The diff is large but mostly the XRD re-indent from nesting the existing fields under `spec.template.spec`; the composition change is just reading fields from their new path and stamping `template.metadata.labels` onto the children.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
