### PR TITLE
Add 0.2 Version to hugo.toml and versions

### DIFF
--- a/docs/data/versions.yaml
+++ b/docs/data/versions.yaml
@@ -10,3 +10,5 @@ versions:
     url: "https://main.docs.modelplane.ai"
   - version: "0.1"
     url: "https://v0-1.docs.modelplane.ai"
+  - version: "0.2"
+    url: "https://v0-2.docs.modelplane.ai"

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -102,7 +102,7 @@ ignoreFiles = ["themes/geekboot/content/.*", "README.md"]
   version = "main"
   # Latest stable release. Drives the version dropdown and the "not the latest
   # release" banners; the apex (docs.modelplane.ai) is this release's own build.
-  latest = "0.1"
+  latest = "0.2"
   [params.anchors]
     min = 2
     max = 5


### PR DESCRIPTION
<!--
Thanks for contributing to Modelplane! Read CONTRIBUTING.md before opening a PR
and follow it, especially the commit, pull request, and writing style
conventions: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md
PRs that don't follow it will be closed.
-->

### Description of your changes

Adds 0.2 release branch to the version drop down

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
