### PR TITLE
Schedule around taints on InferenceClusters

### DIFF
--- a/apis/inferenceclusters/definition.yaml
+++ b/apis/inferenceclusters/definition.yaml
@@ -172,6 +172,30 @@ spec:
                           mk8s cluster Kubernetes version. Defaults to a
                           version where Dynamic Resource Allocation (DRA)
                           is generally available.
+              taints:
+                type: array
+                description: >-
+                  Taints that repel ModelDeployments from this cluster unless
+                  they carry a matching toleration, following the Kubernetes
+                  taint model. NoSchedule keeps new replicas off the cluster
+                  while leaving existing ones in place; NoExecute additionally
+                  drains the replicas already here, which the scheduler
+                  reschedules onto other tolerated clusters (the declarative
+                  equivalent of draining a node before maintenance).
+                x-kubernetes-list-type: map
+                x-kubernetes-list-map-keys: [key, effect]
+                items:
+                  type: object
+                  required: [key, effect]
+                  properties:
+                    key:
+                      type: string
+                      minLength: 1
+                    value:
+                      type: string
+                    effect:
+                      type: string
+                      enum: [NoSchedule, NoExecute]
               nodePools:
                 type: array
                 description: >-

--- a/apis/modeldeployments/definition.yaml
+++ b/apis/modeldeployments/definition.yaml
@@ -143,6 +143,43 @@ spec:
                               Unified serves prefill and decode on one engine.
                               PrefillDecode splits them across two engines, each marking
                               its phase as Prefill or Decode.
+                      tolerations:
+                        type: array
+                        description: >-
+                          Tolerations that let this deployment's replicas
+                          schedule onto, and stay on, InferenceClusters carrying
+                          matching taints, following the Kubernetes toleration
+                          model. A replica tolerating a cluster's NoSchedule
+                          taint can be placed there; one tolerating a NoExecute
+                          taint is not drained when that taint is applied.
+                        x-kubernetes-list-type: atomic
+                        items:
+                          type: object
+                          x-kubernetes-validations:
+                          - rule: "self.operator != 'Equal' || (has(self.key) && self.key != '')"
+                            message: "an Equal toleration must set a key"
+                          - rule: "self.operator != 'Exists' || !has(self.value)"
+                            message: "an Exists toleration must not set a value"
+                          properties:
+                            key:
+                              type: string
+                              description: >-
+                                Taint key to match. Empty with operator Exists
+                                tolerates every taint.
+                            operator:
+                              type: string
+                              enum: [Exists, Equal]
+                              default: Equal
+                              description: >-
+                                Exists matches any taint with the key (ignoring
+                                value); Equal matches key and value.
+                            value:
+                              type: string
+                            effect:
+                              type: string
+                              enum: [NoSchedule, NoExecute]
+                              description: >-
+                                Taint effect to match. Empty matches all effects.
                       engines:
                         type: array
                         description: >-

--- a/functions/compose-model-deployment/function/scheduling.py
+++ b/functions/compose-model-deployment/function/scheduling.py
@@ -318,6 +318,49 @@ def _cluster_ready(cluster: icv1alpha1.InferenceCluster) -> bool:
     return any(c.type == "Ready" and c.status == "True" for c in cluster.status.conditions or [])
 
 
+_EFFECT_NO_SCHEDULE = "NoSchedule"
+_EFFECT_NO_EXECUTE = "NoExecute"
+
+
+def _tolerates(toleration: mdv1alpha1.Toleration, taint: icv1alpha1.Taint) -> bool:
+    """Whether a toleration matches a taint, following Kubernetes semantics.
+
+    An empty toleration effect matches any effect; otherwise the effects must be
+    equal. Operator Exists matches any taint with the key (an empty key matches
+    every taint); Equal (the default) matches on key and value.
+    """
+    if toleration.effect and toleration.effect != taint.effect:
+        return False
+    if (toleration.operator or "Equal") == "Exists":
+        return not toleration.key or toleration.key == taint.key
+    return toleration.key == taint.key and (toleration.value or "") == (taint.value or "")
+
+
+def _has_untolerated_taint(
+    cluster: icv1alpha1.InferenceCluster,
+    tolerations: list[mdv1alpha1.Toleration],
+    effects: tuple[str, ...],
+) -> bool:
+    """Whether the cluster carries a taint with one of `effects` that no toleration matches."""
+    return any(
+        taint.effect in effects and not any(_tolerates(t, taint) for t in tolerations)
+        for taint in cluster.spec.taints or []
+    )
+
+
+def _repels_new(cluster: icv1alpha1.InferenceCluster, tolerations: list[mdv1alpha1.Toleration]) -> bool:
+    """Whether an untolerated taint keeps NEW replicas off this cluster.
+
+    Both NoSchedule and NoExecute block new placements.
+    """
+    return _has_untolerated_taint(cluster, tolerations, (_EFFECT_NO_SCHEDULE, _EFFECT_NO_EXECUTE))
+
+
+def _evicts_existing(cluster: icv1alpha1.InferenceCluster, tolerations: list[mdv1alpha1.Toleration]) -> bool:
+    """Whether an untolerated NoExecute taint drains the replicas already here."""
+    return _has_untolerated_taint(cluster, tolerations, (_EFFECT_NO_EXECUTE,))
+
+
 def _device_satisfies(device: icv1alpha1.Device, programs: list[cel.Program]) -> bool:
     """Whether a pool device satisfies every selector (all ANDed)."""
     # by_alias keeps the DRA wire names (bool/int, not the generated bool_/int_
@@ -566,6 +609,11 @@ def _retain(
         if identity in seen:
             continue
         cluster = clusters_by_name[cluster_name]
+        # A NoExecute taint the deployment doesn't tolerate drains this replica:
+        # drop it from the retained set so the fill phase reschedules it onto a
+        # tolerated cluster (delete-plus-create, like a Kubernetes drain).
+        if _evicts_existing(cluster, deployment.spec.template.spec.tolerations or []):
+            continue
         placements = _retained_placements(r, cluster, engines)
         if placements is None:
             continue
@@ -972,7 +1020,12 @@ def schedule(
         # must not charge our dropped or scaled-down replicas, whose nodes are
         # freeing up. Fill then decrements it only as it places NEW replicas.
         ledger = _build_ledger(deployment, clusters, retained, all_replicas)
-        placed = _fill(engines, clusters, retained, ledger, desired - len(retained))
+        # New replicas avoid clusters carrying an untolerated taint (NoSchedule
+        # or NoExecute). The ledger still spans every cluster, so a tainted
+        # cluster's capacity is accounted for other deployments' replicas.
+        tolerations = deployment.spec.template.spec.tolerations or []
+        schedulable = [c for c in clusters if not _repels_new(c, tolerations)]
+        placed = _fill(engines, schedulable, retained, ledger, desired - len(retained))
 
     result = retained + placed
     result.sort(key=lambda c: (c.name, c.index))

--- a/functions/compose-model-deployment/tests/test_scheduling.py
+++ b/functions/compose-model-deployment/tests/test_scheduling.py
@@ -115,6 +115,7 @@ def _deployment(
     count: int = 1,
     requests: list[mdv1alpha1.Device] | None = None,
     engines: list[mdv1alpha1.Engine] | None = None,
+    tolerations: list[mdv1alpha1.Toleration] | None = None,
 ) -> mdv1alpha1.ModelDeployment:
     """Construct a ModelDeployment.
 
@@ -129,7 +130,9 @@ def _deployment(
         metadata=metav1.ObjectMeta(name=name, namespace="ml-team"),
         spec=mdv1alpha1.SpecModel1(
             replicas=replicas,
-            template=mdv1alpha1.TemplateModel(spec=mdv1alpha1.SpecModel(engines=engines)),
+            template=mdv1alpha1.TemplateModel(
+                spec=mdv1alpha1.SpecModel(engines=engines, tolerations=tolerations),
+            ),
         ),
     )
 
@@ -182,6 +185,7 @@ def _cluster(
     ready: bool = True,
     gateway_address: str = "10.0.0.1",
     pools: list[dict] | None = None,
+    taints: list[icv1alpha1.Taint] | None = None,
 ) -> icv1alpha1.InferenceCluster:
     """Construct an InferenceCluster with the given readiness and pools.
 
@@ -210,6 +214,7 @@ def _cluster(
                 source="Existing",
                 existing=icv1alpha1.Existing(secretRef=icv1alpha1.SecretRef(name="k")),
             ),
+            taints=taints,
         ),
         status=icv1alpha1.Status(
             conditions=conditions,
@@ -1606,6 +1611,99 @@ class TestScheduleMembers(unittest.TestCase):
             with self.subTest(case.name):
                 got = scheduling.schedule(case.deployment, case.clusters, case.all_replicas)
                 self.assertEqual(case.want, got, f"{case.name}: -want, +got")
+
+
+class TestScheduleTaints(unittest.TestCase):
+    """Taints on InferenceClusters gate placement; a matching toleration on the
+    ModelDeployment overrides them. NoSchedule keeps new replicas off a cluster
+    but leaves existing ones; NoExecute additionally drains the existing ones,
+    which fill reschedules onto a tolerated cluster."""
+
+    _MAINT = icv1alpha1.Taint(key="modelplane.ai/maintenance", value="on", effect="NoSchedule")
+    _DECOMM = icv1alpha1.Taint(key="modelplane.ai/decommission", effect="NoExecute")
+
+    def _names(self, got: list[scheduling.Candidate]) -> list[tuple[str, int]]:
+        return [(c.name, c.index) for c in got]
+
+    def test_noschedule_keeps_new_replicas_off(self) -> None:
+        clusters = [_cluster("cluster-a", taints=[self._MAINT]), _cluster("cluster-b", gateway_address="10.0.0.2")]
+        got = scheduling.schedule(_deployment(replicas=1), clusters, [])
+        self.assertEqual(self._names(got), [("cluster-b", 0)])
+
+    def test_noschedule_leaves_existing_replica_in_place(self) -> None:
+        existing = _replica("my-model", "cluster-a")
+        got = scheduling.schedule(_deployment(replicas=1), [_cluster("cluster-a", taints=[self._MAINT])], [existing])
+        self.assertEqual(self._names(got), [("cluster-a", 0)])
+
+    def test_toleration_allows_placement_on_tainted(self) -> None:
+        tol = mdv1alpha1.Toleration(key="modelplane.ai/maintenance", operator="Exists")
+        got = scheduling.schedule(
+            _deployment(replicas=1, tolerations=[tol]), [_cluster("cluster-a", taints=[self._MAINT])], []
+        )
+        self.assertEqual(self._names(got), [("cluster-a", 0)])
+
+    def test_noexecute_drains_and_reschedules(self) -> None:
+        existing = _replica("my-model", "cluster-a")
+        clusters = [_cluster("cluster-a", taints=[self._DECOMM]), _cluster("cluster-b", gateway_address="10.0.0.2")]
+        got = scheduling.schedule(_deployment(replicas=1), clusters, [existing])
+        self.assertEqual(self._names(got), [("cluster-b", 0)])
+
+    def test_noexecute_toleration_retains_in_place(self) -> None:
+        tol = mdv1alpha1.Toleration(key="modelplane.ai/decommission", operator="Exists")
+        existing = _replica("my-model", "cluster-a")
+        got = scheduling.schedule(
+            _deployment(replicas=1, tolerations=[tol]), [_cluster("cluster-a", taints=[self._DECOMM])], [existing]
+        )
+        self.assertEqual(self._names(got), [("cluster-a", 0)])
+
+    def test_noexecute_drain_leaves_count_unmet_when_nowhere_to_go(self) -> None:
+        """Draining with no tolerated cluster to reschedule onto yields fewer
+        than spec.replicas; the deploy function surfaces the shortfall."""
+        existing = _replica("my-model", "cluster-a")
+        got = scheduling.schedule(_deployment(replicas=1), [_cluster("cluster-a", taints=[self._DECOMM])], [existing])
+        self.assertEqual(got, [])
+
+    def test_noschedule_toleration_does_not_cover_a_noexecute_taint(self) -> None:
+        """Matching the key but not the effect doesn't tolerate: an operator who
+        tolerates only NoSchedule is still drained by a NoExecute taint."""
+        tol = mdv1alpha1.Toleration(key="modelplane.ai/decommission", operator="Exists", effect="NoSchedule")
+        existing = _replica("my-model", "cluster-a")
+        clusters = [_cluster("cluster-a", taints=[self._DECOMM]), _cluster("cluster-b", gateway_address="10.0.0.2")]
+        got = scheduling.schedule(_deployment(replicas=1, tolerations=[tol]), clusters, [existing])
+        self.assertEqual(self._names(got), [("cluster-b", 0)])
+
+    def test_untolerated_second_taint_still_repels(self) -> None:
+        """Tolerating one of a cluster's taints isn't enough; any untolerated
+        taint keeps new replicas off."""
+        other = icv1alpha1.Taint(key="modelplane.ai/reserved", effect="NoSchedule")
+        tol = mdv1alpha1.Toleration(key="modelplane.ai/maintenance", operator="Exists")
+        clusters = [
+            _cluster("cluster-a", taints=[self._MAINT, other]),
+            _cluster("cluster-b", gateway_address="10.0.0.2"),
+        ]
+        got = scheduling.schedule(_deployment(replicas=1, tolerations=[tol]), clusters, [])
+        self.assertEqual(self._names(got), [("cluster-b", 0)])
+
+    def test_equal_toleration_matches_on_value(self) -> None:
+        """Equal tolerates only when key and value both match."""
+        match = mdv1alpha1.Toleration(key="modelplane.ai/maintenance", operator="Equal", value="on")
+        placed = scheduling.schedule(
+            _deployment(replicas=1, tolerations=[match]), [_cluster("cluster-a", taints=[self._MAINT])], []
+        )
+        self.assertEqual(self._names(placed), [("cluster-a", 0)])
+
+        mismatch = mdv1alpha1.Toleration(key="modelplane.ai/maintenance", operator="Equal", value="off")
+        repelled = scheduling.schedule(
+            _deployment(replicas=1, tolerations=[mismatch]), [_cluster("cluster-a", taints=[self._MAINT])], []
+        )
+        self.assertEqual(repelled, [])
+
+    def test_keyless_exists_tolerates_every_taint(self) -> None:
+        """An Exists toleration with no key tolerates any taint on the cluster."""
+        tol = mdv1alpha1.Toleration(operator="Exists")
+        clusters = [_cluster("cluster-a", taints=[self._MAINT, self._DECOMM])]
+        got = scheduling.schedule(_deployment(replicas=1, tolerations=[tol]), clusters, [])
+        self.assertEqual(self._names(got), [("cluster-a", 0)])
 
 
 if __name__ == "__main__":

--- a/schemas/python/models/ai/modelplane/inferencecluster/v1alpha1.py
+++ b/schemas/python/models/ai/modelplane/inferencecluster/v1alpha1.py
@@ -185,6 +185,12 @@ class NodePool(BaseModel):
     """
 
 
+class Taint(BaseModel):
+    effect: Literal['NoSchedule', 'NoExecute']
+    key: constr(min_length=1)
+    value: str | None = None
+
+
 class Spec(BaseModel):
     cluster: Cluster
     crossplane: Crossplane | None = None
@@ -194,6 +200,10 @@ class Spec(BaseModel):
     nodePools: list[NodePool] | None = Field(None, max_length=8, min_length=1)
     """
     GPU node pools available on this cluster. Each pool references an InferenceClass that describes the hardware shape and (for provisioned clusters) how to create the pool. System pools for control-plane components are provisioned automatically.
+    """
+    taints: list[Taint] | None = None
+    """
+    Taints that repel ModelDeployments from this cluster unless they carry a matching toleration, following the Kubernetes taint model. NoSchedule keeps new replicas off the cluster while leaving existing ones in place; NoExecute additionally drains the replicas already here, which the scheduler reschedules onto other tolerated clusters (the declarative equivalent of draining a node before maintenance).
     """
 
 

--- a/schemas/python/models/ai/modelplane/modeldeployment/v1alpha1.py
+++ b/schemas/python/models/ai/modelplane/modeldeployment/v1alpha1.py
@@ -226,6 +226,22 @@ class Serving(BaseModel):
     """
 
 
+class Toleration(BaseModel):
+    effect: Literal['NoSchedule', 'NoExecute'] | None = None
+    """
+    Taint effect to match. Empty matches all effects.
+    """
+    key: str | None = None
+    """
+    Taint key to match. Empty with operator Exists tolerates every taint.
+    """
+    operator: Literal['Exists', 'Equal'] | None = 'Equal'
+    """
+    Exists matches any taint with the key (ignoring value); Equal matches key and value.
+    """
+    value: str | None = None
+
+
 class SpecModel(BaseModel):
     clusterSelector: ClusterSelector | None = None
     """
@@ -242,6 +258,10 @@ class SpecModel(BaseModel):
     serving: Serving | None = None
     """
     How the deployment is served from the cluster edge to its engines. Unified (the default) fronts the engines with a Service. PrefillDecode serves prefill and decode from the two engines marking those phases, with inference-aware routing that sequences prefill then decode. Omitted means Unified.
+    """
+    tolerations: list[Toleration] | None = None
+    """
+    Tolerations that let this deployment's replicas schedule onto, and stay on, InferenceClusters carrying matching taints, following the Kubernetes toleration model. A replica tolerating a cluster's NoSchedule taint can be placed there; one tolerating a NoExecute taint is not drained when that taint is applied.
     """
 
 


### PR DESCRIPTION
Fixes #16.

Taking an InferenceCluster out of service meant coordinating by hand: find every ModelDeployment placed on it, reschedule or delete those, then delete the cluster. There was no declarative way for a platform team to say "stop scheduling here" or "drain what's here," and no way for an ML team to keep a critical deployment in place through it.

This adds taints to `InferenceCluster` (`spec.taints`) and tolerations to `ModelDeployment` (`spec.template.spec.tolerations`), following the Kubernetes model. When placing new replicas the scheduler skips a cluster carrying an untolerated taint (NoSchedule and NoExecute alike). A `NoExecute` taint additionally drains the replicas already there: the retain phase drops them so the fill phase reschedules them onto tolerated clusters (delete-plus-create, like a node drain). `NoSchedule` leaves existing replicas in place. A drain with nowhere to reschedule leaves the deployment below `spec.replicas`, reported by its existing `ReplicasScheduled` condition.

```yaml
apiVersion: modelplane.ai/v1alpha1
kind: InferenceCluster
metadata:
  name: gpu-us-east
spec:
  taints:
  - key: modelplane.ai/maintenance
    effect: NoSchedule    # NoExecute to also drain existing replicas
```

```yaml
apiVersion: modelplane.ai/v1alpha1
kind: ModelDeployment
spec:
  replicas: 1
  template:
    spec:
      tolerations:
      - key: modelplane.ai/maintenance
        operator: Exists
      engines: [...]
```

The issue framed this on an "InferenceEnvironment" with `spec.environments`; that kind is `InferenceCluster` today and a ModelDeployment scales by `spec.replicas` across clusters it selects by label, so the fields here map the idea onto the current API. Worth a look that the mapping is what you had in mind.

This revision keeps to the taint/toleration scheduling only. An earlier version also published `status.scheduledReplicas` (with a REPLICAS printer column) and a `Drained` condition on InferenceCluster. Per review, that condition was really just `scheduledReplicas == 0`, and Kubernetes' own `Node` neither counts scheduled pods nor carries such a condition — you list the pods on it. So both the field and the condition are dropped: a platform team confirms a drain by listing the ModelReplicas placed on the cluster, matching the Node pattern.

Rebased onto `main` now that the `spec.template` restructure (#343) has merged, so tolerations live at `spec.template.spec.tolerations`.

Validated with `crossplane render`: a NoSchedule-tainted cluster is skipped for new placement, and a NoExecute taint drains an existing replica and reschedules it onto another cluster. On a dev control plane the apiserver's CEL rejects keyless `Equal` tolerations, `Exists` tolerations carrying a value, keyless taints, and unknown effects. `nix flake check` passes (the taint/toleration scheduling tests and the docs-manifest validation run green locally).

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
