### PR TITLE
feat(nix): Finish control plane setup and surface failures in the nix run app

### DIFF
--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -137,16 +137,58 @@
             rm -f _output/functions
             ln -s ${functionsPkg} _output/functions
 
-            crossplane project run "$@"
+            # The CLI's default --timeout of 5m covers waiting for the
+            # installed configuration to become healthy, which first-time
+            # image pulls through nix.sh's Docker-in-Docker daemon regularly
+            # exceed. Default to a longer wait; an explicit --timeout on the
+            # command line still wins.
+            timeout_args=(--timeout 15m)
+            for arg in "$@"; do
+              case "$arg" in
+                --timeout | --timeout=*) timeout_args=() ;;
+              esac
+            done
+
+            # On failure, dump the package revision state: installs time out
+            # with only "context deadline exceeded", and under nix.sh the
+            # cluster is gone by the time anyone can look at it.
+            if ! crossplane project run "''${timeout_args[@]}" "$@"; then
+              echo ""
+              echo "crossplane project run failed; package revision state:"
+              for cluster in $(kind get clusters 2>/dev/null); do
+                kind export kubeconfig --name "$cluster" >/dev/null 2>&1 || true
+              done
+              kubectl get pkgrev || true
+              kubectl get pkgrev -o yaml || true
+              failed=1
+            else
+              # The control plane is up and healthy - finish the setup the
+              # getting-started flow otherwise does by hand. prerequisites.yaml
+              # carries the modelplane-system namespace, composition RBAC, and
+              # provider-helm's DeploymentRuntimeConfig and ImageConfig.
+              kubectl apply -f docs/manifests/getting-started/prerequisites.yaml
+
+              # crossplane project run installs providers before
+              # prerequisites.yaml is applied, and Crossplane resolves
+              # ImageConfig runtime configs only at ProviderRevision creation -
+              # so provider-helm always comes up on the default runtime config,
+              # whose ServiceAccount lacks the RBAC granted above. Point it at
+              # its DeploymentRuntimeConfig explicitly.
+              kubectl patch provider.pkg.crossplane.io modelplane-provider-helm --type merge \
+                -p '{"spec":{"runtimeConfigRef":{"apiVersion":"pkg.crossplane.io/v1beta1","kind":"DeploymentRuntimeConfig","name":"provider-helm-modelplane"}}}'
+            fi
 
             # When running via nix.sh, the cluster lives inside the container's
             # Docker daemon and would vanish when the container exits. Drop into
-            # a dev shell so the user can interact with it before exiting.
+            # a dev shell so the user can interact with it before exiting -
+            # after a failure, that's where to debug the cluster.
             if [ "''${NIX_SH_CONTAINER:-}" = "1" ]; then
               echo ""
               echo "Entering development shell (exit to stop)..."
               exec nix develop
             fi
+
+            exit "''${failed:-0}"
           '';
         }
       );


### PR DESCRIPTION
<!--
Thanks for contributing to Modelplane! Read CONTRIBUTING.md before opening a PR
and follow it, especially the commit, pull request, and writing style
conventions: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md
PRs that don't follow it will be closed.
-->

### Description of your changes
The nix run app started a control plane with `crossplane project run` and stopped there, which left it in a state that doesn't match what the getting-started guide produces. The prerequisites manifest, the modelplane-system namespace, composition RBAC, and provider-helm's DeploymentRuntimeConfig and ImageConfig, was never applied, so compositions that rely on that RBAC fail. Now the app applies `docs/manifests/getting-started/prerequisites.yaml` once the control plane is healthy.

Applying the manifest alone isn't enough for provider-helm, though: `crossplane project run` installs providers before the prerequisites exist, and Crossplane resolves ImageConfig runtime configs only at ProviderRevision creation. provider-helm therefore always comes up on the default runtime config, whose ServiceAccount lacks the RBAC granted above. The app now patches the provider's `spec.runtimeConfigRef` to point at `provider-helm-modelplane` explicitly, so it runs with the intended ServiceAccount regardless of install order.

Failures were also effectively undebuggable under nix.sh: installs that time out report only "context deadline exceeded", and the kind cluster lives inside the container's Docker daemon, so it's gone before anyone can inspect it. On failure the app now exports the kind kubeconfig and dumps `kubectl get pkgrev` (plus the full YAML) before dropping into the dev shell, and it propagates the failure as its exit code instead of swallowing it. The default `--timeout` is also raised from the CLI's 5m to 15m, since first-time image pulls through the Docker-in-Docker daemon regularly exceed 5m; an explicit `--timeout` on the command line still wins.


<!--
Lead with the problem, then the change and why it's right. Direct reviewers to
the parts that need judgment. Don't pad or invent rationale. See the Pull
requests and Writing style sections of CONTRIBUTING.md for what a good
description looks like.

If this PR fixes an open issue, reference it below, e.g. "Fixes #95".
-->

Fixes #

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
