### PR TITLE
Fix discrepancies in getting-started docs and concepts manifests

### DIFF
--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -23,9 +23,9 @@ This is not a production setup and takes around 45 minutes to run.
 
 ## What you'll build
 
-The platform team provisions a starter cluster and grows it to two A100 regions;
-the ML team serves a model on the L4, then scales it onto an A100, all behind one
-endpoint.
+The platform team provisions a starter cluster and grows it to two larger-GPU
+regions; the ML team serves a model on the L4, then scales it onto a bigger GPU,
+all behind one endpoint.
 
 {{< asciinema src="what-youll-build.cast" poster="npt:2:13" >}}
 

--- a/docs/content/getting-started/scale-the-model.md
+++ b/docs/content/getting-started/scale-the-model.md
@@ -11,13 +11,13 @@ across two regions.
 ```mermaid
 graph LR
     subgraph fleet ["Fleet"]
-        IC1["us-east\nL4"]
-        IC2["us-west\nlarger GPU"]
+        IC1["region-a\nL4"]
+        IC2["region-b\nlarger GPU"]
     end
 
     subgraph ml ["ML team"]
         MD1["ModelDeployment\nqwen-demo"]
-        MD2["ModelDeployment\nqwen-west\nclusterSelector: us-west"]
+        MD2["ModelDeployment\nqwen-west\nclusterSelector: region-b"]
         MS["ModelService qwen\n/ml-team/qwen/v1/..."]
     end
 

--- a/docs/content/getting-started/scale-the-platform.md
+++ b/docs/content/getting-started/scale-the-platform.md
@@ -13,7 +13,7 @@ Provisioning two more clusters takes about 10 to 15 minutes.
 
 {{< tabs >}}
 {{< tab "EKS" >}}
-Register two more clusters with a bigger hardware class: `L40S` (`48 Gi`) in
+Register two more clusters with a bigger hardware class: `L40S` (`48 GB`) in
 `us-west` and `eu-central`:
 
 {{< manifests "getting-started/eks/platform-scale.yaml" >}}
@@ -25,7 +25,7 @@ up]({{< ref "getting-started/clean-up.md" >}})).
 {{< /hint >}}
 {{< /tab >}}
 {{< tab "GKE" >}}
-Register two more clusters with a bigger hardware class: `A100` (`40 Gi`) in
+Register two more clusters with a bigger hardware class: `A100` (`40 GB`) in
 `us-west` and `us-east`. Apply the manifest, setting each cluster's `project` to
 your GCP project:
 

--- a/docs/manifests/concepts/inference-cluster-eks.yaml
+++ b/docs/manifests/concepts/inference-cluster-eks.yaml
@@ -3,8 +3,8 @@
 # Modelplane provisions the full EKS cluster (VPC, subnets, internet
 # gateway, IAM roles for the cluster and nodes, system + GPU node
 # groups, vpc-cni / kube-proxy / coredns addons) and installs the
-# inference stack (cert-manager, Traefik, Prometheus, KEDA,
-# LeaderWorkerSet).
+# inference stack (cert-manager, Envoy Gateway, Prometheus,
+# LeaderWorkerSet, Gateway API).
 #
 # The system node group that hosts control-plane components is
 # provisioned automatically and is not declared here. Only GPU node

--- a/docs/manifests/concepts/inference-cluster-nebius.yaml
+++ b/docs/manifests/concepts/inference-cluster-nebius.yaml
@@ -3,7 +3,8 @@
 # Modelplane provisions the full mk8s cluster (VPC network and subnet,
 # control plane with a public endpoint, system + GPU node groups, GPU
 # clusters for InfiniBand fabrics) and installs the inference stack
-# (cert-manager, Traefik, Prometheus, KEDA, LeaderWorkerSet).
+# (cert-manager, Envoy Gateway, Prometheus, LeaderWorkerSet, Gateway
+# API).
 #
 # The system node group that hosts control-plane components is
 # provisioned automatically and is not declared here. Only GPU node


### PR DESCRIPTION
Cross-checking the docs against the XRDs surfaced three documentation-only inaccuracies.

The concepts EKS and Nebius `InferenceCluster` manifests described the serving stack as "Traefik, Prometheus, KEDA, LeaderWorkerSet", contradicting the GKE one. It installs Envoy Gateway, not Traefik (Traefik is the separate `InferenceGateway` backend), and no longer runs in-cluster KEDA (KEDA driving `ModelDeployment.spec.replicas` is a separate, unaffected usage). All three cloud manifests now match.

The getting-started changes make shared EKS/GKE content cloud-agnostic and fix the L40S/A100 memory units (GB, not `Gi`).

Validated with `nix flake check`.


I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
