### PR TITLE
Update flake.lock to the actual crossplane-cli v2.5.0 commit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
-        "lastModified": 1782321263,
-        "narHash": "sha256-pD91bH+K0nWDXv51mWtNlQVtBLi/zDEjAxAJ6ywd69g=",
+        "lastModified": 1787290757,
+        "narHash": "sha256-ksym0FzurF2fkpKtIiTJ184Wzj4Xz48uCUPSBUeSgbg=",
         "owner": "crossplane",
         "repo": "cli",
-        "rev": "ef9b974770a45e085aacee3b2cdda6284ab6cf51",
+        "rev": "1acb525095a4e43c9a765954efa66a47667a432b",
         "type": "github"
       },
       "original": {
@@ -48,43 +48,43 @@
         ]
       },
       "locked": {
-        "lastModified": 1770313987,
-        "narHash": "sha256-81QP51jUEgp2sOkGEXZ2TDsfbls98/A9aQTu7PAyP30=",
+        "lastModified": 1770585520,
+        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
         "owner": "nix-community",
         "repo": "gomod2nix",
-        "rev": "75c2866d585a75a1b30c634dbd7c2dcce5a6c3a7",
+        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "gomod2nix",
-        "rev": "75c2866d585a75a1b30c634dbd7c2dcce5a6c3a7",
+        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776221942,
-        "narHash": "sha256-FbQAeVNi7G4v3QCSThrSAAvzQTmrmyDLiHNPvTF2qFM=",
+        "lastModified": 1787101114,
+        "narHash": "sha256-gwrPcFf/rDjHPaVflbDZ040ZDmBTRj/7+s8ZmE2SaIM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1766437c5509f444c1b15331e82b8b6a9b967000",
+        "rev": "b18a4b905f8d028dc4476412e6d6891728695379",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1776255774,
-        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
+        "lastModified": 1787172299,
+        "narHash": "sha256-PShzS87awOlE5XWkxUGBd/58/F+AtE2ZMgFffKj4r8s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "rev": "07e1d92cdc0ed416cfa11ff3ca40d17e61cfba7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Description of your changes

`flake.lock` pinned `crossplane-cli` to `ef9b974` (2026-06-24) while claiming to be on `v2.5.0`, which is `1acb525` (2026-08-21), 151 commits later.

1916658b bumped the input in `flake.nix` from `v2.4.0` to `v2.5.0` and, in `flake.lock`, updated only the `original.ref` field. `locked.rev` was left alone. Nix re-resolves an input when the lock's `original` entry disagrees with `flake.nix`; here they agreed, so the lock looked valid and the stale rev survived. Every `nix develop`, `nix run .#build`, and CI run since has used a June build of the CLI while reporting v2.5.0.

The symptom that surfaced it was schema drift. crossplane/cli#270 generates schemas for transitive package dependencies. It merged 2026-08-20 and is in v2.5.0, but not in `ef9b974`. #397 dropped the direct family provider dependencies from `crossplane-project.yaml` on the basis that #270 makes them transitive, which is correct for v2.5.0. Running `nix run .#build` with the CLI that was actually pinned instead deleted 21 family provider models, three of which are imported by composition functions:

```
functions/compose-gke-cluster/function/fn.py:42  models.io.upbound.m.gcp.clusterproviderconfig.v1beta1
functions/compose-gke-cluster/function/fn.py:47  models.io.upbound.m.gcp.providerconfig.v1beta1
functions/compose-aks-cluster/function/fn.py:67  models.io.upbound.m.azure.resourcegroup.v1beta1
```

So the committed schemas were correct and the toolchain was wrong. Re-locking the input is the whole fix: `nix run .#build` on this branch leaves `schemas/` byte-for-byte untouched, and `nix flake check` passes.

Re-locking also picks up crossplane-cli's own inputs as of the v2.5.0 tag, which moves the nixpkgs used to *build the CLI* from nixos-25.11 to nixos-26.05. That's crossplane-cli's private input, not the nixpkgs this project builds against.

Nothing in CI would catch a recurrence. `nix run .#build` runs only in the `push-package` job, which is skipped on pull requests, so stale generated schemas can't be detected pre-merge; and nothing validates that a locked rev matches the ref it claims. Neither can be a `nix flake check` derivation, since both need network.

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.
