### PR TITLE
ci: skip credential-dependent steps in fork runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,12 @@ jobs:
     needs: [check]
     runs-on: ubuntu-24.04
 
+    # Secrets aren't available in if expressions, so expose the (non-secret)
+    # robot ID as an env var that the push steps can gate on. Forks don't have
+    # the secret, so their runs build the package but skip pushing it.
+    env:
+      UP_ROBOT_ID: ${{ secrets.UP_ROBOT_ID }}
+
     steps:
       # Building and pushing the package needs more disk than the runner has
       # free by default, so reclaim space we don't use.
@@ -92,11 +98,11 @@ jobs:
 
       # The Crossplane CLI uses Docker's credential store for OCI pushes.
       - name: Login to registry
-        if: secrets.UP_ROBOT_ID != ''
+        if: env.UP_ROBOT_ID != ''
         uses: docker/login-action@v3
         with:
           registry: xpkg.upbound.io
-          username: ${{ secrets.UP_ROBOT_ID }}
+          username: ${{ env.UP_ROBOT_ID }}
           password: ${{ secrets.UP_ROBOT_TOKEN }}
 
       # On a release run, fetch the GitHub release's notes so the push app
@@ -114,7 +120,7 @@ jobs:
       # With a tag input (a release) push that exact version; otherwise push a
       # dev version the push app derives from git metadata.
       - name: Push
-        if: secrets.UP_ROBOT_ID != ''
+        if: env.UP_ROBOT_ID != ''
         run: |
           if [ -n "${TAG}" ]; then
             nix run .#push --print-build-logs -- --tag "${TAG}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,12 @@ jobs:
         with:
           use-flakehub: false
 
+      - name: Build
+        run: nix run .#build --print-build-logs
+
       # The Crossplane CLI uses Docker's credential store for OCI pushes.
       - name: Login to registry
+        if: secrets.UP_ROBOT_ID != ''
         uses: docker/login-action@v3
         with:
           registry: xpkg.upbound.io
@@ -109,9 +113,9 @@ jobs:
 
       # With a tag input (a release) push that exact version; otherwise push a
       # dev version the push app derives from git metadata.
-      - name: Build and Push
+      - name: Push
+        if: secrets.UP_ROBOT_ID != ''
         run: |
-          nix run .#build --print-build-logs
           if [ -n "${TAG}" ]; then
             nix run .#push --print-build-logs -- --tag "${TAG}"
           else

--- a/.github/workflows/docsearch.yml
+++ b/.github/workflows/docsearch.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   crawl:
+    if: secrets.ALGOLIA_ADMIN_KEY != ''
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/.github/workflows/docsearch.yml
+++ b/.github/workflows/docsearch.yml
@@ -22,15 +22,20 @@ concurrency:
 
 jobs:
   crawl:
-    if: secrets.ALGOLIA_ADMIN_KEY != ''
     runs-on: ubuntu-24.04
+    # Secrets aren't available in if expressions (and the env context isn't
+    # available in job-level ones), so mirror the secret into the job env and
+    # gate the steps on it. Forks don't have the secret, so their scheduled
+    # runs skip the crawl instead of failing.
+    env:
+      ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
     steps:
       - name: Checkout
+        if: env.ALGOLIA_ADMIN_KEY != ''
         uses: actions/checkout@v4
 
       - name: Crawl docs.modelplane.ai into Algolia
-        env:
-          ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
+        if: env.ALGOLIA_ADMIN_KEY != ''
         run: |
           docker run --rm \
             -e APPLICATION_ID=CQDMTRM1TJ \


### PR DESCRIPTION
<!--
Thanks for contributing to Modelplane! Read CONTRIBUTING.md before opening a PR
and follow it, especially the commit, pull request, and writing style
conventions: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md
PRs that don't follow it will be closed.
-->

### Description of your changes

Fork PRs do not have access to repository secrets, causing the registry login, push, and Algolia crawl steps to fail or run unnecessarily.

Split Build and Push into separate Build and Push steps, move Build before auth so CI fails fast on build errors before touching credentials
Gate Login to registry and Push on `secrets.UP_ROBOT_ID != ''` so forks build but skip the push
Gate the docsearch crawl job on `secrets.ALGOLIA_ADMIN_KEY != ''` so scheduled runs in forks don't spin up a runner at all

<!--
Lead with the problem, then the change and why it's right. Direct reviewers to
the parts that need judgment. Don't pad or invent rationale. See the Pull
requests and Writing style sections of CONTRIBUTING.md for what a good
description looks like.

If this PR fixes an open issue, reference it below, e.g. "Fixes #95".
-->

Fixes #

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
