### PR TITLE
WIP: Add an OCI source to ModelCache

### DIFF
--- a/apis/modelcaches/definition.yaml
+++ b/apis/modelcaches/definition.yaml
@@ -17,7 +17,7 @@ spec:
     additionalPrinterColumns:
     - name: SOURCE
       type: string
-      jsonPath: .spec.source.huggingFace.repo
+      jsonPath: .spec.source
     - name: READY
       type: string
       jsonPath: .status.summary.ready
@@ -32,10 +32,12 @@ spec:
             x-kubernetes-validations:
             - rule: "self.source != 'HuggingFace' || has(self.huggingFace)"
               message: spec.huggingFace is required when spec.source is HuggingFace.
+            - rule: "self.source != 'OCI' || has(self.oci)"
+              message: spec.oci is required when spec.source is OCI.
             properties:
               source:
                 type: string
-                enum: [HuggingFace]
+                enum: [HuggingFace, OCI]
                 description: >-
                   Which kind of artifact source to stage from. The
                   matching source object (e.g. spec.huggingFace) must
@@ -71,6 +73,43 @@ spec:
                       key:
                         type: string
                         default: HF_TOKEN
+                  sizeGiB:
+                    type: integer
+                    description: >-
+                      Capacity to allocate for the staged artifact on
+                      each matched cluster.
+                    minimum: 1
+                    maximum: 100000
+              oci:
+                type: object
+                description: >-
+                  OCI source. Required when source is OCI. The
+                  hydration Job pulls the artifact with modctl and
+                  extracts it onto the cache volume, restoring the
+                  file layout the artifact was built with.
+                required: [ref, sizeGiB]
+                properties:
+                  ref:
+                    type: string
+                    description: >-
+                      Registry reference to the model artifact, by tag
+                      or digest (e.g. registry.example.com/models/
+                      qwen2.5-0.5b:v1).
+                    minLength: 1
+                  pullSecret:
+                    type: object
+                    description: >-
+                      Optional Secret holding registry credentials for
+                      a private repository. Names a
+                      kubernetes.io/dockerconfigjson Secret in the
+                      ModelCache's own namespace; Modelplane propagates
+                      it to each matched cluster for the hydration Job
+                      to read.
+                    required: [name]
+                    properties:
+                      name:
+                        type: string
+                        minLength: 1
                   sizeGiB:
                     type: integer
                     description: >-

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -74,6 +74,9 @@ against. The control-plane cluster needs no DRA.
 nix run .#e2e              # bring up both clusters + deploy the mock model
 nix run .#e2e -- --verify  # same, then wait for readiness and assert a live 200
 nix run .#e2e -- --clean   # tear both clusters down
+
+# additionally stage a `source: OCI` ModelCache and assert the artifact lands
+MP_E2E_OCI_REF=ttl.sh/my-model:24h nix run .#e2e -- --verify --oci
 ```
 
 `crossplane project run` installs the config and applies the resources, then
@@ -101,6 +104,26 @@ kubectl run curl -n ml-team --rm -it --image=curlimages/curl@sha256:7c12af72ceb3
 failure. It's the exact command the `E2E` CI workflow runs, so a green `--verify`
 locally and a green CI run mean the same thing; use the manual curls above to
 poke the endpoints interactively.
+
+### `--oci`
+
+`--oci` adds a `source: OCI` `ModelCache` pointing at `MP_E2E_OCI_REF`, waits for
+the hydration Job on the workload cluster, then mounts the cache volume from a
+throwaway pod and asserts the artifact's files are on it — including a nested
+path, since preserving subdirectories is the part of `modctl`'s extract the
+source depends on.
+
+It is off by default and not part of the CI gate, because it needs an artifact
+pushed somewhere the workload cluster can pull from, which makes it non-hermetic.
+Build one with [`modctl`](https://github.com/modelpack/modctl):
+
+```bash
+modctl build -t ttl.sh/my-model:24h -f Modelfile . && modctl push ttl.sh/my-model:24h
+```
+
+This proves hydration, not loading. The engine here is a mock, so nothing reads
+the weights off the volume; proving a load needs a real engine on CPU or a real
+cluster.
 
 ## How it's structured
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -122,6 +122,11 @@ export DOCKER_CONFIG="$docker_config"
 #   --verify    after apply, wait for the ModelService and assert a live 200,
 #               exiting non-zero on failure. This is exactly what CI runs, so
 #               running it locally gives the same pass/fail signal (dev/CI parity).
+#   --oci       additionally stage a `source: OCI` ModelCache from the registry
+#               reference in MP_E2E_OCI_REF and assert the artifact's files land
+#               on the cache volume. Off by default: it needs an artifact pushed
+#               somewhere the workload cluster can pull, so it is not hermetic
+#               and is not part of the CI gate.
 rendered="$work/rendered"
 mkdir -p "$rendered"
 cp "$ROOT/e2e/manifests/"*.yaml "$rendered/"
@@ -129,10 +134,19 @@ sed -i.bak "s/172\.18\.255/${PREFIX}.255/g" "$rendered/"*.yaml && rm -f "$render
 cpctx="kind-$CP"
 apply_manifests=1
 verify=0
-case "${1:-}" in
---no-apply) apply_manifests=0 ;;
---verify) verify=1 ;;
-esac
+oci=0
+for arg in "$@"; do
+	case "$arg" in
+	--no-apply) apply_manifests=0 ;;
+	--verify) verify=1 ;;
+	--oci) oci=1 ;;
+	esac
+done
+if [ "$oci" = 1 ] && [ -z "${MP_E2E_OCI_REF:-}" ]; then
+	echo "--oci needs MP_E2E_OCI_REF set to a ModelPack reference the workload cluster can pull, e.g." >&2
+	echo "  MP_E2E_OCI_REF=ttl.sh/my-model:24h nix run .#e2e -- --verify --oci" >&2
+	exit 1
+fi
 
 log "Building + running the control plane"
 cd "$ROOT"
@@ -249,3 +263,81 @@ kubectl --context "$cpctx" -n "$ns" delete pod -l app.kubernetes.io/name=e2e-ver
 	exit 1
 }
 log "End to end OK: $addr serves OpenAI (/v1/chat/completions) and Anthropic (/v1/messages)"
+
+# --oci: stage a ModelCache from an OCI artifact and assert its files land on
+# the cache volume. This is the hydration half of the OCI source -- the pull,
+# the extract, and the layout on the PVC. It does not prove an engine loads
+# from it: the engine here is a mock, so nothing reads the weights.
+if [ "$oci" = 1 ]; then
+	log "Staging a source: OCI ModelCache from $MP_E2E_OCI_REF"
+	cache=oci-poc
+	kubectl --context "$cpctx" apply -f - <<-EOF
+	apiVersion: modelplane.ai/v1alpha1
+	kind: ModelCache
+	metadata:
+	  name: $cache
+	  namespace: $ns
+	spec:
+	  source: OCI
+	  clusterSelector:
+	    matchLabels:
+	      modelplane.ai/region: local
+	  oci:
+	    ref: $MP_E2E_OCI_REF
+	    sizeGiB: 1
+	EOF
+
+	# The hydration Job runs on the workload cluster, so watch the PVC and Job
+	# there rather than the XR's status: a Job that pulls and exits is the thing
+	# under test, and its failure message is what a user would have to read.
+	job=""
+	for _ in $(seq 1 40); do
+		job="$(kubectl --context "$WLCTX" -n default get job \
+			-l "modelplane.ai/modelcache=$cache" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+		[ -n "$job" ] && break
+		sleep 15
+	done
+	[ -n "$job" ] || {
+		echo "verify: no hydration Job appeared on the workload cluster for ModelCache $cache" >&2
+		kubectl --context "$cpctx" -n "$ns" describe modelcache "$cache" 2>&1 | tail -30 >&2 || true
+		exit 1
+	}
+	log "Hydration Job: $job"
+
+	if ! kubectl --context "$WLCTX" -n default wait --for=condition=complete "job/$job" --timeout=10m; then
+		echo "verify: hydration Job $job did not complete" >&2
+		kubectl --context "$WLCTX" -n default logs "job/$job" --tail=60 2>&1 >&2 || true
+		kubectl --context "$WLCTX" -n default describe "job/$job" 2>&1 | tail -30 >&2 || true
+		exit 1
+	fi
+
+	# Read the volume back through a pod that mounts the same PVC, which is how
+	# an engine would see it. Select the PVC by label so this does not depend on
+	# the child-name hash.
+	pvc="$(kubectl --context "$WLCTX" -n default get pvc \
+		-l "modelplane.ai/modelcache=$cache" -o jsonpath='{.items[0].metadata.name}')"
+	log "Cache volume: $pvc"
+	kubectl --context "$WLCTX" -n default delete pod e2e-cache-ls --now >/dev/null 2>&1 || true
+	kubectl --context "$WLCTX" -n default run e2e-cache-ls --restart=Never --image="$CURL_IMAGE" \
+		--overrides="$(printf '{"spec":{"containers":[{"name":"ls","image":"%s","command":["find","/mnt/models","-type","f"],"volumeMounts":[{"name":"c","mountPath":"/mnt/models","readOnly":true}]}],"volumes":[{"name":"c","persistentVolumeClaim":{"claimName":"%s","readOnly":true}}]}}' "$CURL_IMAGE" "$pvc")" \
+		>/dev/null 2>&1 || true
+	listing=""
+	for _ in $(seq 1 30); do
+		listing="$(kubectl --context "$WLCTX" -n default logs e2e-cache-ls 2>/dev/null || true)"
+		[ -n "$listing" ] && break
+		sleep 3
+	done
+	kubectl --context "$WLCTX" -n default delete pod e2e-cache-ls --now >/dev/null 2>&1 || true
+	printf '%s\n' "$listing" | sed 's/^/    /'
+	# Assert the weight file and a nested path, since preserving subdirectories
+	# is the part of modctl's extract this depends on.
+	printf '%s' "$listing" | grep -q '\.gguf$' || {
+		echo "verify: no .gguf file on the cache volume; the OCI extract did not land the weights" >&2
+		exit 1
+	}
+	printf '%s' "$listing" | grep -q '/nested/' || {
+		echo "verify: no nested path on the cache volume; modctl's extract flattened the artifact" >&2
+		exit 1
+	}
+	log "OCI OK: $MP_E2E_OCI_REF hydrated onto $pvc with its layout intact"
+fi

--- a/functions/compose-model-cache/function/fn.py
+++ b/functions/compose-model-cache/function/fn.py
@@ -14,11 +14,17 @@
 
 """Compose a ModelCache.
 
-Stages a HuggingFace model onto a ReadWriteMany PVC on every matched
-InferenceCluster via a one-shot hydration Job. Pods that reference the
-cache (ModelDeployment.spec.modelCacheRef -> ModelReplica) mount the PVC
-at /mnt/models, so weights are downloaded once per cluster and read N
-times by every pod in an LWS gang.
+Stages a model onto a ReadWriteMany PVC on every matched InferenceCluster
+via a one-shot hydration Job. Pods that reference the cache
+(ModelDeployment.spec.modelCacheRef -> ModelReplica) mount the PVC at
+/mnt/models, so weights are fetched once per cluster and read N times by
+every pod in an LWS gang.
+
+spec.source picks where the artifact comes from. HuggingFace downloads a
+repo with huggingface_hub, which writes a flat model directory.  OCI pulls
+a ModelPack artifact from a registry with modctl, which restores whatever
+file layout the artifact was built with. Both land on the same mount and
+an engine reads them the same way, by path.
 """
 
 from typing import Literal
@@ -78,11 +84,31 @@ PHASE_FAILED: _Phase = "Failed"
 # functions set this independently, so they are a contract — change together.
 REMOTE_NS = "default"
 
-# Hydration container. python:3.11-slim has pip; we install huggingface_hub
-# at runtime. A Modelplane-owned image with the tool preinstalled is a
-# follow-up (#115).
+# Hydration containers, one per source, each fetching its tool at runtime:
+# huggingface_hub from PyPI, and the modctl release tarball over HTTP. A
+# Modelplane-owned image with both preinstalled is a follow-up (#115), and is
+# what would let either source hydrate in an air-gapped cluster - neither can
+# today, because both reach out before they reach the artifact.
 HYDRATION_IMAGE = "python:3.11-slim"
+OCI_HYDRATION_IMAGE = "alpine:3.20"
 HYDRATION_MOUNT = "/mnt/artifact"
+
+# modctl publishes release tarballs rather than an image, so the Job downloads
+# one. Pinned: the artifactType and layer media types it writes are still the
+# pre-donation `vnd.cnai.*` names rather than the `vnd.cncf.*` ones in the
+# ModelPack spec, so a version bump can change what an artifact looks like.
+_MODCTL_VERSION = "0.2.2"
+
+# Where the propagated registry credential is projected for an OCI source.
+# modctl looks for `config.json` under DOCKER_CONFIG, while a
+# kubernetes.io/dockerconfigjson Secret stores it under `.dockerconfigjson`, so
+# the volume renames the key on the way in.
+_REGISTRY_AUTH_MOUNT = "/etc/modelplane/registry"
+
+# spec.source values, and the key a kubernetes.io/dockerconfigjson Secret stores
+# its payload under.
+_SOURCE_OCI = "OCI"
+_DOCKERCONFIG_KEY = ".dockerconfigjson"
 
 # ttlSecondsAfterFinished governs how long the completed Job (and its
 # PVC-pinning pod) lingers before its TTL controller cascade-deletes both. Keep
@@ -159,6 +185,41 @@ def _hf_hydration(hf: v1alpha1.HuggingFace, auth_secret_name: str | None) -> tup
     return env, command
 
 
+def _oci_hydration(oci: v1alpha1.Oci) -> tuple[list[dict], str]:
+    """Return (env, shell command) for an OCI source.
+
+    `modctl pull --extract-from-remote` streams the artifact from the registry
+    and `--extract-dir` writes its files straight onto the mount, so nothing
+    stages a second copy in the container filesystem.
+
+    What lands is the layout the artifact was *built* with: modctl records a
+    filepath annotation per descriptor and extract restores those paths,
+    subdirectories included. A `modctl build` over a model directory therefore
+    yields that same flat directory here, not a HuggingFace hub cache tree, so an
+    engine reads this mount by path rather than by repo id. Synthesizing a hub
+    layout from the manifest's model name is a follow-up; the artifact does not
+    carry one.
+
+    A registry credential arrives as the propagated dockerconfigjson Secret,
+    projected to the filename modctl's auth lookup expects and pointed at with
+    DOCKER_CONFIG.
+    """
+    env: list[dict] = []
+    if oci.pullSecret:
+        env.append({"name": "DOCKER_CONFIG", "value": _REGISTRY_AUTH_MOUNT})
+    url = f"https://github.com/modelpack/modctl/releases/download/v{_MODCTL_VERSION}/modctl-{_MODCTL_VERSION}-linux-$a.tar.gz"
+    command = (
+        "set -e; "
+        f"{_SKIP_IF_HYDRATED}"
+        'case "$(uname -m)" in aarch64|arm64) a=arm64;; *) a=amd64;; esac; '
+        "apk add --no-cache curl tar >/dev/null; "
+        f"curl -sSfL {url} | tar -xz -C /tmp modctl; "
+        f"/tmp/modctl pull {oci.ref} --extract-dir {HYDRATION_MOUNT} --extract-from-remote --no-progress; "
+        f"touch {_HYDRATED_MARKER}"
+    )
+    return env, command
+
+
 class FunctionRunner(grpcv1.FunctionRunnerServiceServicer):
     """A FunctionRunner handles gRPC RunFunctionRequests."""
 
@@ -186,12 +247,53 @@ class Composer:
         # references an authSecret and that key is present; empty otherwise.
         self.auth_data: dict[str, str] = {}
 
+    # --- source dispatch ---
+    # Every difference between sources is one of four things: the credential the
+    # Job needs, the capacity for the PVC, the hydration command, and the label
+    # for an event. Each is answered here so the composition below reads the same
+    # whichever source is set. A CEL rule on the XRD guarantees the sibling
+    # matching spec.source is present, so each branch can assume its own.
+
+    def _is_oci(self) -> bool:
+        return self.xr.spec.source == _SOURCE_OCI
+
+    def _credential(self) -> tuple[str, str, str] | None:
+        """(field, Secret name, key) of the credential this source references on
+        the control plane, or None when it needs none. The field is carried so a
+        warning names what the user actually wrote - `pullSecret` for OCI,
+        `authSecret` for HuggingFace - rather than a generic word for both. The
+        OCI key is fixed by the dockerconfigjson Secret type; the HuggingFace one
+        is user-selectable."""
+        if self._is_oci():
+            oci = self.xr.spec.oci
+            assert oci is not None
+            return ("pullSecret", oci.pullSecret.name, _DOCKERCONFIG_KEY) if oci.pullSecret else None
+        hf = self.xr.spec.huggingFace
+        assert hf is not None
+        return ("authSecret", hf.authSecret.name, hf.authSecret.key or "HF_TOKEN") if hf.authSecret else None
+
+    def _size_gib(self) -> int:
+        """Capacity for the PVC. Declared per source because a source that
+        stages nothing would have nothing to size."""
+        source = self.xr.spec.oci if self._is_oci() else self.xr.spec.huggingFace
+        assert source is not None
+        # Protobuf delivers XRD integers as float.
+        return int(source.sizeGiB)
+
+    def _artifact(self) -> str:
+        """What this cache stages, for events and messages."""
+        if self._is_oci():
+            assert self.xr.spec.oci is not None
+            return self.xr.spec.oci.ref
+        assert self.xr.spec.huggingFace is not None
+        return self.xr.spec.huggingFace.repo
+
     def _auth_missing(self) -> bool:
-        """Whether the XR references an authSecret whose token couldn't be
-        resolved. compose() only runs past resolve_inputs() once the auth
-        requirement (if any) is resolved, so an empty auth_data here means the
-        Secret was found-but-empty or absent, not merely unresolved."""
-        return self.xr.spec.huggingFace.authSecret is not None and not self.auth_data  # ty: ignore[unresolved-attribute]  # XRD guarantees huggingFace is set
+        """Whether the XR references a credential that couldn't be resolved.
+        compose() only runs past resolve_inputs() once the requirement (if any)
+        is resolved, so empty auth_data here means the Secret was
+        found-but-empty or absent, not merely unresolved."""
+        return self._credential() is not None and not self.auth_data
 
     def compose(self) -> None:
         if not self.resolve_inputs():
@@ -235,18 +337,18 @@ class Composer:
             match_labels=match_labels,
         )
 
-        # When the cache references an authSecret, require that Secret from the
-        # XR's own namespace on the control plane. Its token is propagated to
-        # each workload cluster (compose_cluster_resources) so the hydration Job
-        # finds it; without resolving it first we can't materialize it remotely.
-        auth = self.xr.spec.huggingFace.authSecret  # ty: ignore[unresolved-attribute]  # XRD guarantees huggingFace is set
-        if auth:
+        # When the source references a credential, require that Secret from the
+        # XR's own namespace on the control plane. It is propagated to each
+        # workload cluster (compose_cluster_resources) so the hydration Job finds
+        # it; without resolving it first we can't materialize it remotely.
+        credential = self._credential()
+        if credential:
             response.require_resources(
                 self.rsp,
                 name="auth-secret",
                 api_version="v1",
                 kind="Secret",
-                match_name=auth.name,
+                match_name=credential[1],
                 namespace=_namespace(self.xr.metadata),
             )
 
@@ -256,7 +358,7 @@ class Composer:
         # for both to resolve before composing.
         if "clusters" not in self.req.required_resources:
             return False
-        if auth and "auth-secret" not in self.req.required_resources:
+        if credential and "auth-secret" not in self.req.required_resources:
             return False
         self.clusters = [
             icv1alpha1.InferenceCluster.model_validate(c) for c in request.get_required_resources(self.req, "clusters")
@@ -264,25 +366,24 @@ class Composer:
 
         # Resolve the token best-effort: a missing one doesn't block the PVC,
         # only the hydration Job and token Secret (see _resolve_auth_data).
-        if auth:
-            self._resolve_auth_data(auth, request.get_required_resource(self.req, "auth-secret"))
+        if credential:
+            self._resolve_auth_data(credential[2], request.get_required_resource(self.req, "auth-secret"))
 
         return True
 
-    def _resolve_auth_data(self, auth: v1alpha1.AuthSecret, secret: dict | None) -> None:
-        """Read the token from the resolved control-plane authSecret into
+    def _resolve_auth_data(self, key: str, secret: dict | None) -> None:
+        """Read the credential from the resolved control-plane Secret into
         self.auth_data, copying its base64 `data` verbatim (re-encoding would
         corrupt it).
 
         Best-effort: the caller proceeds either way. A resolved Secret that's
         missing, or whose referenced key is absent or empty, leaves auth_data
         empty (an empty value is as broken as a missing key - the Job would run
-        with an empty HF_TOKEN). That gates the hydration Job and token Secret
-        out while leaving the PVC - which doesn't depend on the token - to
-        compose, so an already-staged cache isn't pruned when its token is later
-        rotated away. derive_conditions surfaces the misconfiguration only when
-        it actually blocks progress."""
-        key = auth.key or "HF_TOKEN"
+        with an empty credential). That gates the hydration Job and the
+        propagated Secret out while leaving the PVC - which doesn't depend on the
+        credential - to compose, so an already-staged cache isn't pruned when its
+        token is later rotated away. derive_conditions surfaces the
+        misconfiguration only when it actually blocks progress."""
         data = (secret.get("data") if secret else {}) or {}
         if data.get(key):
             self.auth_data = {key: data[key]}
@@ -342,8 +443,7 @@ class Composer:
             )
 
     def _pvc_manifest(self, cluster: icv1alpha1.InferenceCluster) -> dict:
-        hf = self.xr.spec.huggingFace
-        size_gib = int(hf.sizeGiB)  # ty: ignore[unresolved-attribute]  # XRD guarantees huggingFace is set; protobuf delivers XRD ints as float
+        size_gib = self._size_gib()
         return {
             "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
@@ -356,18 +456,26 @@ class Composer:
         }
 
     def _auth_secret_manifest(self) -> dict:
-        """The workload-cluster Secret carrying the propagated HF token.
+        """The workload-cluster Secret carrying the propagated credential.
 
         Namespace-qualified name in REMOTE_NS, matching the PVC/Job, so caches
         from different control-plane namespaces don't collide. `data` carries the
-        referenced authSecret key with its base64 value copied verbatim - the
-        hydration Job's env reads that same key from it."""
-        return {
+        referenced key with its base64 value copied verbatim - the hydration Job
+        reads that same key, as an env var for HuggingFace or as a projected file
+        for OCI.
+
+        An OCI credential is typed kubernetes.io/dockerconfigjson so the kubelet
+        validates the payload it projects, rather than leaving a malformed
+        registry config to surface as an auth failure inside the Job."""
+        manifest: dict = {
             "apiVersion": "v1",
             "kind": "Secret",
             "metadata": {"name": self._auth_secret_name(), "namespace": REMOTE_NS, "labels": self._labels()},
             "data": self.auth_data,
         }
+        if self._is_oci():
+            manifest["type"] = "kubernetes.io/dockerconfigjson"
+        return manifest
 
     def _wrap_remote(
         self,
@@ -418,7 +526,31 @@ class Composer:
         return {"modelplane.ai/modelcache": _name(self.xr.metadata)}
 
     def _job_manifest(self) -> dict:
-        env, command = _hf_hydration(self.xr.spec.huggingFace, self._auth_secret_name())  # ty: ignore[invalid-argument-type]  # XRD guarantees huggingFace is set
+        """The one-shot hydration Job. Everything source-specific is the tool it
+        runs and how it reads its credential; the Job around them is the same."""
+        mounts = [{"name": "artifact", "mountPath": HYDRATION_MOUNT}]
+        volumes: list[dict] = [{"name": "artifact", "persistentVolumeClaim": {"claimName": self._pvc_name()}}]
+        if self._is_oci():
+            oci = self.xr.spec.oci
+            assert oci is not None
+            image, (env, command) = OCI_HYDRATION_IMAGE, _oci_hydration(oci)
+            if self.auth_data:
+                # Rename the dockerconfigjson key to the filename modctl reads,
+                # so DOCKER_CONFIG can point at the directory.
+                mounts.append({"name": "registry-auth", "mountPath": _REGISTRY_AUTH_MOUNT, "readOnly": True})
+                volumes.append(
+                    {
+                        "name": "registry-auth",
+                        "secret": {
+                            "secretName": self._auth_secret_name(),
+                            "items": [{"key": _DOCKERCONFIG_KEY, "path": "config.json"}],
+                        },
+                    }
+                )
+        else:
+            hf = self.xr.spec.huggingFace
+            assert hf is not None
+            image, (env, command) = HYDRATION_IMAGE, _hf_hydration(hf, self._auth_secret_name())
         return {
             "apiVersion": "batch/v1",
             "kind": "Job",
@@ -433,18 +565,13 @@ class Composer:
                         "containers": [
                             {
                                 "name": "hydrate",
-                                "image": HYDRATION_IMAGE,
+                                "image": image,
                                 "command": ["/bin/sh", "-c", command],
                                 "env": env,
-                                "volumeMounts": [{"name": "artifact", "mountPath": HYDRATION_MOUNT}],
+                                "volumeMounts": mounts,
                             }
                         ],
-                        "volumes": [
-                            {
-                                "name": "artifact",
-                                "persistentVolumeClaim": {"claimName": self._pvc_name()},
-                            }
-                        ],
+                        "volumes": volumes,
                     },
                 },
             },
@@ -555,10 +682,10 @@ class Composer:
         # token rotated away after hydration is neither reported nor warned.
         ready_count = sum(1 for _, p in per_cluster_phase if p == PHASE_READY)
         if self._auth_missing() and ready_count != len(matched):
-            # _auth_missing is true only when huggingFace.authSecret is set.
-            auth = self.xr.spec.huggingFace.authSecret  # ty: ignore[unresolved-attribute]  # XRD guarantees huggingFace is set
-            assert auth is not None
-            key = auth.key or "HF_TOKEN"
+            # _auth_missing is true only when the source references a credential.
+            credential = self._credential()
+            assert credential is not None
+            field, name, key = credential
             response.set_conditions(
                 self.rsp,
                 resource.Condition(
@@ -569,7 +696,7 @@ class Composer:
             )
             response.warning(
                 self.rsp,
-                f"authSecret {_namespace(self.xr.metadata)}/{auth.name} is missing or has no key {key!r}",
+                f"{field} {_namespace(self.xr.metadata)}/{name} is missing or has no key {key!r}",
             )
         elif any(p == PHASE_FAILED for _, p in per_cluster_phase):
             response.set_conditions(
@@ -607,7 +734,7 @@ class Composer:
             names = ", ".join(_name(c.metadata) for c in matched)
             response.normal(
                 self.rsp,
-                f"Staging {self.xr.spec.huggingFace.repo} to {len(matched)} clusters: {names}",  # ty: ignore[unresolved-attribute]  # XRD guarantees huggingFace is set
+                f"Staging {self._artifact()} to {len(matched)} clusters: {names}",
             )
         if now_ready and not was_ready:
             response.normal(self.rsp, f"Artifact staged on all {len(matched)} clusters")

--- a/functions/compose-model-cache/tests/test_fn.py
+++ b/functions/compose-model-cache/tests/test_fn.py
@@ -58,6 +58,18 @@ def _cache_xr(**hf_extra: Any) -> v1alpha1.ModelCache:
     )
 
 
+# The OCI counterpart. Same metadata as _cache_xr, so the PVC/Job/Secret names
+# are identical and the shared name constants apply to both sources.
+def _oci_cache_xr(**oci_extra: Any) -> v1alpha1.ModelCache:
+    return v1alpha1.ModelCache(
+        metadata=metav1.ObjectMeta(name="qwen", namespace="ml-team"),
+        spec=v1alpha1.Spec(
+            source="OCI",
+            oci=v1alpha1.Oci(ref="registry.example.com/models/qwen:v1", sizeGiB=20, **oci_extra),
+        ),
+    )
+
+
 def _cluster_dict(name: str, pc: str, *, source: str = "GKE", storage_class: str | None = None) -> dict:
     """An InferenceCluster as Crossplane returns it in a required-resource set.
 
@@ -187,6 +199,19 @@ _HYDRATE_CMD_REVISION = (
     "touch /mnt/artifact/.modelplane-hydrated"
 )
 
+# The OCI hydration script: fetch the pinned modctl release for the node's
+# architecture, then stream the artifact straight onto the mount.
+_OCI_HYDRATE_CMD = (
+    "set -e; if [ -f /mnt/artifact/.modelplane-hydrated ]; then echo 'already hydrated, skipping'; exit 0; fi; "
+    'case "$(uname -m)" in aarch64|arm64) a=arm64;; *) a=amd64;; esac; '
+    "apk add --no-cache curl tar >/dev/null; "
+    "curl -sSfL https://github.com/modelpack/modctl/releases/download/v0.2.2/"
+    "modctl-0.2.2-linux-$a.tar.gz | tar -xz -C /tmp modctl; "
+    "/tmp/modctl pull registry.example.com/models/qwen:v1 --extract-dir /mnt/artifact "
+    "--extract-from-remote --no-progress; "
+    "touch /mnt/artifact/.modelplane-hydrated"
+)
+
 _PVC_NAME = "modelcache-ml-team-qwen-17db2"
 _JOB_NAME = "modelcache-ml-team-qwen-hydrate-256ec"
 _AUTH_NAME = "modelcache-ml-team-qwen-auth-ae01b"
@@ -195,6 +220,10 @@ _LABELS = {"modelplane.ai/modelcache": "qwen"}
 # The token data the control-plane authSecret carries, base64 as the API server
 # stores it. Propagated verbatim into the workload-cluster Secret's data.
 _TOKEN_B64 = "aGYtdG9rZW4tdmFsdWU="
+
+# A dockerconfigjson payload, base64 as the API server stores it. Propagated
+# verbatim, the same as the HuggingFace token.
+_DOCKERCFG_B64 = "eyJhdXRocyI6e319"
 
 
 def _pvc_object(pc: str, *, storage_class: str = "modelplane-rwx") -> dict:
@@ -220,7 +249,15 @@ def _pvc_object(pc: str, *, storage_class: str = "modelplane-rwx") -> dict:
     }
 
 
-def _job_object(pc: str, *, command: str = _HYDRATE_CMD, env: list | None = None) -> dict:
+def _job_object(
+    pc: str,
+    *,
+    command: str = _HYDRATE_CMD,
+    env: list | None = None,
+    image: str = "python:3.11-slim",
+    mounts: list | None = None,
+    volumes: list | None = None,
+) -> dict:
     return {
         "apiVersion": "kubernetes.m.crossplane.io/v1alpha1",
         "kind": "Object",
@@ -240,13 +277,14 @@ def _job_object(pc: str, *, command: str = _HYDRATE_CMD, env: list | None = None
                                 "containers": [
                                     {
                                         "name": "hydrate",
-                                        "image": "python:3.11-slim",
+                                        "image": image,
                                         "command": ["/bin/sh", "-c", command],
                                         "env": env or [],
-                                        "volumeMounts": [{"name": "artifact", "mountPath": "/mnt/artifact"}],
+                                        "volumeMounts": mounts or [{"name": "artifact", "mountPath": "/mnt/artifact"}],
                                     },
                                 ],
-                                "volumes": [
+                                "volumes": volumes
+                                or [
                                     {"name": "artifact", "persistentVolumeClaim": {"claimName": _PVC_NAME}},
                                 ],
                             },
@@ -277,6 +315,28 @@ def _auth_object(pc: str) -> dict:
                     "kind": "Secret",
                     "metadata": {"name": _AUTH_NAME, "namespace": "default", "labels": _LABELS},
                     "data": {"HF_TOKEN": _TOKEN_B64},
+                },
+            },
+            "providerConfigRef": {"kind": "ClusterProviderConfig", "name": pc},
+        },
+    }
+
+
+def _registry_auth_object(pc: str) -> dict:
+    """The workload-cluster Secret propagating a registry credential. Typed
+    dockerconfigjson so the kubelet validates the payload it projects, rather
+    than a malformed config surfacing as an auth failure inside the Job."""
+    return {
+        "apiVersion": "kubernetes.m.crossplane.io/v1alpha1",
+        "kind": "Object",
+        "spec": {
+            "forProvider": {
+                "manifest": {
+                    "apiVersion": "v1",
+                    "kind": "Secret",
+                    "type": "kubernetes.io/dockerconfigjson",
+                    "metadata": {"name": _AUTH_NAME, "namespace": "default", "labels": _LABELS},
+                    "data": {".dockerconfigjson": _DOCKERCFG_B64},
                 },
             },
             "providerConfigRef": {"kind": "ClusterProviderConfig", "name": pc},
@@ -785,6 +845,122 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
         want13.requirements.resources["clusters"].CopyFrom(_CLUSTERS_SELECTOR)
         want13.requirements.resources["auth-secret"].CopyFrom(_AUTH_SELECTOR)
 
+        # --- Case 14: an OCI source. Same PVC as a HuggingFace cache, since
+        # capacity and naming don't depend on the source, but the Job runs modctl
+        # out of an alpine image instead of huggingface_hub out of python. ---
+        want14 = fnv1.RunFunctionResponse(
+            meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
+            desired=fnv1.State(
+                composite=fnv1.Resource(
+                    resource=resource.dict_to_struct(
+                        {
+                            "status": {
+                                "summary": {"ready": "0/1"},
+                                "clusters": [{"name": "cluster-a", "phase": "Pending"}],
+                            },
+                        },
+                    ),
+                ),
+                resources={
+                    "pvc-cluster-a": fnv1.Resource(resource=resource.dict_to_struct(_pvc_object("cluster-a-pc"))),
+                    "hydrate-cluster-a": fnv1.Resource(
+                        resource=resource.dict_to_struct(
+                            _job_object(
+                                "cluster-a-pc",
+                                command=_OCI_HYDRATE_CMD,
+                                image="alpine:3.20",
+                            ),
+                        ),
+                    ),
+                },
+            ),
+            conditions=[
+                fnv1.Condition(type="ClustersMatched", status=fnv1.STATUS_CONDITION_TRUE, reason="Matched"),
+                fnv1.Condition(type="ArtifactReady", status=fnv1.STATUS_CONDITION_FALSE, reason="Hydrating"),
+            ],
+            results=[
+                fnv1.Result(
+                    severity=fnv1.SEVERITY_NORMAL,
+                    message="Staging registry.example.com/models/qwen:v1 to 1 clusters: cluster-a",
+                ),
+            ],
+            context=structpb.Struct(),
+        )
+        want14.requirements.resources["clusters"].CopyFrom(_CLUSTERS_SELECTOR)
+
+        # --- Case 15: an OCI source with a pullSecret. The propagated Secret is
+        # typed dockerconfigjson, and the Job reads it as a projected file rather
+        # than an env var: DOCKER_CONFIG names the directory, and the volume
+        # renames .dockerconfigjson to the config.json modctl looks for. ---
+        xr15 = _oci_cache_xr(pullSecret=v1alpha1.PullSecret(name="regcreds"))
+        mounts15 = [
+            {"name": "artifact", "mountPath": "/mnt/artifact"},
+            {"name": "registry-auth", "mountPath": "/etc/modelplane/registry", "readOnly": True},
+        ]
+        volumes15 = [
+            {"name": "artifact", "persistentVolumeClaim": {"claimName": _PVC_NAME}},
+            {
+                "name": "registry-auth",
+                "secret": {
+                    "secretName": _AUTH_NAME,
+                    "items": [{"key": ".dockerconfigjson", "path": "config.json"}],
+                },
+            },
+        ]
+        want15 = fnv1.RunFunctionResponse(
+            meta=fnv1.ResponseMeta(ttl=durationpb.Duration(seconds=60)),
+            desired=fnv1.State(
+                composite=fnv1.Resource(
+                    resource=resource.dict_to_struct(
+                        {
+                            "status": {
+                                "summary": {"ready": "0/1"},
+                                "clusters": [{"name": "cluster-a", "phase": "Pending"}],
+                            },
+                        },
+                    ),
+                ),
+                resources={
+                    "pvc-cluster-a": fnv1.Resource(resource=resource.dict_to_struct(_pvc_object("cluster-a-pc"))),
+                    "auth-cluster-a": fnv1.Resource(
+                        resource=resource.dict_to_struct(_registry_auth_object("cluster-a-pc")),
+                    ),
+                    "hydrate-cluster-a": fnv1.Resource(
+                        resource=resource.dict_to_struct(
+                            _job_object(
+                                "cluster-a-pc",
+                                command=_OCI_HYDRATE_CMD,
+                                image="alpine:3.20",
+                                env=[{"name": "DOCKER_CONFIG", "value": "/etc/modelplane/registry"}],
+                                mounts=mounts15,
+                                volumes=volumes15,
+                            ),
+                        ),
+                    ),
+                },
+            ),
+            conditions=[
+                fnv1.Condition(type="ClustersMatched", status=fnv1.STATUS_CONDITION_TRUE, reason="Matched"),
+                fnv1.Condition(type="ArtifactReady", status=fnv1.STATUS_CONDITION_FALSE, reason="Hydrating"),
+            ],
+            results=[
+                fnv1.Result(
+                    severity=fnv1.SEVERITY_NORMAL,
+                    message="Staging registry.example.com/models/qwen:v1 to 1 clusters: cluster-a",
+                ),
+            ],
+            context=structpb.Struct(),
+        )
+        want15.requirements.resources["clusters"].CopyFrom(_CLUSTERS_SELECTOR)
+        want15.requirements.resources["auth-secret"].CopyFrom(
+            fnv1.ResourceSelector(
+                api_version="v1",
+                kind="Secret",
+                match_name="regcreds",
+                namespace="ml-team",
+            ),
+        )
+
         cases = [
             Case(
                 name="GKE cluster first pass composes RWX PVC and hydration Job",
@@ -873,6 +1049,26 @@ class TestFunctionRunner(unittest.IsolatedAsyncioTestCase):
                 name="authSecret missing with no clusters reports NoClusters not AuthSecretMissing",
                 req=_req(xr13, [], auth=_auth_secret(data={"OTHER": _TOKEN_B64})),
                 want=want13,
+            ),
+            Case(
+                name="OCI source composes the same PVC and a modctl hydration Job",
+                req=_req(_oci_cache_xr(), [_cluster_dict("cluster-a", "cluster-a-pc")]),
+                want=want14,
+            ),
+            Case(
+                name="OCI pullSecret propagates a dockerconfigjson Secret and projects it",
+                req=_req(
+                    xr15,
+                    [_cluster_dict("cluster-a", "cluster-a-pc")],
+                    auth={
+                        "apiVersion": "v1",
+                        "kind": "Secret",
+                        "metadata": {"name": "regcreds", "namespace": "ml-team"},
+                        "type": "kubernetes.io/dockerconfigjson",
+                        "data": {".dockerconfigjson": _DOCKERCFG_B64},
+                    },
+                ),
+                want=want15,
             ),
         ]
 

--- a/schemas/python/models/ai/modelplane/modelcache/v1alpha1.py
+++ b/schemas/python/models/ai/modelplane/modelcache/v1alpha1.py
@@ -69,6 +69,25 @@ class HuggingFace(BaseModel):
     """
 
 
+class PullSecret(BaseModel):
+    name: constr(min_length=1)
+
+
+class Oci(BaseModel):
+    pullSecret: PullSecret | None = None
+    """
+    Optional Secret holding registry credentials for a private repository. Names a kubernetes.io/dockerconfigjson Secret in the ModelCache's own namespace; Modelplane propagates it to each matched cluster for the hydration Job to read.
+    """
+    ref: constr(min_length=1)
+    """
+    Registry reference to the model artifact, by tag or digest (e.g. registry.example.com/models/ qwen2.5-0.5b:v1).
+    """
+    sizeGiB: conint(ge=1, le=100000)
+    """
+    Capacity to allocate for the staged artifact on each matched cluster.
+    """
+
+
 class Spec(BaseModel):
     clusterSelector: ClusterSelector | None = None
     """
@@ -82,7 +101,11 @@ class Spec(BaseModel):
     """
     HuggingFace source. Required when source is HuggingFace.
     """
-    source: Literal['HuggingFace'] = 'HuggingFace'
+    oci: Oci | None = None
+    """
+    OCI source. Required when source is OCI. The hydration Job pulls the artifact with modctl and extracts it onto the cache volume, restoring the file layout the artifact was built with.
+    """
+    source: Literal['HuggingFace', 'OCI']
     """
     Which kind of artifact source to stage from. The matching source object (e.g. spec.huggingFace) must be set.
     """


### PR DESCRIPTION
### Description of your changes

A `ModelCache` could only stage from HuggingFace, so a customer whose models already live in their own registry had no way to point Modelplane at them, and no way to serve from a registry they control.

This adds `spec.source: OCI` with an `oci` sibling carrying a registry `ref` and an optional `pullSecret`. The hydration Job pulls the artifact with `modctl` and extracts it onto the same cache volume a HuggingFace source stages to, so nothing downstream changes: `compose-model-replica` mounts the same PVC at the same path and the engine reads files the same way.

Everything source-specific reduces to four questions — which credential, how much capacity, which hydration variant, and what to name in an event — so the composition below them reads the same either way. A hydration variant is an image, an env list and a command, which is why the OCI path runs `modctl` out of `alpine` while HuggingFace keeps running `huggingface_hub` out of `python`.

```yaml
apiVersion: modelplane.ai/v1alpha1
kind: ModelCache
metadata:
  name: qwen25-05b-oci
  namespace: ml-team
spec:
  source: OCI
  oci:
    ref: us-docker.pkg.dev/my-project/my-repo/qwen2.5-0.5b-instruct:modelpack-v1
    sizeGiB: 5
    pullSecret:
      name: registry-creds     # optional; a kubernetes.io/dockerconfigjson Secret
```

### What ran

Proven end to end on a real GKE cluster: a private registry through to a completion from the loaded model.

Qwen2.5-0.5B-Instruct (988MB of BF16 safetensors, 290 tensors) was packed with `modctl build` and pushed to Artifact Registry. A `ModelCache` with `source: OCI` and a `pullSecret` then hydrated it on the workload cluster:

```
IO summary: 953 MiB in 9.805s, 97.23 MB/s
Successfully pulled model artifact: us-docker.pkg.dev/.../qwen2.5-0.5b-instruct:modelpack-v1
```

The volume held `model.safetensors` at 988,097,824 bytes — byte-identical to the source — alongside the config and tokenizer files, at `/mnt/models`.

vLLM 0.23.0 then loaded from that volume on an NVIDIA L4 bound through DRA:

```
Starting to load model /mnt/models...
Filesystem type for checkpoints: NFS. Checkpoint size: 0.92 GiB.
Loading weights took 6.09 seconds
```

and served a real completion (`"content": "loaded from OCI"`, `finish_reason: "stop"`).

Two things this exercises that were previously only unit-tested. The `pullSecret` path ran against a private registry with real credentials, through the composition's Secret propagation to the workload cluster. And the engine's args came out as `["--served-model-name=qwen2.5-0.5b","--max-model-len=16384","--model=/mnt/models"]` — no `--model` was written by hand, so `apply_cache_args` injected it.

`test-compose-model-cache`, `ty-compose-model-cache` and the `python` check pass. Fifteen cases, two of them new. The local `e2e` harness also gained an `--oci` flag that stages a cache and asserts the artifact's files land on the volume; it is off by default and out of the CI gate, because it needs an artifact in a registry the workload cluster can pull from and so is not hermetic.

### What lands on the volume

An OCI cache is read by path, not by repo id. `modctl` records a filepath annotation per descriptor and extract restores those paths, subdirectories included, so an artifact built over a model directory yields that same directory rather than a HuggingFace hub cache tree. An OCI reference also carries no HuggingFace repo id to build a tree around. So the property #407 is after — one engine command whether or not a cache exists — holds for a HuggingFace source and not for this one.

That interacts with #407 in a way worth settling before either lands. #407 asks to hydrate into the hub layout and to set `HF_HUB_CACHE` and `HF_HUB_OFFLINE` on any engine referencing a cache. The second cannot be unconditional once an OCI source exists: an OCI volume is not a hub cache tree, so an engine reading it by path is fine, but one handed a repo id with `HF_HUB_OFFLINE=1` would fail to resolve. The env injection has to be conditioned on the cache's source, which means `compose-model-replica` needs to know something about the cache beyond its volume name — today it deliberately knows nothing.

`modctl` also still writes the pre-donation media types: `artifactType: application/vnd.cnai.model.manifest.v1+json`, layers `vnd.cnai.model.weight.v1.raw`, annotations `org.cnai.model.filepath`, where the ModelPack spec documents `vnd.cncf.model.*`. The version is pinned for that reason, and anything that later switches on `artifactType` has to accept both.

### `sizeGiB` is close to meaningless on GKE

Worth raising because the GKE run made it concrete. The composed `modelplane-rwx` StorageClass is Filestore at `tier: enterprise`, whose minimum share is 1TiB. `sizeGiB: 5` provisioned a **1024 GB** Filestore instance — no PVC error, roughly ten minutes, and a bill for a terabyte to cache a 1GB model.

So `sizeGiB` reads like it controls cost and does not, below 1TiB on GKE. That also undercuts deriving the size from the manifest by summing descriptor bytes: the platform rounds that up by two orders of magnitude, so tier choice is the lever, not sizing logic. The PVC is also `ReadWriteMany` unconditionally, which a Standalone single-node engine does not need.

I would rather settle this than keep `sizeGiB` required, but it is a separate change from adding the source.

### Drive-by fix

The `SOURCE` printer column read `.spec.source.huggingFace.repo` against a `source` that is a string, so it never resolved. It now reads `.spec.source`.

### Still open

`#115` is now a prerequisite rather than a follow-up. The image stops being one image, and neither source can hydrate air-gapped today, because both fetch a tool before they fetch the artifact.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run the affected checks (`test-compose-model-cache`, `ty-compose-model-cache`, `python`) and made sure they pass.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
