### PR TITLE
Add a local two-cluster end-to-end test (no cloud, no GPU)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,99 @@
+name: E2E
+
+# The local two-cluster e2e in e2e/ is heavy — it stands up two kind clusters
+# and the full serving stack (cert-manager, Envoy Gateway/AI Gateway, GAIE,
+# kube-prometheus-stack, NFD, DRA) and waits for it to reconcile, ~15-20 min. The
+# time is that install and reconcile, not model weights (the engine is a mock).
+# So it doesn't run on every push: add the `test-e2e` label to a PR to run it (it
+# re-runs on each push while the label is set), or trigger it manually. Unlike
+# the package push, it needs no cloud or registry credentials.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch: {}
+
+# Cancel in-progress runs for the same PR. Runs on main are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    # Run on manual dispatch, when the test-e2e label is added, or on a push
+    # (synchronize/opened/reopened) while the PR carries it. Scoping the
+    # `labeled` event to test-e2e keeps adding any *other* label from firing a
+    # fresh ~20 min run.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.event.action == 'labeled' && github.event.label.name == 'test-e2e')
+      || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'test-e2e'))
+    runs-on: ubuntu-24.04
+    # Generous: a cold Nix cache (the Actions cache throttles) rebuilds the
+    # function images, on top of the two-cluster bring-up and serving-stack
+    # install. 45m was too tight on a cold run.
+    timeout-minutes: 60
+
+    steps:
+      # Two kind clusters and the serving stack need more disk than the runner
+      # has free by default, the same reason the push-package job reclaims space.
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          tool-cache: true
+          swap-storage: false
+          large-packages: false
+          docker-images: false
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: log-lines = 500
+
+      # See ci.yml for why use-flakehub is off.
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
+        with:
+          use-flakehub: false
+
+      # The exact command a developer runs locally (--print-build-logs is only CI
+      # verbosity), so a green run here and a green run on a laptop mean the same
+      # thing. It brings up both clusters, deploys the mock model, waits for the
+      # ModelService, and asserts a live 200 — exiting non-zero on any failure.
+      - name: Run e2e
+        run: nix run .#e2e --print-build-logs -- --verify
+
+      # On failure, capture what the clusters looked like before teardown.
+      # `kind export logs` dumps every pod's logs (crossplane, providers, the
+      # serving stack); the status snapshots make triage quick.
+      - name: Collect diagnostics
+        if: failure()
+        run: |
+          mkdir -p e2e-logs
+          nix develop --command bash -c '
+            kind export logs e2e-logs/control-plane --name modelplane-e2e-local || true
+            kind export logs e2e-logs/workload --name modelplane-e2e-workload || true
+            kubectl --context kind-modelplane-e2e-local get composite -o wide > e2e-logs/composites.txt 2>&1 || true
+            kubectl --context kind-modelplane-e2e-local -n ml-team get modeldeployment,modelreplica,modelendpoint,modelservice -o yaml > e2e-logs/model.yaml 2>&1 || true
+          '
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-diagnostics
+          path: e2e-logs
+          if-no-files-found: ignore
+
+      # Always tear both clusters down, even on failure or cancellation.
+      - name: Teardown
+        if: always()
+        run: nix run .#e2e -- --clean

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,16 @@ nix flake check            # or: ./nix.sh flake check
 `nix run .#fix` auto-fixes most lint and formatting issues. Run it before
 opening a PR.
 
+`nix flake check` is the unit layer — fast and sandboxed, proving each
+composition function renders the right resources. The integration layer is
+`nix run .#e2e`, which brings up two local `kind` clusters and runs the
+whole path — scheduling, the serving-stack install on a registered cluster,
+gateway routing, a live request — with no cloud credentials. Add `-- --verify`
+and it waits for readiness, asserts a 200, and exits non-zero on failure. That
+verify command is what the label-gated `E2E` workflow runs on CI (add the
+`test-e2e` label to a PR), so a green local `--verify` and a green CI run mean
+the same thing. See `e2e/README.md`.
+
 ## Submitting changes
 
 Before opening a PR, run `nix flake check` and make sure it passes. If you

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,186 @@
+# Local end-to-end test (no cloud, no GPU)
+
+Exercise the full Modelplane path — publish capacity, register a cluster, deploy
+a model, route a request through the control-plane gateway — on local `kind`
+clusters, with **no cloud provider and no GPU**.
+
+This is the integration layer. The composition functions run in-cluster against
+real providers, so it catches failures unit tests can't: missing RBAC,
+cross-cluster routing, CLI parsing, provider readiness gating, and teardown
+ordering. It needs no cloud or registry credentials, only public images — so it
+can gate a merge where the cloud e2e can't.
+
+It uses **two clusters**, mirroring a real deployment:
+
+- a **control-plane** cluster (crossplane + the Configuration + the
+  `InferenceGateway`), managed by `crossplane project run`;
+- a **workload** cluster registered via `source: Existing`, where the serving
+  stack and the model run.
+
+Two clusters rather than one because the control-plane `InferenceGateway`
+(Traefik) and the workload `ServingStack` (Envoy) both install the Gateway API
+CRDs — co-located on one cluster they race for the same cluster-scoped CRDs and
+the gateway wedges (`encountered composed resource without required
+composition-resource-name annotation`). Separate clusters, as in production,
+avoid it.
+
+Two Modelplane primitives make it cloud-free:
+
+- **`source: Existing`** — the `InferenceCluster` registers a bring-your-own
+  cluster (the workload kind cluster) via a kubeconfig Secret instead of
+  provisioning EKS/GKE/Nebius.
+- **`claim: DRA` + a fake GPU driver** — the `InferenceClass` advertises a
+  `gpu.example.com` device backed by the **dra-example-driver**
+  (kubernetes-sigs), which publishes fake GPUs with **no real hardware**. The
+  engine's `ResourceClaim` binds a fake device on a GPU-less node, so the *real*
+  DRA allocation path runs. (A claimable device is required: the fleet scheduler
+  rejects an engine whose only device is `Synthetic`.)
+
+The engine is a **mock server** (a few lines of Python) that answers both
+`/v1/chat/completions` (OpenAI) and `/v1/messages` (Anthropic), the way a vLLM
+server exposes both, so the pod goes Ready without a real model or GPU.
+
+## What this does and does not test
+
+| Tested | Not tested |
+|---|---|
+| Fleet scheduling / placement (CEL vs declared capacity) | Real token generation (mock engine) |
+| `ModelDeployment` → `ModelReplica` → `ModelEndpoint` → `ModelService` wiring | Real GPU drivers / CUDA (fake DRA devices only) |
+| DRA `ResourceClaim` → fake device binding (the real allocation path) | Multi-node / disaggregated (`PrefillDecode`) serving |
+| Serving-stack install on a real (BYO) workload cluster | Cloud provisioning (EKS/GKE/Nebius) |
+| Control-plane `InferenceGateway` + cross-cluster routing to the replica | |
+| Status propagation and foreground-deletion ordering | |
+
+## Prerequisites
+
+- **Docker** with real headroom — **≥ 16 GB memory** and **plenty of disk**
+  (raise Docker Desktop's disk-image size). Two kind clusters, 13 provider
+  packages, the built function images, and the serving stack
+  (kube-prometheus-stack et al.) add up fast; a full Docker disk surfaces as
+  `no space left on device`. Reclaim between runs with `docker builder prune -af`
+  and `docker image prune -af`.
+- Everything else — `kind`, `kubectl`, `curl`, `git`, and the `crossplane` CLI —
+  is provided by the flake via `nix run .#e2e`.
+
+The workload cluster is pinned to **k8s v1.34** (in `run.sh`) for the
+`resource.k8s.io` (DRA) APIs, on-by-default in 1.34: both the serving stack's
+NVIDIA DRA driver and the dra-example-driver register DeviceClasses, and the
+example driver publishes the `ResourceSlice`s the engine's `ResourceClaim` binds
+against. The control-plane cluster needs no DRA.
+
+## Run
+
+```bash
+nix run .#e2e              # bring up both clusters + deploy the mock model
+nix run .#e2e -- --verify  # same, then wait for readiness and assert a live 200
+nix run .#e2e -- --clean   # tear both clusters down
+```
+
+`crossplane project run` installs the config and applies the resources, then
+returns; the serving-stack install and model rollout reconcile in the background.
+So wait for the `ModelService` to publish an address before curling. That address
+is on the kind Docker subnet, which the host can't route to on macOS, so curl
+from a pod on the control plane:
+
+```bash
+kubectl -n ml-team get ms mock -w          # wait for ADDRESS to appear
+addr=$(kubectl -n ml-team get ms mock -o jsonpath='{.status.address}')
+
+# OpenAI Chat Completions
+kubectl run curl -n ml-team --rm -it --image=curlimages/curl@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13 -- \
+  curl -s "$addr/v1/chat/completions" -H 'content-type: application/json' \
+  -d '{"model":"mock","messages":[{"role":"user","content":"hi"}]}'
+
+# Anthropic Messages API (same address; vLLM and the mock serve both)
+kubectl run curl -n ml-team --rm -it --image=curlimages/curl@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13 -- \
+  curl -s "$addr/v1/messages" -H 'content-type: application/json' -H 'anthropic-version: 2023-06-01' \
+  -d '{"model":"mock","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
+```
+
+`--verify` runs both of those (OpenAI then Anthropic) and exits non-zero on
+failure. It's the exact command the `E2E` CI workflow runs, so a green `--verify`
+locally and a green CI run mean the same thing; use the manual curls above to
+poke the endpoints interactively.
+
+## How it's structured
+
+`nix run .#e2e` materialises the Nix-built function images and hands off to
+`run.sh`, which does the cross-cluster orchestration that `crossplane project
+run` flags can't express:
+
+1. Create the **workload** kind cluster (pinned v1.34).
+2. Install MetalLB on it (the serving stack doesn't) with a pool inside the
+   detected kind subnet and disjoint from the InferenceGateway's, install the
+   **dra-example-driver** (fake GPUs), and label its node for the `gpu-synthetic`
+   pool.
+3. `crossplane project run` for the **control plane**, with
+   `lean-control-plane.yaml` as `--init-resources` so the provider trims land
+   before the providers install.
+4. Finish the setup the getting-started flow does by hand (as the nix run app
+   does since #375): `kubectl apply` the RBAC prerequisites, point provider-helm
+   at its DeploymentRuntimeConfig, add the workload kubeconfig Secret (`kind get
+   kubeconfig --internal`, reachable from control-plane pods over the shared kind
+   network), then apply the subnet-templated Modelplane manifests.
+
+Everything the control plane needs is a declarative manifest; the shell in
+`run.sh` is only the irreducible cross-cluster setup (a second cluster, its
+MetalLB and DRA driver, the cross-cluster kubeconfig).
+
+```
+e2e/
+  run.sh                     # two-cluster orchestration
+  dra-example-driver.yaml    # vendored fake DRA GPU driver (applied to workload)
+  manifests/                 # applied to the control plane after setup
+    00-namespaces.yaml
+    10-inference-gateway.yaml
+    20-inference-class.yaml
+    30-inference-cluster.yaml # source: Existing -> the workload cluster
+    40-model-deployment.yaml
+    50-model-service.yaml
+```
+
+## Why the extra moving parts
+
+- **MetalLB on both clusters.** Both gateways — control-plane Traefik and the
+  workload Envoy Gateway (whose readiness the serving stack gates on,
+  `_GATEWAY_READY_CEL`) — need `LoadBalancer` addresses kind can't provide. The
+  `InferenceGateway` installs MetalLB on the control plane itself
+  (`compose_metallb`, pool `.200-.250`); the serving stack does *not*, so `run.sh`
+  installs MetalLB on the workload cluster with a **disjoint** pool (`.100-.149`).
+  Both pools sit inside the detected kind Docker subnet (see caveat) so the
+  control plane can route across it to the workload gateway's IP.
+- **Fake DRA driver.** A `claim: DRA` engine emits a `ResourceClaim`; with no DRA
+  driver it stays Pending and the pod never schedules. `run.sh` applies the
+  vendored **dra-example-driver**, which publishes fake `gpu.example.com` devices
+  so the claim binds on a GPU-less node.
+- **Cross-cluster kubeconfig.** `source: Existing` needs a kubeconfig the
+  control-plane provider pods can use to reach the workload API server.
+  `kind get kubeconfig --internal` gives an address routable across the shared
+  kind network; a host kubeconfig (`127.0.0.1:<port>`) wouldn't be.
+- **Node label.** On a BYO cluster Modelplane doesn't provision/label pools, so
+  `run.sh` labels the workload node `modelplane.ai/pool=gpu-synthetic` (matching
+  `nodePools[].name`); without it worker pods stay Pending.
+
+## Caveats / open questions
+
+- **Cross-cluster networking uses the detected kind subnet.** `run.sh` reads the
+  `kind` Docker network's subnet (usually 172.18.0.0/16, but kind bumps to
+  172.19/... when earlier networks already hold 172.18) and derives both disjoint
+  MetalLB pools from it — the workload pool directly, the InferenceGateway's by
+  rewriting its manifest. A hardcoded 172.18 would leave the LB IP off-subnet and
+  the cross-cluster curl would time out.
+- **Reconcile runs after the command returns.** `crossplane project run` waits
+  for the config to install, then applies the resources and exits — it doesn't
+  block on XR readiness. The serving-stack install (the long pole) and the model
+  rollout happen after, so watch the `ModelService` address rather than the
+  command's exit. `--timeout` in `run.sh` bounds the build and config install.
+- **Two DRA drivers on a GPU-less node.** The serving stack's **NVIDIA** DRA
+  driver targets NFD-GPU-labelled nodes, so it sits at 0/0 (inert) yet its Helm
+  release still reports Ready. The **dra-example-driver** `run.sh` installs is the
+  active one — it publishes the fake `gpu.example.com` devices the engine binds.
+- **Serving-stack weight.** cert-manager, Envoy Gateway, Envoy AI Gateway, GAIE
+  CRDs, kube-prometheus-stack, LeaderWorkerSet, NFD, DRA driver — all on the
+  workload node. Give Docker headroom.
+- **Package version.** Installs the **current branch** build (via `crossplane
+  project run`), not the published `v0.1.0`, because the `source: Existing` /
+  DRA-on-BYO path may postdate that tag.

--- a/e2e/dra-example-driver.yaml
+++ b/e2e/dra-example-driver.yaml
@@ -1,0 +1,271 @@
+# dra-example-driver v0.4.0 — a fake DRA GPU driver (no real hardware).
+#
+# VENDORED, do not hand-edit. Regenerate with:
+#   git clone --depth 1 --branch v0.4.0 \
+#     https://github.com/kubernetes-sigs/dra-example-driver
+#   helm template dra-example-driver \
+#     dra-example-driver/deployments/helm/dra-example-driver \
+#     --namespace dra-example-driver --kube-version 1.34.0 \
+#     --api-versions resource.k8s.io/v1
+#   # (--api-versions makes the chart pick the GA DeviceClass apiVersion;
+#   #  then prepend the Namespace below. The template output already starts with
+#   #  a --- separator, so don't add another after the Namespace.)
+#
+# run.sh applies this to the workload cluster. The kubeletplugin publishes 8 fake
+# gpu.example.com devices via a ResourceSlice, so a `claim: DRA` engine's
+# ResourceClaim binds on a GPU-less node — exercising the real DRA allocation
+# path the fleet scheduler and composition emit, without a GPU.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dra-example-driver
+---
+# Source: dra-example-driver/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dra-example-driver-service-account
+  namespace: dra-example-driver
+  labels:
+    helm.sh/chart: dra-example-driver-0.0.0-dev
+    app.kubernetes.io/name: dra-example-driver
+    app.kubernetes.io/instance: dra-example-driver
+    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: dra-example-driver/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dra-example-driver-role
+  namespace: dra-example-driver
+rules:
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/status"]
+  verbs: ["update"]
+# Kubernetes 1.36+ enforces granular authorization for ResourceClaim status
+# writes via the DRAResourceClaimGranularStatusAuthorization feature gate. As a
+# node-local driver, we need the "associated-node" verbs on
+# "resourceclaims/driver" for our own driver name. This rule is inert on older
+# clusters that have not yet enabled the feature gate.
+# See https://github.com/kubernetes/kubernetes/issues/138149
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/driver"]
+  verbs: ["associated-node:update", "associated-node:patch"]
+  resourceNames: ["gpu.example.com"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceslices"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+# Source: dra-example-driver/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dra-example-driver-role-binding
+  namespace: dra-example-driver
+subjects:
+- kind: ServiceAccount
+  name: dra-example-driver-service-account
+  namespace: dra-example-driver
+roleRef:
+  kind: ClusterRole
+  name: dra-example-driver-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: dra-example-driver/templates/kubeletplugin-metrics-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: dra-example-driver-kubeletplugin-metrics
+  namespace: dra-example-driver
+  labels:
+    helm.sh/chart: dra-example-driver-0.0.0-dev
+    app.kubernetes.io/name: dra-example-driver
+    app.kubernetes.io/instance: dra-example-driver
+    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: kubeletplugin
+spec:
+  selector:
+    app.kubernetes.io/name: dra-example-driver
+    app.kubernetes.io/instance: dra-example-driver
+    app.kubernetes.io/component: kubeletplugin
+  ports:
+  - name: metrics
+    protocol: TCP
+    port: 8080
+    targetPort: metrics
+---
+# Source: dra-example-driver/templates/kubeletplugin.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dra-example-driver-kubeletplugin
+  namespace: dra-example-driver
+  labels:
+    helm.sh/chart: dra-example-driver-0.0.0-dev
+    app.kubernetes.io/name: dra-example-driver
+    app.kubernetes.io/instance: dra-example-driver
+    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: kubeletplugin
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dra-example-driver
+      app.kubernetes.io/instance: dra-example-driver
+      app.kubernetes.io/component: kubeletplugin
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dra-example-driver
+        app.kubernetes.io/instance: dra-example-driver
+        app.kubernetes.io/component: kubeletplugin
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: dra-example-driver-service-account
+      securityContext:
+        {}
+      containers:
+      - name: plugin
+        securityContext:
+          privileged: true
+        image: registry.k8s.io/dra-example-driver/dra-example-driver:v0.4.0
+        imagePullPolicy: IfNotPresent
+        command: ["dra-example-kubeletplugin"]
+        resources:
+          {}
+
+        livenessProbe:
+          grpc:
+            port: 51515
+            service: liveness
+          failureThreshold: 3
+          periodSeconds: 10
+        ports:
+        - name: metrics
+          containerPort: 8080
+          protocol: TCP
+        env:
+        - name: DRIVER_NAME
+          value: "gpu.example.com"
+        - name: DEVICE_PROFILE
+          value: "gpu"
+        - name: CDI_ROOT
+          value: /var/run/cdi
+        - name: KUBELET_REGISTRAR_DIRECTORY_PATH
+          value: "/var/lib/kubelet/plugins_registry"
+        - name: KUBELET_PLUGINS_DIRECTORY_PATH
+          value: "/var/lib/kubelet/plugins"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        # Simulated number of devices the example driver will pretend to have.
+        - name: NUM_DEVICES
+          value: "8"
+        - name: GPU_DEVICE_STATUS
+          value: "false"
+        - name: GPU_ALLOW_MULTIPLE_ALLOCATIONS
+          value: "false"
+        - name: HEALTHCHECK_PORT
+          value: "51515"
+        - name: METRICS_PORT
+          value: "8080"
+        - name: GPU_PARTITIONS
+          value: "0"
+        - name: CPU_NUMA_NODES
+          value: "8"
+        - name: CPUS_PER_NUMA_NODE
+          value: "4"
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: BINDING_CONDITIONS
+          value: "false"
+        volumeMounts:
+        - name: plugins-registry
+          mountPath: "/var/lib/kubelet/plugins_registry"
+        - name: plugins
+          mountPath: "/var/lib/kubelet/plugins"
+        - name: cdi
+          mountPath: /var/run/cdi
+      volumes:
+      - name: plugins-registry
+        hostPath:
+          path: "/var/lib/kubelet/plugins_registry"
+      - name: plugins
+        hostPath:
+          path: "/var/lib/kubelet/plugins"
+      - name: cdi
+        hostPath:
+          path: /var/run/cdi
+---
+# Source: dra-example-driver/templates/deviceclass.yaml
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: gpu.example.com
+spec:
+  selectors:
+  - cel:
+      expression: "device.driver == 'gpu.example.com'"
+---
+# Source: dra-example-driver/templates/validatingadmissionpolicy.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: resourceslices-policy-dra-example-driver
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["resource.k8s.io"]
+      apiVersions: ["v1beta1", "v1beta2", "v1"]
+      operations:  ["CREATE", "UPDATE", "DELETE"]
+      resources:   ["resourceslices"]
+  matchConditions:
+  - name: isRestrictedUser
+    expression: >-
+      request.userInfo.username == "system:serviceaccount:dra-example-driver:dra-example-driver-service-account"
+  variables:
+  - name: userNodeName
+    expression: >-
+      request.userInfo.extra[?'authentication.kubernetes.io/node-name'][0].orValue('')
+  - name: objectNodeName
+    expression: >-
+      (request.operation == "DELETE" ? oldObject : object).spec.?nodeName.orValue("")
+  validations:
+  - expression: variables.userNodeName != ""
+    message: >-
+      no node association found for user, this user must run in a pod on a node and ServiceAccountTokenPodNodeInfo must be enabled
+  - expression: variables.userNodeName == variables.objectNodeName
+    messageExpression: >-
+      "this user running on node '"+variables.userNodeName+"' may not modify " +
+      (variables.objectNodeName == "" ?"cluster resourceslices" : "resourceslices on node '"+variables.objectNodeName+"'")
+---
+# Source: dra-example-driver/templates/validatingadmissionpolicybinding.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: resourceslices-policy-dra-example-driver
+spec:
+  policyName: resourceslices-policy-dra-example-driver
+  validationActions: [Deny]
+  # All ResourceSlices are matched.

--- a/e2e/lean-control-plane.yaml
+++ b/e2e/lean-control-plane.yaml
@@ -1,0 +1,51 @@
+# Trim the control plane to what the BYO (source: Existing) scenario actually
+# uses. The Configuration depends on ~10 cloud providers (AWS/GCP/Azure/Nebius)
+# that only exist to *provision* clusters; here the workload cluster already
+# exists, so the compositions use only provider-kubernetes and provider-helm.
+#
+# run.sh feeds this via `crossplane project run --init-resources`, which applies
+# it BEFORE the Configuration's dependencies install, so the cloud providers
+# never activate their managed resources or run their controllers.
+
+# 1. Scale the unused cloud provider controllers to zero. The cloud packages all
+#    live under xpkg.upbound.io/upbound/provider-*, while the two we use are
+#    xpkg.upbound.io/modelplane/*, so this prefix matches only the unused ones.
+#    ImageConfig applies the runtime config to matching packages including ones
+#    installed as dependencies (Crossplane docs: packages/image-configs).
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: scale-to-zero
+spec:
+  deploymentTemplate:
+    spec:
+      selector: {}
+      replicas: 0
+      template: {}
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: ImageConfig
+metadata:
+  name: dormant-cloud-providers
+spec:
+  matchImages:
+  - type: Prefix
+    prefix: xpkg.upbound.io/upbound/provider-
+  runtime:
+    configRef:
+      name: scale-to-zero
+---
+# 2. Replace the Helm chart's default catch-all MRAP (activate: ["*"]) with one
+#    that activates only the managed resources the BYO compositions use, so the
+#    cloud providers' MRs stay dormant (fewer CRDs). The compositions run
+#    provider-helm/kubernetes v2, whose MRs are namespaced (.m.crossplane.io) —
+#    the same forms the shipped apis/mrap.yaml activates — so the cluster-scoped
+#    variants aren't needed here.
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: ManagedResourceActivationPolicy
+metadata:
+  name: default
+spec:
+  activate:
+  - "*.kubernetes.m.crossplane.io"
+  - "*.helm.m.crossplane.io"

--- a/e2e/manifests/00-namespaces.yaml
+++ b/e2e/manifests/00-namespaces.yaml
@@ -1,0 +1,7 @@
+# The model resources live in ml-team; run.sh applies these manifests with
+# kubectl once the control plane is ready. modelplane-system is created earlier
+# by prerequisites.yaml, before run.sh adds the workload kubeconfig Secret to it.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ml-team

--- a/e2e/manifests/10-inference-gateway.yaml
+++ b/e2e/manifests/10-inference-gateway.yaml
@@ -1,0 +1,21 @@
+# Control-plane front door. On kind there's no cloud LoadBalancer, so Traefik's
+# Service gets its external IP from MetalLB. Setting loadBalancer: MetalLB makes
+# the InferenceGateway composition install MetalLB on the control-plane cluster
+# and configure this pool itself (see compose_metallb), so no separate MetalLB
+# install is needed here. The workload cluster runs its own MetalLB, installed
+# by run.sh, for the serving stack's Envoy gateway.
+apiVersion: modelplane.ai/v1alpha1
+kind: InferenceGateway
+metadata:
+  name: default
+spec:
+  backend: Traefik
+  traefik:
+    version: "40.2.0"
+    loadBalancer: MetalLB
+    metallb:
+      # run.sh rewrites the 172.18 prefix to the actual kind Docker subnet before
+      # applying (kind bumps off 172.18 when earlier networks hold it — see the
+      # subnet detection there). Kept disjoint from the workload cluster's MetalLB
+      # pool (.100-.149) since both clusters share the subnet.
+      addressPool: "172.18.255.200-172.18.255.250"

--- a/e2e/manifests/20-inference-class.yaml
+++ b/e2e/manifests/20-inference-class.yaml
@@ -1,0 +1,22 @@
+# A fake-GPU class backed by kubernetes-sigs/dra-example-driver (installed on the
+# workload cluster by run.sh). claim: DRA is required — the fleet scheduler
+# rejects an engine whose only device is Synthetic, because it needs a claimable
+# device to bind a ResourceClaim through (see scheduling.py). The example driver
+# publishes fake gpu.example.com devices (memory 80Gi) with no real hardware, so
+# the engine's ResourceClaim binds on a GPU-less node. No provisioning block — it
+# describes hardware on a BYO/Existing cluster.
+apiVersion: modelplane.ai/v1alpha1
+kind: InferenceClass
+metadata:
+  name: synthetic-gpu
+spec:
+  description: "Fake GPU via dra-example-driver (no real hardware)"
+  devices:
+  - name: gpu
+    claim: DRA
+    driver: gpu.example.com
+    deviceClassName: gpu.example.com
+    count: 1
+    capacity:
+      # The example driver publishes 80Gi per device; the >= 20Gi selector matches.
+      memory: { value: "80Gi" }

--- a/e2e/manifests/30-inference-cluster.yaml
+++ b/e2e/manifests/30-inference-cluster.yaml
@@ -1,0 +1,22 @@
+# Registers the separate workload kind cluster via source: Existing. run.sh
+# creates that cluster, builds the referenced kubeconfig Secret in
+# modelplane-system (--internal address, reachable from the control plane's
+# provider pods over the shared kind network), and labels its node
+# modelplane.ai/pool=gpu-synthetic.
+apiVersion: modelplane.ai/v1alpha1
+kind: InferenceCluster
+metadata:
+  name: local
+  labels:
+    modelplane.ai/region: local
+spec:
+  cluster:
+    source: Existing
+    existing:
+      secretRef:
+        name: local-cluster-kubeconfig
+        key: kubeconfig
+  nodePools:
+  - name: gpu-synthetic
+    className: synthetic-gpu
+    nodeCount: 1

--- a/e2e/manifests/40-model-deployment.yaml
+++ b/e2e/manifests/40-model-deployment.yaml
@@ -1,0 +1,79 @@
+# A single Standalone engine (Unified serving, the default). Modelplane composes
+# the full serving path for it (an InferencePool, an endpoint-picker, and an
+# HTTPRoute), so this exercises real routing. The engine is a mock server: it
+# needs no GPU and no model, so the pod goes Ready and answers both
+# /v1/chat/completions (OpenAI) and /v1/messages (Anthropic), the way a vLLM
+# server exposes both, without real inference.
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelDeployment
+metadata:
+  name: mock-demo
+  namespace: ml-team
+spec:
+  replicas: 1
+  template:
+    spec:
+      engines:
+      - name: mock
+        members:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 1
+              selectors:
+              # Matches the fake GPU's declared capacity (80Gi >= 20Gi). Domain is
+              # gpu.example.com — the dra-example-driver's driver name.
+              - cel: |
+                  device.capacity["gpu.example.com"].memory.compareTo(quantity("20Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                # python:3.12-alpine, pinned by digest (multi-arch) so a moving tag can't flake CI.
+                image: python@sha256:6d43704baacd1bfbe7c295d7f13079d5d8104ed33568873133f8fc69980419df
+                command: ["python", "-u", "-c"]
+                args:
+                - |
+                  import json, http.server
+                  class H(http.server.BaseHTTPRequestHandler):
+                      def _s(self, o, c=200):
+                          b = json.dumps(o).encode()
+                          self.send_response(c)
+                          self.send_header("content-type", "application/json")
+                          self.send_header("content-length", str(len(b)))
+                          self.end_headers()
+                          self.wfile.write(b)
+                      def do_GET(self):
+                          if self.path == "/health":
+                              self._s({"status": "ok"})
+                          elif self.path.startswith("/v1/models"):
+                              self._s({"object": "list", "data": [{"id": "mock", "object": "model"}]})
+                          else:
+                              self._s({"error": "not found"}, 404)
+                      def do_POST(self):
+                          n = int(self.headers.get("content-length") or 0)
+                          self.rfile.read(n)
+                          text = "Hello from the Modelplane local mock engine."
+                          if self.path.startswith("/v1/messages"):
+                              # Anthropic Messages API; vLLM serves it alongside the OpenAI routes.
+                              self._s({
+                                  "id": "msg-mock", "type": "message", "role": "assistant",
+                                  "model": "mock", "stop_reason": "end_turn",
+                                  "content": [{"type": "text", "text": text}],
+                                  "usage": {"input_tokens": 1, "output_tokens": 1},
+                              })
+                          else:
+                              self._s({
+                                  "id": "chatcmpl-mock", "object": "chat.completion", "model": "mock",
+                                  "choices": [{"index": 0, "finish_reason": "stop",
+                                               "message": {"role": "assistant", "content": text}}],
+                                  "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                              })
+                      def log_message(self, *a):
+                          pass
+                  http.server.HTTPServer(("0.0.0.0", 8000), H).serve_forever()
+                # The ModelDeployment container template is a curated subset
+                # (name/image/command/args/env); the composition wires the port,
+                # readiness, and any GPU resources itself (it assumes port 8000). So
+                # no ports/readinessProbe/resources here — the XRD rejects them.

--- a/e2e/manifests/50-model-service.yaml
+++ b/e2e/manifests/50-model-service.yaml
@@ -1,0 +1,12 @@
+# Fronts the mock deployment's replicas behind one OpenAI-compatible endpoint on
+# the control-plane gateway. Its status.address is what you curl (see README).
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelService
+metadata:
+  name: mock
+  namespace: ml-team
+spec:
+  endpoints:
+  - selector:
+      matchLabels:
+        modelplane.ai/deployment: mock-demo

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# Two-cluster local e2e (no cloud, no GPU). Usually invoked via
+# `nix run .#e2e` (which provides the tooling and the Nix-built function
+# images). See README.md.
+#
+# Two clusters, because the control-plane InferenceGateway (Traefik) and the
+# workload ServingStack (Envoy) both install the Gateway API CRDs — on one
+# cluster they race for the same cluster-scoped CRDs and the gateway wedges. So:
+#   - a workload kind cluster (this script creates it), registered via
+#     source: Existing, where the serving stack + model run;
+#   - a control-plane cluster (crossplane project run manages it) with crossplane
+#     + the config + the InferenceGateway.
+set -euo pipefail
+
+CP=modelplane-e2e-local
+WL=modelplane-e2e-workload
+# Pinned so the workload cluster has the DRA APIs the serving stack's NVIDIA DRA
+# driver needs (resource.k8s.io, GA in k8s 1.34). The control-plane cluster that
+# project run creates needs no DRA, so its image doesn't matter here.
+WL_NODE_IMAGE=kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
+METALLB_URL=https://raw.githubusercontent.com/metallb/metallb/v0.14.8/config/manifests/metallb-native.yaml
+# Pinned by digest (a multi-arch manifest list) so a moving :latest can't flake
+# the verify curl pod.
+CURL_IMAGE=curlimages/curl@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
+ROOT="$(git rev-parse --show-toplevel)"
+
+log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+
+if [ "${1:-}" = "--clean" ]; then
+	# Always delete both clusters — don't gate kind delete on project stop's exit
+	# code (it can exit 0 without removing the cluster). project stop is
+	# best-effort for the local registry it also manages.
+	crossplane project stop --control-plane-name "$CP" 2>/dev/null || true
+	kind delete cluster --name "$CP" || true
+	kind delete cluster --name "$WL" || true
+	docker rm -f "${CP}-registry" >/dev/null 2>&1 || true
+	exit 0
+fi
+
+# One temp dir for everything this run creates (the isolated Docker config and
+# the rendered manifests), removed on exit. mktemp -d gives a fresh unique path
+# and the trap captures it on the next line, so the rm -rf can never reach a real
+# directory. --no-apply clears the trap to keep the dir for manual apply.
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+WLCTX="kind-$WL"
+if kind get clusters 2>/dev/null | grep -qx "$WL"; then
+	# Reuse an existing workload cluster only if it's the pinned version. An
+	# older one lacks the DRA APIs and would fail the run confusingly later.
+	ver="$(kubectl --context "$WLCTX" get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' 2>/dev/null || true)"
+	case "$ver" in
+	v1.34.*) log "Reusing workload cluster $WL ($ver)" ;;
+	*)
+		echo "workload cluster $WL is ${ver:-unreachable}, but v1.34 is required for the DRA APIs; recreate it with: nix run .#e2e -- --clean" >&2
+		exit 1
+		;;
+	esac
+else
+	log "Creating workload cluster $WL (k8s v1.34, for DRA)"
+	kind create cluster --name "$WL" --image "$WL_NODE_IMAGE"
+fi
+
+# Both kind clusters share one Docker network; MetalLB hands out LoadBalancer IPs
+# from it, and the control plane must ROUTE to the workload gateway's IP across
+# it. So the pools must sit inside the *actual* kind subnet — normally
+# 172.18.0.0/16, but kind bumps to 172.19/172.20/... when earlier Docker networks
+# already hold 172.18. Detect it and derive both pools (this one and the
+# InferenceGateway's) from the same prefix; a hardcoded 172.18 leaves the LB IP
+# off-subnet and silently breaks cross-cluster routing (curl times out).
+# `|| true` so a detection miss (grep finds nothing) doesn't trip set -e here —
+# the explicit check below then reports it instead of an opaque abort.
+SUBNET="$(docker network inspect kind -f '{{range .IPAM.Config}}{{println .Subnet}}{{end}}' | grep -E '^[0-9]+\.' | head -1 || true)"
+PREFIX="$(printf '%s' "$SUBNET" | cut -d. -f1-2)"
+[ -n "$PREFIX" ] || {
+	echo "could not detect the kind Docker subnet" >&2
+	exit 1
+}
+log "kind Docker subnet ${SUBNET} -> MetalLB pools ${PREFIX}.255.x"
+
+# The serving stack doesn't install MetalLB, so the workload Envoy gateway needs
+# it here. Use a range disjoint from the InferenceGateway's pool (.200-.250) —
+# both clusters share the subnet, so their pools must not overlap.
+log "Installing MetalLB on the workload cluster (pool ${PREFIX}.255.100-.149)"
+kubectl --context "$WLCTX" apply -f "$METALLB_URL"
+kubectl --context "$WLCTX" -n metallb-system rollout status deploy/controller --timeout=180s
+kubectl --context "$WLCTX" apply -f - <<POOL
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata: { name: kind-pool, namespace: metallb-system }
+spec: { addresses: ["${PREFIX}.255.100-${PREFIX}.255.149"] }
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata: { name: kind-l2, namespace: metallb-system }
+spec: { ipAddressPools: [kind-pool] }
+POOL
+
+# Fake DRA GPUs so a `claim: DRA` engine's ResourceClaim binds on this GPU-less
+# node (vendored dra-example-driver — see dra-example-driver.yaml). Without a DRA
+# driver the ResourceClaim stays Pending and the engine pod never schedules; the
+# fleet scheduler also rejects an engine whose only device is Synthetic.
+log "Installing dra-example-driver (fake GPUs) on the workload cluster"
+kubectl --context "$WLCTX" apply -f "$ROOT/e2e/dra-example-driver.yaml"
+kubectl --context "$WLCTX" -n dra-example-driver rollout status ds/dra-example-driver-kubeletplugin --timeout=120s
+
+# BYO clusters aren't labelled by Modelplane; the gpu-synthetic pool selects on this.
+log "Labelling the workload node for pool gpu-synthetic"
+kubectl --context "$WLCTX" label node "${WL}-control-plane" modelplane.ai/pool=gpu-synthetic --overwrite
+
+# No system PATH in the nix app, so a Docker config using credsStore "desktop"
+# would break package resolution. The provider packages are public.
+docker_config="$work/docker"
+mkdir -p "$docker_config"
+printf '{}' >"$docker_config/config.json"
+export DOCKER_CONFIG="$docker_config"
+
+# Render the manifests with the detected subnet prefix (the InferenceGateway's
+# MetalLB addressPool is the only IP baked into them). Flags pick the mode:
+#   --no-apply  install and finish the control plane but skip the model
+#               manifests — for gradual, manual apply/debugging.
+#   --verify    after apply, wait for the ModelService and assert a live 200,
+#               exiting non-zero on failure. This is exactly what CI runs, so
+#               running it locally gives the same pass/fail signal (dev/CI parity).
+rendered="$work/rendered"
+mkdir -p "$rendered"
+cp "$ROOT/e2e/manifests/"*.yaml "$rendered/"
+sed -i.bak "s/172\.18\.255/${PREFIX}.255/g" "$rendered/"*.yaml && rm -f "$rendered/"*.bak
+cpctx="kind-$CP"
+apply_manifests=1
+verify=0
+case "${1:-}" in
+--no-apply) apply_manifests=0 ;;
+--verify) verify=1 ;;
+esac
+
+log "Building + running the control plane"
+cd "$ROOT"
+# Install the config with the lean control-plane trims (narrowed MRAP + scale-to-0)
+# applied before the providers. prerequisites.yaml is applied afterwards with
+# kubectl, not through --init-resources: it opens with a comment-only YAML
+# document that `crossplane project run` rejects but kubectl skips.
+crossplane project run \
+	--control-plane-name "$CP" --cluster-admin --timeout 25m \
+	--init-resources "$ROOT/e2e/lean-control-plane.yaml"
+
+# Config healthy. Finish the setup the getting-started flow does by hand (as the
+# nix run app now does too, PR #375): apply the RBAC prerequisites, then point
+# provider-helm at the DeploymentRuntimeConfig they define. Providers install
+# before prerequisites.yaml, and an ImageConfig binds only at ProviderRevision
+# creation, so provider-helm otherwise comes up without the granted RBAC.
+log "Finishing control-plane setup: prerequisites + provider-helm runtime config"
+kubectl --context "$cpctx" apply -f "$ROOT/docs/manifests/getting-started/prerequisites.yaml"
+kubectl --context "$cpctx" patch provider.pkg.crossplane.io modelplane-provider-helm --type merge \
+	-p '{"spec":{"runtimeConfigRef":{"apiVersion":"pkg.crossplane.io/v1beta1","kind":"DeploymentRuntimeConfig","name":"provider-helm-modelplane"}}}'
+
+# The InferenceCluster (source: Existing) reads this kubeconfig to reach the
+# workload cluster; --internal gives an address routable from the control plane's
+# provider pods. It lives in modelplane-system, created by prerequisites.yaml above.
+{
+	printf 'apiVersion: v1\nkind: Secret\nmetadata: {name: local-cluster-kubeconfig, namespace: modelplane-system}\nstringData:\n  kubeconfig: |\n'
+	kind get kubeconfig --internal --name "$WL" | sed 's/^/    /'
+} | kubectl --context "$cpctx" apply -f -
+
+if [ "$apply_manifests" = 0 ]; then
+	trap - EXIT # keep $work so the rendered manifests survive for manual apply
+	log "--no-apply: control plane ready; apply manifests from $rendered (kept for you)"
+	exit 0
+fi
+
+# RBAC is in place, so the InferenceGateway composes its native cluster resources
+# without wedging. Apply the model manifests.
+kubectl --context "$cpctx" apply -f "$rendered/"
+
+if [ "$verify" = 0 ]; then
+	log "Done. Curl the ModelService per the README; clean up with: nix run .#e2e -- --clean"
+	exit 0
+fi
+
+# --verify: project run returns once the config is healthy and the resources are
+# applied, so the serving-stack install and model rollout are still reconciling.
+# Wait for the ModelService to publish an address, then route a real request to
+# the engine and assert a 200. Any failure exits non-zero — that is what makes
+# this usable as a CI gate.
+log "Verifying the model serves end to end"
+ns=ml-team
+svc=mock
+
+addr=""
+for _ in $(seq 1 80); do
+	addr="$(kubectl --context "$cpctx" -n "$ns" get modelservice "$svc" -o jsonpath='{.status.address}' 2>/dev/null || true)"
+	[ -n "$addr" ] && break
+	sleep 15
+done
+[ -n "$addr" ] || {
+	echo "verify: ModelService $ns/$svc never published an address" >&2
+	exit 1
+}
+log "ModelService address: $addr"
+
+# The address is on the kind Docker subnet the host can't route to on macOS, so
+# curl from a pod on the control plane, reading the status from the pod's logs
+# (not `run -i`, whose attach drops output on a headless runner). curl_status
+# runs one throwaway pod per call and echoes the HTTP code; it polls the logs
+# (curl writes the code once, then exits) so a failed attempt costs seconds, and
+# a unique pod name per call keeps retries from reading a prior pod's output.
+curl_status() {
+	local pod="$1" url="$2"
+	shift 2
+	kubectl --context "$cpctx" -n "$ns" run "$pod" --restart=Never \
+		--labels=app.kubernetes.io/name=e2e-verify --image="$CURL_IMAGE" \
+		--command -- curl -sS --max-time 15 -o /dev/null -w '%{http_code}' "$url" "$@" \
+		>/dev/null 2>&1 || true
+	local c=""
+	for _ in $(seq 1 30); do
+		c="$(kubectl --context "$cpctx" -n "$ns" logs "$pod" 2>/dev/null | tr -dc '0-9' || true)"
+		[ -n "$c" ] && break
+		sleep 2
+	done
+	printf '%s' "$c"
+}
+
+# OpenAI /v1/chat/completions, retried: the address can publish a moment before
+# the cross-cluster route is serving, and a slower CI runner widens that gap.
+oai='{"model":"'"$svc"'","messages":[{"role":"user","content":"ping"}]}'
+code=""
+for attempt in $(seq 1 10); do
+	code="$(curl_status "e2e-verify-oai-$attempt" "$addr/v1/chat/completions" -H 'content-type: application/json' -d "$oai")"
+	log "verify attempt $attempt (OpenAI): HTTP ${code:-none}"
+	[ "$code" = "200" ] && break
+	sleep 10
+done
+[ "$code" = "200" ] || {
+	echo "verify: $addr/v1/chat/completions did not return 200 within retries (last: ${code:-none})" >&2
+	kubectl --context "$cpctx" -n "$ns" delete pod -l app.kubernetes.io/name=e2e-verify --now >/dev/null 2>&1 || true
+	exit 1
+}
+
+# Anthropic Messages API on the same address: vLLM serves /v1/messages alongside
+# the OpenAI routes (PR #360) and the route preserves the path. Serving is up by
+# now, so one attempt suffices.
+ant='{"model":"'"$svc"'","max_tokens":16,"messages":[{"role":"user","content":"ping"}]}'
+mcode="$(curl_status e2e-verify-anthropic "$addr/v1/messages" -H 'content-type: application/json' -H 'anthropic-version: 2023-06-01' -d "$ant")"
+log "verify (Anthropic /v1/messages): HTTP ${mcode:-none}"
+kubectl --context "$cpctx" -n "$ns" delete pod -l app.kubernetes.io/name=e2e-verify --now >/dev/null 2>&1 || true
+[ "$mcode" = "200" ] || {
+	echo "verify: $addr/v1/messages did not return 200 (last: ${mcode:-none})" >&2
+	exit 1
+}
+log "End to end OK: $addr serves OpenAI (/v1/chat/completions) and Anthropic (/v1/messages)"

--- a/flake.nix
+++ b/flake.nix
@@ -174,6 +174,7 @@
             dockerCredentialUp = pkgs.upbound;
           };
           stop = apps.stop { inherit crossplane; };
+          e2e = apps.e2e { inherit crossplane functionsPkg; };
           docs-serve = apps.docsServe { };
           docs-generate = apps.docsGenerate { };
         }

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -278,6 +278,52 @@
       );
     };
 
+  # Run the two-cluster local end-to-end test: a workload
+  # kind cluster registered via source: Existing (serving stack + model) and a
+  # control-plane cluster (crossplane + the InferenceGateway). Two clusters
+  # because the control-plane and workload layers both install the Gateway API
+  # CRDs and collide on a single cluster. See e2e. Tear down with
+  # `nix run .#e2e -- --clean`. This app just materialises the Nix-built
+  # function images (as `run` does), then hands off to run.sh, which needs real
+  # orchestration (a second cluster, a cross-cluster kubeconfig) that
+  # `crossplane project run` flags can't express — kept a normal shell file so
+  # it stays shellcheck-clean rather than escaped nix strings.
+  e2e =
+    {
+      crossplane,
+      functionsPkg,
+    }:
+    {
+      type = "app";
+      meta.description = "Run the local two-cluster end-to-end test";
+      program = pkgs.lib.getExe (
+        pkgs.writeShellApplication {
+          name = "modelplane-e2e";
+          runtimeInputs = [
+            crossplane
+            pkgs.coreutils
+            pkgs.gnused
+            pkgs.gnugrep
+            pkgs.gawk
+            pkgs.kind
+            pkgs.kubectl
+            pkgs.curl
+            pkgs.docker-client
+            pkgs.git
+            pkgs.bash
+          ];
+          inheritPath = false;
+          text = ''
+            mkdir -p _output
+            rm -f _output/functions
+            ln -s ${functionsPkg} _output/functions
+
+            exec bash e2e/run.sh "$@"
+          '';
+        }
+      );
+    };
+
   # Serve the docs site locally with live reload. Extra args pass through to
   # hugo server, e.g.: nix run .#docs-serve -- --port 8080
   docsServe = _: {


### PR DESCRIPTION
### Description of your changes

Modelplane has no end-to-end test in the repo. Unit tests cover what each composition function renders, but nothing checks that the composed resources actually reconcile and serve on a real cluster. The one path that exercises the full flow (publish capacity, register a cluster, deploy a model, serve a request) is getting started, which provisions EKS/GKE/Nebius and needs GPUs, so it can't run on a laptop or gate CI without a cloud account and accelerators. The failures that only surface at runtime (missing RBAC, cross-cluster routing, provider readiness, teardown ordering) have had nothing to catch them.

This adds `nix run .#e2e`: the whole path on two local `kind` clusters.

- **No cloud, no GPU, no credentials.** The `InferenceCluster` registers the workload cluster from a kubeconfig Secret (`source: Existing`) instead of provisioning EKS/GKE/Nebius; the `InferenceClass` advertises a fake `gpu.example.com` device (`claim: DRA`, vendored dra-example-driver) that binds on a GPU-less node; and the `ModelDeployment` runs a mock server in place of a real engine, answering both the OpenAI and Anthropic message APIs, so the pod goes Ready without a real model.
- **Dev/CI parity.** `nix run .#e2e -- --verify` brings it up, waits for the ModelService, and asserts a live 200. You run it locally; CI runs the identical command. The workflow is a thin wrapper (disk, cache, diagnostics, teardown) with no test logic of its own.
- **Label-gated.** Behind a `test-e2e` PR label, not every push (a run is 15-20 minutes). No secrets, so it can gate a PR on its own.
- **Real orchestration.** Two clusters, because the control-plane and workload gateways both install the Gateway API CRDs and collide on one; the full ModelDeployment, ModelReplica, ModelEndpoint, ModelService chain; a DRA ResourceClaim actually bound on the workload cluster.

`nix run .#e2e -- --verify` brings both clusters up, asserts the endpoint serves (it curls from a pod on the control plane and checks the status), and leaves the whole platform queryable, no cloud in sight:

```console
$ nix run .#e2e -- --verify
...
==> ModelService address: http://172.19.255.200/ml-team/mock
==> verify attempt 1 (OpenAI): HTTP 200
==> verify (Anthropic /v1/messages): HTTP 200
==> End to end OK: http://172.19.255.200/ml-team/mock serves OpenAI (/v1/chat/completions) and Anthropic (/v1/messages)

$ kubectl get inferencegateway,inferencecluster,inferenceclass
NAME                                     GATEWAY   ADDRESS          SYNCED   READY
inferencegateway.modelplane.ai/default   Traefik   172.19.255.200   True     True
NAME                                   SOURCE     GATEWAY          SYNCED   READY
inferencecluster.modelplane.ai/local   Existing   172.19.255.100   True     True
NAME                                         SYNCED   READY
inferenceclass.modelplane.ai/synthetic-gpu   True     True

$ kubectl -n ml-team get modeldeployment,modelservice
NAME                                      REPLICAS   SYNCED   READY
modeldeployment.modelplane.ai/mock-demo   1          True     True
NAME                              ADDRESS                              SYNCED   READY
modelservice.modelplane.ai/mock   http://172.19.255.200/ml-team/mock   True     True
```

**Scope.** Stops short of real token generation (mock engine), GPU drivers/CUDA (fake DRA), cloud provisioning, and multi-node serving. `e2e/README.md` has the design and a tested/not-tested table; CONTRIBUTING gains a note placing the two layers (unit via `nix flake check`, integration via `nix run .#e2e`).

**Alternatives ruled out.**

- A declarative test runner like Chainsaw for the assertions: the hard part is the two-cluster bootstrap, which is irreducible shell a runner would only wrap, so it wasn't worth a third testing idiom for one scenario.
- A small real model on CPU: exercises the inference engine, not Modelplane's orchestration, at a large cost in image size, weights, and runtime.

`nix run .#e2e -- --verify` passes both locally and in CI (green run: https://github.com/ytsarev/modelplane-public/actions/runs/30901652231).

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~~Added or updated tests covering any composition function changes.~~ (no `functions/` changes)
- [x] Signed off every commit with `git commit -s`.