### PR TITLE
fix/clamp-uv-manylinux-platform

### DIFF
--- a/nix/functions.nix
+++ b/nix/functions.nix
@@ -54,12 +54,20 @@ let
   # glibc baseline is taken from the interpreter we actually ship, so uv accepts
   # every wheel that interpreter can load (manylinux tags <= our glibc). Some
   # deps, e.g. google-re2, only publish wheels for a fairly recent glibc.
+  #
+  # uv's --python-platform is a closed enum of manylinux tags that currently
+  # tops out at manylinux_2_40, so clamp the minor version to that: nixpkgs
+  # 26.05 ships glibc 2.42, which uv rejects. The clamp only excludes wheels
+  # tagged newer than 2.40, and no wheels on PyPI are tagged that new. Once uv
+  # learns the newer tags, raise or drop the clamp.
+  uvMaxManylinuxMinor = 40;
   uvPlatform =
     targetPkgs: arch:
     let
-      glibc = lib.versions.majorMinor targetPkgs.stdenv.cc.libc.version;
+      glibc = targetPkgs.stdenv.cc.libc.version;
+      minor = lib.min (lib.toInt (lib.versions.minor glibc)) uvMaxManylinuxMinor;
     in
-    "${archToUvArch.${arch}}-manylinux_${lib.replaceStrings [ "." ] [ "_" ] glibc}";
+    "${archToUvArch.${arch}}-manylinux_${lib.versions.major glibc}_${toString minor}";
 
   # uv runs on the build host, so take it from the host package set.
   inherit (pkgs.unstable) uv;


### PR DESCRIPTION
<!--
Thanks for contributing to Modelplane! Read CONTRIBUTING.md before opening a PR
and follow it, especially the commit, pull request, and writing style
conventions: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md
PRs that don't follow it will be closed.
-->

### Description of your changes
fix for: https://github.com/modelplaneai/modelplane/actions/runs/31514718929/job/93858634297#step:6:552

The site-packages derivations derive uv's --python-platform from the target nixpkgs' glibc, so uv accepts every wheel the shipped interpreter can load. That assumed uv understands any manylinux tag we hand it.

It doesn't: --python-platform is a closed enum, hardcoded in uv, that currently tops out at manylinux_2_40 in the uv we pin (0.12.1), the latest release (0.12.3), and uv's main branch. The nixpkgs 26.05 bump brought glibc 2.42, so we now generate x86_64-manylinux_2_42 and uv rejects the flag outright, failing every image build.

This clamps the minor version to 40. Nothing is lost: wheels are tagged with the oldest glibc they require and none on PyPI are tagged newer than 2.40, so the clamp selects exactly the wheels a 2_42 platform would, and the manylinux compatibility guarantee means our glibc 2.42 loads all of them. Once uv learns the newer tags the clamp can be raised or dropped.

https://github.com/astral-sh/uv/blob/main/crates/uv-configuration/src/target_triple.rs#L335

<!--
Lead with the problem, then the change and why it's right. Direct reviewers to
the parts that need judgment. Don't pad or invent rationale. See the Pull
requests and Writing style sections of CONTRIBUTING.md for what a good
description looks like.

If this PR fixes an open issue, reference it below, e.g. "Fixes #95".
-->

Fixes #

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
