### PR TITLE
[docs] DocSearch Algolia fix

### DIFF
--- a/docs/layouts/robots.txt
+++ b/docs/layouts/robots.txt
@@ -1,0 +1,2 @@
+# Algolia-Crawler-Verif: 49AA2A09027617D0
+User-agent: *

--- a/docs/layouts/robots.txt
+++ b/docs/layouts/robots.txt
@@ -1,2 +1,2 @@
-# Algolia-Crawler-Verif: 49AA2A09027617D0
+# Algolia-Crawler-Verif: F69C38A910C2B294
 User-agent: *

--- a/docs/themes/geekboot/layouts/partials/scripts.html
+++ b/docs/themes/geekboot/layouts/partials/scripts.html
@@ -12,9 +12,9 @@
 
     docsearch({
     container: '#docSearch',
-    appId: 'CQDMTRM1TJ',
-    indexName: 'modelplane',
-    apiKey: 'd3056ed34b0725f5eb96a188e3df70a3',
+    appId: 'PQSS9LVZU8',
+    indexName: 'Modelplane Docs',
+    apiKey: '166282d02b04578bb8986beef34e0b36',
     placeholder: 'Search the docs'
     });
 


### PR DESCRIPTION
This PR adds a robot verification step for the docs domains.

Also removes the Algolia Build Plan search and replaces it with a DocSearch application which provides a free crawler we don't need a gh action to reindex. Matches the Crossplane/Upbound docs search process


Fixes #371 

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
