### PR TITLE
Set the project on the composed ProjectIAMMember

### DIFF
--- a/docs/content/getting-started/build-the-platform.md
+++ b/docs/content/getting-started/build-the-platform.md
@@ -24,14 +24,14 @@ against this capacity without knowing which cluster it runs on.
   | Role | Needed for |
   |---|---|
   | `roles/container.admin` | the cluster and its node pools |
-  | `roles/compute.admin` | the VPC network and subnetwork |
+  | `roles/compute.admin` | the VPC network and subnet |
   | `roles/serviceusage.serviceUsageAdmin` | enabling the APIs the cluster needs |
   | `roles/iam.serviceAccountAdmin` | the node service account |
   | `roles/iam.serviceAccountKeyAdmin` | the node service account's key |
   | `roles/iam.serviceAccountUser` | attaching that account to the nodes |
   | `roles/resourcemanager.projectIamAdmin` | granting the node account `container.admin` |
 
-  The last one is worth a look before you hand the key over: Modelplane grants
+  The last one is worth a look before you hand the key over. Modelplane grants
   the node service account `roles/container.admin`, so the credential doing the
   provisioning has to be able to set project IAM policy.
 {{< /tab >}}

--- a/docs/content/getting-started/build-the-platform.md
+++ b/docs/content/getting-started/build-the-platform.md
@@ -19,8 +19,21 @@ against this capacity without knowing which cluster it runs on.
 - AWS access key ID and secret access key
 {{< /tab >}}
 {{< tab "GKE" >}}
-- A GCP account with permissions to create GKE clusters, VPCs, and IAM roles
-- A GCP service account JSON key
+- A GCP service account JSON key, granted these roles on the project:
+
+  | Role | Needed for |
+  |---|---|
+  | `roles/container.admin` | the cluster and its node pools |
+  | `roles/compute.admin` | the VPC network and subnetwork |
+  | `roles/serviceusage.serviceUsageAdmin` | enabling the APIs the cluster needs |
+  | `roles/iam.serviceAccountAdmin` | the node service account |
+  | `roles/iam.serviceAccountKeyAdmin` | the node service account's key |
+  | `roles/iam.serviceAccountUser` | attaching that account to the nodes |
+  | `roles/resourcemanager.projectIamAdmin` | granting the node account `container.admin` |
+
+  The last one is worth a look before you hand the key over: Modelplane grants
+  the node service account `roles/container.admin`, so the credential doing the
+  provisioning has to be able to set project IAM policy.
 {{< /tab >}}
 {{< tab "AKS" >}}
 - An Azure account with permissions to create AKS clusters and managed identities

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -51,6 +51,26 @@ server exposes both, so the pod goes Ready without a real model or GPU.
 | Control-plane `InferenceGateway` + cross-cluster routing to the replica | |
 | Status propagation and foreground-deletion ordering | |
 
+### Why cloud provisioning cannot be tested here
+
+`lean-control-plane.yaml` trims the control plane to what a BYO cluster needs,
+and both trims stop a cloud `InferenceCluster` from reconciling at all. Neither
+announces itself, so this is what to expect if you point this control plane at a
+real cloud:
+
+- The MRAP activates only `*.kubernetes.m.crossplane.io` and
+  `*.helm.m.crossplane.io`. A cloud provider's managed resources are then never
+  activated, so they sit with **no status conditions at all** — which reads as
+  nothing happening rather than as an error.
+- The `dormant-cloud-providers` `ImageConfig` maps every
+  `xpkg.upbound.io/upbound/provider-*` to a zero-replica runtime config. Editing
+  that `ImageConfig` is not enough on its own: it is resolved when a package
+  revision reconciles, so existing Deployments keep their replica count until
+  something scales them.
+
+Undoing both is possible but leaves a control plane that is no longer the one CI
+runs, so prefer a separate control plane for cloud work.
+
 ## Prerequisites
 
 - **Docker** with real headroom — **≥ 16 GB memory** and **plenty of disk**

--- a/functions/compose-gke-cluster/function/fn.py
+++ b/functions/compose-gke-cluster/function/fn.py
@@ -175,9 +175,11 @@ class Composer:
     def resolve_project(self) -> str | None:
         """Fetch the GCP provider config and return its projectID.
 
-        The GCP provider uses projectID from the ProviderConfig/ClusterProviderConfig
-        as the default for all managed resources, so we only need the value
-        explicitly for the workloadPool string in the GKE cluster spec.
+        The GCP provider late-initializes projectID from the
+        ProviderConfig/ClusterProviderConfig into most managed resources, so the
+        value is needed explicitly only where that does not happen: the
+        workloadPool string in the GKE cluster spec, and the ProjectIAMMember,
+        which creates with an empty project unless it is set.
 
         When the ProviderConfig is transiently gone but the cluster already
         exists, falls back to the project embedded in the observed cluster's
@@ -506,6 +508,12 @@ class Composer:
                     forProvider=iamv1beta1.ForProvider(
                         role="roles/container.admin",
                         member=f"serviceAccount:{sa_email}",
+                        # Set explicitly. The provider late-initializes `project`
+                        # from the ProviderConfig for the Network, Subnetwork and
+                        # ServiceAccount, but not for this resource: it goes to
+                        # create with an empty project and the GCP call 404s on
+                        # "Error retrieving IAM policy for project ''".
+                        project=self.project,
                     ),
                 ),
             ),

--- a/functions/compose-gke-cluster/tests/test_fn.py
+++ b/functions/compose-gke-cluster/tests/test_fn.py
@@ -274,6 +274,7 @@ def _iam_binding(
             "forProvider": {
                 "role": "roles/container.admin",
                 "member": f"serviceAccount:{sa_email}",
+                "project": "my-gcp-project",
             },
         },
     }


### PR DESCRIPTION
### Description of your changes

Provisioning a GKE `InferenceCluster` fails at the IAM binding:

```
Request `Create IAM Members roles/container.admin
serviceAccount:...@<project>.iam.gserviceaccount.com for project ""`
returned error: Error retrieving IAM policy for project "":
googleapi: got HTTP response code 404
```

`compose_iam_binding` builds `forProvider` from `role` and `member` only, on an assumption written into `resolve_project`'s docstring:

> The GCP provider uses projectID from the ProviderConfig/ClusterProviderConfig as the default for all managed resources, so we only need the value explicitly for the workloadPool string in the GKE cluster spec.

That holds for the `Network`, `Subnetwork` and `ServiceAccount` — all three come back with `project` late-initialized into their specs — but not for `ProjectIAMMember`, which creates with an empty project before any late-init happens. `project` is optional on the CRD, so nothing catches the omission before the call goes out.

`self.project` is already resolved for `workloadPool`, so the fix passes the same value.

The blast radius is the whole cluster, not just the binding: the XR stays at `Unready resources: gke-cluster`, so `BackendReady` never installs the serving stack and the `InferenceCluster` never reaches `Ready`.

The existing test encoded the broken shape — it asserted a `forProvider` of exactly `role` and `member` — so it is updated rather than added to.

### Two things found alongside it

**The GCP roles a credential needs were undocumented.** `build-the-platform` said only "permissions to create GKE clusters, VPCs, and IAM roles". Provisioning one cluster produced a separate 403 for each of seven roles, which are now listed. `roles/resourcemanager.projectIamAdmin` gets a callout: Modelplane grants the node service account `roles/container.admin`, so the provisioning credential must be able to set project IAM policy. That is a strong permission and a platform team should know it is required before handing a key over.

**The local e2e control plane cannot provision cloud clusters**, and `e2e/README.md` now says so. Both of `lean-control-plane.yaml`'s trims block it, and neither announces itself: unactivated managed resources report *no status conditions at all* (which reads as idle, not as an error), and the zero-replica `ImageConfig` is not undone by editing the `ImageConfig`, since it resolves only when a package revision reconciles.

### How this was found

Provisioning a real GKE cluster with an L4 pool to validate #411 and #412 against real vLLM. Patching `spec.forProvider.project` on the live managed resource unblocked provisioning, which confirmed the cause before this change was written.

After the fix the same path completed: cluster and node pools provisioned, serving stack installed, and a vLLM engine served a completion.

`test-compose-gke-cluster`, `ty-compose-gke-cluster` and the repo-wide `python` check pass.

### What is not covered

The composition grants the node service account `roles/container.admin` at project scope. That is broader than a node needs and is worth revisiting, but it is existing behaviour and out of scope here.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run the affected checks (`test-compose-gke-cluster`, `ty-compose-gke-cluster`, `python`) and made sure they pass.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
