### PR TITLE
[release-0.1]backport versioning

### DIFF
--- a/docs/data/versions.yaml
+++ b/docs/data/versions.yaml
@@ -10,3 +10,5 @@ versions:
     url: "https://main.docs.modelplane.ai"
   - version: "0.1"
     url: "https://v0-1.docs.modelplane.ai"
+  - version: "0.2"
+    url: "https://v0-2.docs.modelplane.ai"

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -100,8 +100,9 @@ ignoreFiles = ["themes/geekboot/content/.*", "README.md"]
   description = "Modelplane documentation."
   # "main" on the dev branch; "X.Y" (e.g. "0.1") on release branches.
   version = "0.1"
-  # Latest stable release. The apex build redirects its root here.
-  latest = "0.1"
+  # Latest stable release. Drives the version dropdown and the "not the latest
+  # release" banners; the apex (docs.modelplane.ai) is this release's own build.
+  latest = "0.2"
   [params.anchors]
     min = 2
     max = 5


### PR DESCRIPTION
Add 0.2 Version to hugo.toml and versions

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
