### PR TITLE
Collect, normalize, and aggregate fleet metrics

### DIFF
--- a/apis/metricmappings/composition.yaml
+++ b/apis/metricmappings/composition.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: metricmappings.modelplane.ai
+spec:
+  compositeTypeRef:
+    apiVersion: modelplane.ai/v1alpha1
+    kind: MetricMapping
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: modelplane-modelplanecompose-metric-mapping
+    step: compose-metric-mapping

--- a/apis/metricmappings/definition.yaml
+++ b/apis/metricmappings/definition.yaml
@@ -1,0 +1,67 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: metricmappings.modelplane.ai
+spec:
+  group: modelplane.ai
+  names:
+    categories: [crossplane, modelplane]
+    kind: MetricMapping
+    plural: metricmappings
+    shortNames: [mm]
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        required: [spec]
+        properties:
+          spec:
+            type: object
+            description: >-
+              How to normalize one component's Prometheus metrics onto the
+              modelplane_* surface. The metrics collector reads every
+              MetricMapping and renders the matching rename and label rules
+              into its config. Modelplane ships a MetricMapping per common
+              engine; a platform team applies one more for a new or forked
+              engine.
+            properties:
+              selector:
+                type: object
+                description: >-
+                  Selects the pods this mapping applies to, by label. An
+                  engine mapping matches the engine-type label
+                  (modelplane.ai/engine); a scheduler mapping matches the
+                  scheduler's pods.
+                properties:
+                  matchLabels:
+                    type: object
+                    additionalProperties:
+                      type: string
+              rename:
+                type: object
+                description: >-
+                  Source metric name to its modelplane_* name, e.g.
+                  vllm:time_to_first_token_seconds becomes
+                  modelplane_time_to_first_token.
+                additionalProperties:
+                  type: string
+              labels:
+                type: object
+                description: Label rewrites applied to the matched series.
+                properties:
+                  add:
+                    type: object
+                    description: Labels to add to every matched series.
+                    additionalProperties:
+                      type: string
+          status:
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  type: object

--- a/crossplane-project.yaml
+++ b/crossplane-project.yaml
@@ -69,6 +69,10 @@ spec:
       pathPrefix: _output/functions/compose-model-service
   - source: Tarball
     tarball:
+      name: compose-metric-mapping
+      pathPrefix: _output/functions/compose-metric-mapping
+  - source: Tarball
+    tarball:
       name: compose-usages
       pathPrefix: _output/functions/compose-usages
   dependencies:

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,7 @@
         "compose-inference-class"
         "compose-inference-cluster"
         "compose-inference-gateway"
+        "compose-metric-mapping"
         "compose-nebius-cluster"
         "compose-serving-stack"
         "compose-model-cache"

--- a/functions/compose-metric-mapping/function/__init__.py
+++ b/functions/compose-metric-mapping/function/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/functions/compose-metric-mapping/function/fn.py
+++ b/functions/compose-metric-mapping/function/fn.py
@@ -1,0 +1,50 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compose a MetricMapping.
+
+MetricMapping is a data resource: the metrics collector reads every
+MetricMapping to normalize a component's Prometheus metrics onto the
+modelplane_* surface. It has no composed children. This function just
+marks the XR Ready.
+"""
+
+import grpc
+from crossplane.function import logging, resource, response
+from crossplane.function.proto.v1 import run_function_pb2 as fnv1
+from crossplane.function.proto.v1 import run_function_pb2_grpc as grpcv1
+from models.ai.modelplane.metricmapping import v1alpha1
+
+
+class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
+    """A FunctionRunner handles gRPC RunFunctionRequests."""
+
+    def __init__(self) -> None:
+        """Create a new FunctionRunner."""
+        self.log = logging.get_logger()
+
+    async def RunFunction(
+        self, req: fnv1.RunFunctionRequest, _: grpc.aio.ServicerContext | None
+    ) -> fnv1.RunFunctionResponse:  # ty: ignore[invalid-method-override]  # the generated grpc servicer base is untyped
+        """Run the function."""
+        log = self.log.bind(tag=req.meta.tag)
+        log.info("Running function")
+
+        rsp = response.to(req)
+
+        resource.update_status(rsp.desired.composite, v1alpha1.Status())
+        response.set_conditions(rsp, resource.Condition(typ="Accepted", status="True", reason="Available"))
+        rsp.desired.composite.ready = fnv1.READY_TRUE
+
+        return rsp

--- a/functions/compose-metric-mapping/function/main.py
+++ b/functions/compose-metric-mapping/function/main.py
@@ -1,0 +1,55 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The composition function's main CLI."""
+
+import click
+from crossplane.function import logging, runtime
+
+from function import fn
+
+
+@click.command()
+@click.option("--debug", "-d", is_flag=True, help="Emit debug logs.")
+@click.option(
+    "--address",
+    default="0.0.0.0:9443",
+    show_default=True,
+    help="Address at which to listen for gRPC connections",
+)
+@click.option("--tls-certs-dir", help="Serve using mTLS certificates.", envvar="TLS_SERVER_CERTS_DIR")
+@click.option(
+    "--insecure",
+    is_flag=True,
+    help="Run without mTLS credentials. If you supply this flag --tls-certs-dir will be ignored.",
+)
+def cli(debug: bool, address: str, tls_certs_dir: str, insecure: bool) -> None:
+    """A Crossplane composition function."""
+    try:
+        level = logging.Level.INFO
+        if debug:
+            level = logging.Level.DEBUG
+        logging.configure(level=level)
+        runtime.serve(
+            fn.FunctionRunner(),
+            address,
+            creds=runtime.load_credentials(tls_certs_dir),
+            insecure=insecure,
+        )
+    except Exception as e:
+        click.echo(f"Cannot run function: {e}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/functions/compose-metric-mapping/pyproject.toml
+++ b/functions/compose-metric-mapping/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["uv_build>=0.11.0,<0.12"]
+build-backend = "uv_build"
+
+[project]
+name = "compose-metric-mapping"
+version = "0.0.0"
+description = "Mark a MetricMapping as ready."
+requires-python = ">=3.11,<3.14"
+license = "Apache-2.0"
+dependencies = [
+  "crossplane-function-sdk-python>=0.14.0",
+  "click>=8.1.0",
+  "grpcio>=1.73.1",
+  "crossplane-models",
+]
+
+[tool.uv.sources]
+crossplane-models = { workspace = true }
+
+[project.scripts]
+function = "function.main:cli"
+
+[tool.uv.build-backend]
+module-name = "function"
+module-root = ""

--- a/functions/compose-metric-mapping/tests/__init__.py
+++ b/functions/compose-metric-mapping/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/functions/compose-metric-mapping/tests/test_fn.py
+++ b/functions/compose-metric-mapping/tests/test_fn.py
@@ -1,0 +1,100 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the compose-metric-mapping function."""
+
+import dataclasses
+import unittest
+
+from crossplane.function import logging, resource
+from crossplane.function.proto.v1 import run_function_pb2 as fnv1
+from function import fn
+from google.protobuf import duration_pb2 as durationpb
+from google.protobuf import json_format
+from google.protobuf import struct_pb2 as structpb
+
+
+@dataclasses.dataclass
+class Case:
+    """A test case for compose-metric-mapping."""
+
+    name: str
+    req: fnv1.RunFunctionRequest
+    want: fnv1.RunFunctionResponse
+
+
+def setUpModule() -> None:
+    logging.configure(level=logging.Level.DISABLED)
+
+
+class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
+    """Tests for FunctionRunner.RunFunction."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.runner = fn.FunctionRunner()
+
+    async def test_compose(self) -> None:
+        """The function marks the MetricMapping as ready."""
+        cases = [
+            Case(
+                name="marks XR ready with Accepted condition and empty status",
+                req=fnv1.RunFunctionRequest(
+                    observed=fnv1.State(
+                        composite=fnv1.Resource(
+                            resource=resource.dict_to_struct(
+                                {
+                                    "apiVersion": "modelplane.ai/v1alpha1",
+                                    "kind": "MetricMapping",
+                                    "metadata": {"name": "vllm"},
+                                    "spec": {
+                                        "selector": {"matchLabels": {"modelplane.ai/engine": "vllm"}},
+                                        "rename": {
+                                            "vllm:time_to_first_token_seconds": "modelplane_time_to_first_token",
+                                        },
+                                        "labels": {"add": {"engine": "vllm"}},
+                                    },
+                                }
+                            ),
+                        ),
+                    ),
+                ),
+                want=fnv1.RunFunctionResponse(
+                    meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
+                    desired=fnv1.State(
+                        composite=fnv1.Resource(
+                            resource=resource.dict_to_struct({"status": {}}),
+                            ready=fnv1.READY_TRUE,
+                        ),
+                    ),
+                    conditions=[
+                        fnv1.Condition(
+                            type="Accepted",
+                            status=fnv1.STATUS_CONDITION_TRUE,
+                            reason="Available",
+                        ),
+                    ],
+                    context=structpb.Struct(),
+                ),
+            ),
+        ]
+
+        for case in cases:
+            with self.subTest(case.name):
+                got = await self.runner.RunFunction(case.req, None)
+                self.assertEqual(
+                    json_format.MessageToDict(case.want),
+                    json_format.MessageToDict(got),
+                    "-want, +got",
+                )


### PR DESCRIPTION
Implements the metrics design (#363, addressing #269): collect on every cluster, normalize to `modelplane_*`, and aggregate to one control-plane view through an OpenTelemetry collector.

Draft, built up in commits. This first commit adds the **`MetricMapping`** kind — the first-class, cluster-scoped resource that carries an engine's metric rename and label rules, which the collector reads to normalize onto `modelplane_*`. It follows the `InferenceClass` config-kind pattern: an XRD plus a mark-ready composition function (no composed children).

Still to come on this branch:

- Built-in `MetricMapping`s for vLLM, SGLang, and Triton/TensorRT-LLM.
- `compose-serving-stack`: the per-cluster OTel collector — scrape the `modelplane.ai/serving` selector plus the EPP and substrate, transform-rename via the `MetricMapping`s, push outbound.
- The control-plane aggregation collector (stateless in-memory roll-up).
- Name the engine `/metrics` port `http` in `native.py`, `llmd.py`, `routing.py`.

Adding a kind requires `nix run .#build` to regenerate the models; CI runs it.
