### PR TITLE
docs(examples): add Nemotron-3.5-Lightning on Nebius H100 recipe

### DIFF
--- a/docs/content/examples/nemotron-3.5-lightning.md
+++ b/docs/content/examples/nemotron-3.5-lightning.md
@@ -6,7 +6,7 @@ description: An open 30B MoE with 3B active parameters served NVFP4 on a single 
 <!-- vale write-good.Passive = NO -->
 NVIDIA's Nemotron-3.5-Lightning, an open 30B mixture-of-experts model with 3B
 active parameters built for the execution layer of long-running agents, served
-NVFP4 as a single `Standalone` vLLM engine on one H100 80GB node on Nebius.
+NVFP4 as a single `Standalone` vLLM engine on one H100 node on Nebius.
 The NVFP4 checkpoint (~20 GiB) fits a single GPU with headroom for the KV and
 Mamba caches, so the engine needs no tensor parallelism, no gang, and no
 prefill/decode disaggregation. Weights stage once to a `ModelCache` on a

--- a/docs/content/examples/nemotron-3.5-lightning.md
+++ b/docs/content/examples/nemotron-3.5-lightning.md
@@ -1,0 +1,34 @@
+---
+title: Nemotron-3.5-Lightning
+weight: 15
+description: An open 30B MoE with 3B active parameters served NVFP4 on a single H100 on Nebius.
+---
+<!-- vale write-good.Passive = NO -->
+NVIDIA's Nemotron-3.5-Lightning, an open 30B mixture-of-experts model with 3B
+active parameters built for the execution layer of long-running agents, served
+NVFP4 as a single `Standalone` vLLM engine on one H100 80GB node on Nebius.
+The NVFP4 checkpoint (~20 GiB) fits a single GPU with headroom for the KV and
+Mamba caches, so the engine needs no tensor parallelism, no gang, and no
+prefill/decode disaggregation. Weights stage once to a `ModelCache` on a
+Nebius shared filesystem and mount at `/mnt/models`.
+
+This recipe was run end to end on Nebius (`eu-north`): serving and tool
+calling validated on a single H100 node.
+`nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4` is a public repository
+(OpenMDW-1.1), so no Hugging Face token or Secret is needed. Apply the
+platform side first, then the ML side.
+
+## Platform
+
+{{< manifests "examples/nemotron-3.5-lightning/inference-class-nebius.yaml" >}}
+
+{{< manifests "examples/nemotron-3.5-lightning/inference-cluster-nebius.yaml" >}}
+
+## Deployment
+
+{{< manifests "examples/nemotron-3.5-lightning/model-cache.yaml" >}}
+
+{{< manifests "examples/nemotron-3.5-lightning/model-deployment.yaml" >}}
+
+{{< manifests "examples/nemotron-3.5-lightning/model-service.yaml" >}}
+<!-- vale write-good.Passive = YES -->

--- a/docs/manifests/examples/nemotron-3.5-lightning/inference-class-nebius.yaml
+++ b/docs/manifests/examples/nemotron-3.5-lightning/inference-class-nebius.yaml
@@ -1,0 +1,33 @@
+# An InferenceClass describing a Nebius gpu-h100-sxm node with 1x NVIDIA
+# H100 80GB. Nebius sizes nodes by platform + preset rather than an
+# instance type; gpu-h100-sxm + 1gpu-16vcpu-200gb is one single-H100 SXM
+# node. The devices block describes the hardware DRA-style; it is what
+# the Nemotron ModelDeployment's nodeSelector matches on.
+apiVersion: modelplane.ai/v1alpha1
+kind: InferenceClass
+metadata:
+  name: nebius-h100-1x
+spec:
+  description: "Nebius gpu-h100-sxm, 1x NVIDIA H100 80GB"
+  provisioning:
+    provider: Nebius
+    nebius:
+      platform: gpu-h100-sxm
+      preset: 1gpu-16vcpu-200gb
+      diskSizeGb: 200
+      driversPreset: cuda13.0
+      accelerator:
+        type: nvidia-h100
+        count: 1
+  devices:
+  - name: gpu
+    claim: DRA
+    driver: gpu.nvidia.com
+    deviceClassName: gpu.nvidia.com
+    count: 1
+    attributes:
+      architecture: { string: Hopper }
+      cudaComputeCapability: { version: "9.0.0" }
+    capacity:
+      # H100 80GB real usable VRAM (NVIDIA DRA driver), not nominal 80GB.
+      memory: { value: "81559Mi" }

--- a/docs/manifests/examples/nemotron-3.5-lightning/inference-cluster-nebius.yaml
+++ b/docs/manifests/examples/nemotron-3.5-lightning/inference-cluster-nebius.yaml
@@ -1,0 +1,32 @@
+# An InferenceCluster backed by a Nebius mk8s cluster with a single 1x
+# H100 GPU node group. Modelplane provisions the full mk8s cluster (VPC,
+# control plane, system + GPU node groups) and installs the inference
+# stack. ModelCache RWX storage is auto-provisioned via a Nebius shared
+# filesystem, so model-cache.yaml works unchanged.
+#
+# Auth is the Nebius ClusterProviderConfig named default (service-account
+# key + projectID); Modelplane reuses that identity to reach the cluster.
+#
+# eu-north1 (Finland) keeps inference in the EU for data residency.
+#
+# Clean teardown - delete the ML resources first (they hold a usage on the
+# cluster), then the cluster:
+#   kubectl delete modeldeployment,modelservice,modelcache nemotron-lightning -n ml-team
+#   kubectl delete inferencecluster nebius-eu-north --cascade=foreground
+apiVersion: modelplane.ai/v1alpha1
+kind: InferenceCluster
+metadata:
+  name: nebius-eu-north
+  labels:
+    modelplane.ai/region: eu-north
+spec:
+  cluster:
+    source: Nebius
+    nebius: {}
+
+  nodePools:
+  - name: gpu-h100
+    className: nebius-h100-1x
+    nodeCount: 1
+    minNodeCount: 1
+    maxNodeCount: 1

--- a/docs/manifests/examples/nemotron-3.5-lightning/model-cache.yaml
+++ b/docs/manifests/examples/nemotron-3.5-lightning/model-cache.yaml
@@ -1,0 +1,18 @@
+# The model weights, staged once per cluster on a Nebius shared filesystem
+# (RWX) and mounted at /mnt/models in the serving pod, so the engine reads
+# the NVFP4 weights (~20 GiB) locally instead of pulling them from Hugging
+# Face on every start.
+#
+# nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 is a public repo, so no
+# authSecret / HF token is needed. Add one only if you point this at a gated
+# repo.
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelCache
+metadata:
+  name: nemotron-lightning
+  namespace: ml-team
+spec:
+  source: HuggingFace
+  huggingFace:
+    repo: nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4
+    sizeGiB: 50

--- a/docs/manifests/examples/nemotron-3.5-lightning/model-deployment.yaml
+++ b/docs/manifests/examples/nemotron-3.5-lightning/model-deployment.yaml
@@ -1,0 +1,64 @@
+# Nemotron-3.5-Lightning (30B total / 3B active MoE, hybrid
+# Mamba-Transformer) served NVFP4 as a single Standalone vLLM engine on one
+# H100 80GB, weights streamed from the shared ModelCache at /mnt/models. The
+# NVFP4 checkpoint (~20 GiB) fits a single GPU with headroom for the KV and
+# Mamba caches, so no tensor parallelism, no gang, and no prefill/decode
+# disaggregation are needed.
+#
+# Notes on the engine flags:
+#   Quantization needs no flag - the checkpoint auto-detects as
+#     modelopt_mixed.
+#   --moe-backend=humming and --linear-backend=humming are the cookbook's
+#     base-configuration kernels.
+#   The --mamba-* flags configure the hybrid model's state-space cache: the
+#     flashinfer backend with an FP16 SSM cache, stochastic rounding, and
+#     the cookbook's align mode and horizontal SSU algorithm.
+#   --reasoning-parser=nemotron_v3 extracts the thinking block;
+#     --tool-call-parser=qwen3_coder is the parser Nemotron ships with, and
+#     --enable-auto-tool-choice turns on server-side tool selection.
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelDeployment
+metadata:
+  name: nemotron-lightning
+  namespace: ml-team
+spec:
+  replicas: 1
+  template:
+    spec:
+      modelCacheRef:
+        name: nemotron-lightning
+      engines:
+      - name: nemotron-lightning
+        members:
+        - role: Standalone
+          nodeSelector:
+            devices:
+            - name: gpu
+              count: 1
+              selectors:
+              - cel: |
+                  device.driver == "gpu.nvidia.com" && device.capacity["gpu.nvidia.com"].memory.compareTo(quantity("79Gi")) >= 0
+          template:
+            spec:
+              containers:
+              - name: engine
+                image: vllm/vllm-openai:v0.27.1
+                command: ["vllm", "serve", "/mnt/models"]
+                args:
+                - --served-model-name=nemotron-3.5-lightning
+                - --moe-backend=humming
+                - --linear-backend=humming
+                - --max-num-seqs=256
+                - --max-model-len=65536
+                - --max-num-batched-tokens=32768
+                - --enable-prefix-caching
+                - --async-scheduling
+                - --mamba-backend=flashinfer
+                - --mamba-ssm-cache-dtype=float16
+                - --enable-mamba-cache-stochastic-rounding
+                - --mamba-cache-philox-rounds=5
+                - --mamba-cache-mode=align
+                - --mamba-ssu-algorithm=horizontal
+                - --reasoning-parser=nemotron_v3
+                - --enable-auto-tool-choice
+                - --tool-call-parser=qwen3_coder

--- a/docs/manifests/examples/nemotron-3.5-lightning/model-service.yaml
+++ b/docs/manifests/examples/nemotron-3.5-lightning/model-service.yaml
@@ -1,0 +1,15 @@
+# One OpenAI-compatible endpoint for the deployment. Read its public address:
+#   kubectl get ms nemotron-lightning -n ml-team -o jsonpath='{.status.address}'
+# then call it, e.g.:
+#   curl "$ADDR/v1/chat/completions" -H 'Content-Type: application/json' \
+#     -d '{"model":"nemotron-3.5-lightning","messages":[{"role":"user","content":"hello"}]}'
+apiVersion: modelplane.ai/v1alpha1
+kind: ModelService
+metadata:
+  name: nemotron-lightning
+  namespace: ml-team
+spec:
+  endpoints:
+  - selector:
+      matchLabels:
+        modelplane.ai/deployment: nemotron-lightning

--- a/docs/utils/vale/styles/config/vocabularies/Modelplane/accept.txt
+++ b/docs/utils/vale/styles/config/vocabularies/Modelplane/accept.txt
@@ -163,6 +163,10 @@ Kimi-K2
 Kimi
 Llama
 Laguna[\w.-]*
+Nemotron[\w.-]*
+NVFP4
+Mamba
+OpenMDW-1.1
 NIM
 GGUF
 LoRA
@@ -371,6 +375,7 @@ multi-pod
 multi-region
 multi-tenant
 multi-tenancy
+mixture-of-experts
 namespace-scoped
 namespaced
 namespaces?


### PR DESCRIPTION
<!--
Thanks for contributing to Modelplane! Read CONTRIBUTING.md before opening a PR
and follow it, especially the commit, pull request, and writing style
conventions: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md
PRs that don't follow it will be closed.
-->

### Description of your changes

Adds a Modelplane example for NVIDIA's Nemotron model: NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 as a single Standalone engine on Nebius InferenceClass, InferenceCluster, ModelCache, both ModelDeployments, ModelService, plus the recipe page.

Validated end to end on Nebius.
Its based on the following cookbook: https://github.com/NVIDIA-NeMo/Nemotron/blob/main/usage-cookbook/Nemotron-3.5-Lightning/vllm_cookbook.ipynb from the blogpost: https://developer.nvidia.com/blog/nvidia-nemotron-3-5-lightning-delivers-fast-accurate-specialized-task-execution-for-long-running-agents

<!--
Lead with the problem, then the change and why it's right. Direct reviewers to
the parts that need judgment. Don't pad or invent rationale. See the Pull
requests and Writing style sections of CONTRIBUTING.md for what a good
description looks like.

If this PR fixes an open issue, reference it below, e.g. "Fixes #95".
-->

Fixes #

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.

### Tested

```
kubectl get pods -n default
NAMESPACE                 NAME                                                              READY   STATUS    RESTARTS   AGE
default                   nemotron-lightning-f91d7-epp-c76bbfbf5-x5kn7                      1/1     Running   0          12m
default                   nemotron-lightning-f91d7-nemotron-lightning-975b8-bbd5ff4dcf9qb   1/1     Running   0          12m
```

```
kubectl run curl --rm -it --restart=Never --image=curlimages/curl --   curl -s http://172.18.255.200/ml-team/nemotron-lightning/v1/chat/completions   -H 'Content-Type: application/json'   -d '{"model":"nemotron-3.5-lightning","messages":[{"role":"user","content":"hello nemotron"}]}'
```

```
{
    "id": "chatcmpl-07fbc8ad-1c9d-469a-8322-290ded472f9b",
    "object": "chat.completion",
    "created": 1786469502,
    "model": "nemotron-3.5-lightning",
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": "Hello! I'm Nemotron, a language model developed by NVIDIA. How can I help you today?",
                "refusal": null,
                "annotations": null,
                "audio": null,
                "function_call": null,
                "reasoning": "Here's a thinking process:\n\n1.  **Analyze User Input:**\n   - User says: \"hello nemotron\"\n   - This is a greeting, likely referencing the model name \"Nemotron\" (which is my name as a language model, developed by NVIDIA)\n   - The intent is simple: greet back, acknowledge the model name, maybe ask how I can help.\n\n2.  **Identify Key Elements:**\n   - Greeting: \"hello\"\n   - Model reference: \"nemotron\"\n   - Tone: Casual, friendly\n\n3.  **Determine Appropriate Response:**\n   - Acknowledge the greeting\n   - Optionally mention that I'm Nemotron, developed by NVIDIA\n   - Offer assistance\n   - Keep it concise and friendly\n\n4.  **Draft Response (mental):**\n   \"Hello! I'm Nemotron, a language model developed by NVIDIA. How can I help you today?\"\n\n5.  **Check Against Guidelines:**\n   - Accurate? Yes, I am Nemotron.\n   - Helpful? Yes, offers next steps.\n   - Neutral/positive tone? Yes.\n   - No overcomplication.\n\n   Everything looks good. I'll output a concise greeting.✅"
            },
            "logprobs": null,
            "finish_reason": "stop",
            "stop_reason": null,
            "token_ids": null,
            "routed_experts": null
        }
    ],
    "service_tier": null,
    "system_fingerprint": "vllm-0.27.1-29fb5383",
    "usage": {
        "prompt_tokens": 19,
        "total_tokens": 305,
        "completion_tokens": 286,
        "prompt_tokens_details": null
    },
    "prompt_logprobs": null,
    "prompt_token_ids": null,
    "prompt_text": null,
    "kv_transfer_params": null,
    "ec_transfer_params": null,
    "metrics": null
}
```