### PR TITLE
feature(update): nixpkgs to 26.05 and the Upbound CLI to current stable

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -94,6 +94,12 @@ ignoreFiles = ["themes/geekboot/content/.*", "README.md"]
 [security]
   [security.funcs]
     getenv = ["^CONTEXT", "^REVIEW_ID", "^VERCEL_ENV"]
+  [security.node.permissions]
+    # Hugo runs Node tools under Node's permission model, which blocks
+    # native addons unless the tool is listed here. The PostCSS pipeline
+    # needs it: LightningCSS is a native addon. "tailwindcss" is Hugo's
+    # default; keep it when overriding the list.
+    allowAddons = ["postcss", "tailwindcss"]
 
 [params]
   docs = true

--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1786247143,
+        "narHash": "sha256-8S3Kcxs7D4UtxJxSJZz0m14CGhuW0MxfrIwJxeGWGnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "279b4a8275f032c566576b3f181fa0f27197f588",
         "type": "github"
       },
       "original": {
@@ -112,16 +112,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1779102034,
-        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
+        "lastModified": 1786313170,
+        "narHash": "sha256-9BG7OgUWdu0ONDO5X2q6+K4bsuBITkX/3W4nNJu1Ito=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
+        "rev": "fcb8fcd6bf2d0adecae5bd491afaaaf8311b758d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -139,11 +139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776659114,
-        "narHash": "sha256-qapCOQmR++yZSY43dzrp3wCrkOTLpod+ONtJWBk6iKU=",
+        "lastModified": 1785730568,
+        "narHash": "sha256-NjSPsgjJ7MSpBtTkUcmNhRe6AFZ96+zsca2M8YuQi8Y=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "ffaa2161dd5d63e0e94591f86b54fc239660fb2e",
+        "rev": "90fde00db3687922d39d95fc591475fd0bbbcd72",
         "type": "github"
       },
       "original": {
@@ -159,11 +159,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778901413,
-        "narHash": "sha256-GSKXTAnFqRAMlZkJrIPcQMYf+lpMr66K3i60mB9STvc=",
+        "lastModified": 1786031528,
+        "narHash": "sha256-cROiHKO3UbIKqF5FG5NikvydzlfIj4EcR1Cty9qOVt4=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "a228447c3e179d477c1b6246ef3efa8cfe3c469a",
+        "rev": "1b1485546d85f6f6c7aadb10c4923dbc09633263",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779411315,
-        "narHash": "sha256-IMFlxeyClau51KplhhSRGhdGTvD/knShHdybP1UOTuk=",
+        "lastModified": 1786026603,
+        "narHash": "sha256-payw8w/aqR/Vr7LvDp14jxa5egFrZN7g8INsPzn7rN0=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "fdf2a76275d7a9c27deb5d2f2ab33526ac9052ff",
+        "rev": "0dfa8388dc855b1774f509725d8ea6806291571d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -99,6 +99,9 @@
                   inherit system;
                 };
               })
+              # Current Upbound CLI; nixpkgs' package lags the stable
+              # channel (see nix/upbound.nix).
+              (import ./nix/upbound.nix)
             ];
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   description = "Modelplane - The open source control plane for AI models";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
 
     # Unstable nixpkgs, exposed as pkgs.unstable. Used when we need a
     # newer version of a package than the stable channel ships, e.g. uv
@@ -72,7 +72,6 @@
       supportedSystems = [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
 
@@ -199,7 +198,7 @@
               pkgs.python3
               pkgs.unstable.ruff
               pkgs.unstable.ty
-              pkgs.nixfmt-rfc-style
+              pkgs.nixfmt
               pkgs.hugo
               pkgs.nodejs
             ];

--- a/functions/compose-inference-cluster/function/fn.py
+++ b/functions/compose-inference-cluster/function/fn.py
@@ -520,7 +520,7 @@ class Composer:
                 name=resource.child_name(_name(self.xr.metadata), "cluster-kubeconfig"),
             ),
             namespace=_NAMESPACE_SYSTEM,
-            gpuPools=gpu_pools,  # ty: ignore[invalid-argument-type]  # gpu_pools builds the by-alias wire form; pydantic coerces it to GpuPool
+            gpuPools=gpu_pools,  # gpu_pools builds the by-alias wire form; pydantic coerces it to GpuPool
         )
         cache_storage_class = self.observed_cache_storage_class()
         if cache_storage_class:
@@ -884,7 +884,9 @@ class Composer:
         if nebius_ready and nebius_secrets:
             secrets = []
             for s in nebius_secrets:
-                secret = ssv1alpha1.Secret(type=s.type, name=s.name, key=s.key)  # ty: ignore[invalid-argument-type]  # values come from the XRD secret-type enums
+                secret = ssv1alpha1.Secret(
+                    type=s.type, name=s.name, key=s.key
+                )  # values come from the XRD secret-type enums
                 # Only set namespace when the entry carries one, so entries in
                 # the backend's own namespace stay namespace-free.
                 if s.namespace:

--- a/functions/compose-model-deployment/function/scheduling.py
+++ b/functions/compose-model-deployment/function/scheduling.py
@@ -1001,7 +1001,7 @@ def schedule(
     # _retain keeps the first replica seen for a colliding (cluster, index), and
     # _build_ledger charges replicas in iteration order. An unsorted input could
     # otherwise place two equal states differently across reconciles.
-    all_replicas = sorted(all_replicas, key=lambda r: r.metadata.name or "")
+    all_replicas = sorted(all_replicas, key=lambda r: _name(r.metadata))
 
     # Compile every member's nodeSelector selectors once and reuse them
     # across every pool of every cluster. Raises CELCompileError on a malformed

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -17,7 +17,7 @@
           pkgs.unstable.ruff
           pkgs.statix
           pkgs.deadnix
-          pkgs.nixfmt-rfc-style
+          pkgs.nixfmt
           pkgs.shellcheck
           pkgs.shfmt
           pkgs.gnupatch

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -164,7 +164,7 @@ in
         nativeBuildInputs = [
           pkgs.statix
           pkgs.deadnix
-          pkgs.nixfmt-rfc-style
+          pkgs.nixfmt
         ];
       }
       ''

--- a/nix/docs.nix
+++ b/nix/docs.nix
@@ -110,16 +110,16 @@ let
         ];
         outputHashMode = "recursive";
         outputHashAlgo = "sha256";
-        outputHash = "sha256-sWwK8Z5NEpxSbajGd+IjEh+2moQOU2pBUI33c6+gKVY=";
+        outputHash = "sha256-WbPAE0+fnV7gqU7P4c9qKWETRHTR7uP5OpsHCj+l9r4=";
       }
       ''
         export HOME=$TMPDIR
-        # .vale.ini's relative "StylesPath = styles" resolves next to the config
-        # file, so copy it here for vale to sync into $PWD/styles.
         cp ${self}/docs/utils/vale/.vale.ini .vale.ini
+        # Since Vale 3.12, sync installs packages into the XDG data
+        # directory rather than the config's StylesPath.
         vale sync --config="$PWD/.vale.ini"
         mkdir -p $out
-        cp -r styles/* $out/
+        cp -r "$HOME/.local/share/vale/styles/"* $out/
       '';
 in
 {

--- a/nix/functions.nix
+++ b/nix/functions.nix
@@ -140,7 +140,14 @@ let
         src:
         pkgs.fetchurl {
           inherit (src) name url;
-          hash = src.outputHash;
+          # The wheel derivation carries its hash as bare hex with the
+          # algorithm in a separate attribute, but fetchurl's hash argument
+          # only accepts typed (SRI) hashes.
+          hash = builtins.convertHash {
+            hash = src.outputHash;
+            hashAlgo = src.outputHashAlgo;
+            toHashFormat = "sri";
+          };
         };
       wheels = map (p: hostWheel p.src) (builtins.filter isWheel resolved);
       sources = map (p: p.src) (builtins.filter (p: !isWheel p) resolved);

--- a/nix/upbound.nix
+++ b/nix/upbound.nix
@@ -1,0 +1,70 @@
+# The Upbound CLI (up and docker-credential-up). nixpkgs' upbound package
+# pins a sources file that lags the CDN's stable channel - the up source
+# repository is private, so nixpkgs can't auto-update it. This overlay
+# replaces it with the release binaries from the same CDN nixpkgs uses.
+#
+# To bump: set version to what https://cli.upbound.io/stable/current/version
+# reports and refresh the hashes:
+#
+#   for p in linux_amd64 linux_arm64 darwin_arm64; do
+#     for b in up docker-credential-up; do
+#       curl -sL "https://cli.upbound.io/stable/v<version>/bin/$p/$b" | sha256sum
+#     done
+#   done
+_final: prev:
+let
+  version = "0.53.1";
+
+  hashes = {
+    linux_amd64 = {
+      up = "8a701cf15aefa4d35605b329f7cb8e442d4f74cc2c9aa14c1ac020b2ca5cc4e2";
+      docker-credential-up = "1ef5440465ae8e3afdc93814ad469d84824ffa7e960dd17192dadaae56bb7e51";
+    };
+    linux_arm64 = {
+      up = "a4dce7704128db478eba06864cf50b7ef5755a754480a7bf72d0e7eeb3767207";
+      docker-credential-up = "9f58d4a31a3627a96118dd8f9620e28e5493bedc587720e378aa3059a68834cb";
+    };
+    darwin_arm64 = {
+      up = "12af822e6a2e172b0916056597921280b0c195bae58e06f0946d7c60c0e34a37";
+      docker-credential-up = "30c02d248edc0fc78f599c4126c91fcf331b9c24927ccd5ec930c96689fe626c";
+    };
+  };
+
+  platform =
+    {
+      x86_64-linux = "linux_amd64";
+      aarch64-linux = "linux_arm64";
+      aarch64-darwin = "darwin_arm64";
+    }
+    .${prev.stdenv.hostPlatform.system};
+
+  fetchBin =
+    name:
+    prev.fetchurl {
+      inherit name;
+      url = "https://cli.upbound.io/stable/v${version}/bin/${platform}/${name}";
+      sha256 = hashes.${platform}.${name};
+    };
+in
+{
+  upbound = prev.stdenvNoCC.mkDerivation {
+    pname = "upbound";
+    inherit version;
+
+    dontUnpack = true;
+
+    installPhase = ''
+      runHook preInstall
+      install -Dm755 ${fetchBin "up"} $out/bin/up
+      install -Dm755 ${fetchBin "docker-credential-up"} $out/bin/docker-credential-up
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "CLI for interacting with Upbound";
+      homepage = "https://docs.upbound.io/cli/";
+      license = prev.lib.licenses.unfree;
+      mainProgram = "up";
+    };
+  };
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Modelplane! Read CONTRIBUTING.md before opening a PR
and follow it, especially the commit, pull request, and writing style
conventions: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md
PRs that don't follow it will be closed.
-->

### Description of your changes

The dev shell shipped up `0.40.3` while Upbound's stable channel is at `v0.53.1`. nixpkgs can't fix this on its own: its upbound package downloads release binaries from cli.upbound.io at versions pinned in a checked-in sources file, and since the upbound/up repository went private that file no longer gets refreshed. This adds an overlay (nix/upbound.nix) that fetches the current stable release binaries from the same CDN directly, with a documented bump procedure, and replaces pkgs.upbound so the dev shell, .#build, .#push, and .#run all pick it up. The trade-off is that we now own the version pin and its hashes instead of inheriting nixpkgs' cadence. But we need to fix it because of this issue https://github.com/modelplaneai/modelplane/actions/runs/30942547082/job/92168479772 

Alongside this, the flake inputs move from nixos-25.11 to nixos-26.05 (nixos-25.11 EOL https://status.nixos.org/), with nixpkgs-unstable and the uv2nix/pyproject-nix inputs updated to match. 

The updated pyproject-nix exposes wheel hashes as bare hex, which fetchurl no longer accepts untyped, so the wheel re-fetch in nix/functions.nix converts them to SRI form. Vale 3.12 changed vale sync to install packages into the XDG data directory instead of the config's StylesPath, so the valeStyles derivation copies from there now (its fixed-output hash changes with it, as the style packages resolve to their latest releases). 

Hugo 0.163 runs Node tools under Node's permission model, which blocks native addons; the PostCSS pipeline loads LightningCSS's native addon, so postcss is added to security.node.permissions.allowAddons in the docs config. The newer ty flags r.metadata.name on an ObjectMeta | None in compose-model-deployment's replica sort, fixed by using the existing _name helper, and reports two suppression comments in compose-inference-cluster that its improved inference no longer needs, now removed.





<!--
Lead with the problem, then the change and why it's right. Direct reviewers to
the parts that need judgment. Don't pad or invent rationale. See the Pull
requests and Writing style sections of CONTRIBUTING.md for what a good
description looks like.

If this PR fixes an open issue, reference it below, e.g. "Fixes #95".
-->

Fixes #

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
