### PR TITLE
Assert what the served endpoints return, not just a 200

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -92,7 +92,7 @@ against. The control-plane cluster needs no DRA.
 
 ```bash
 nix run .#e2e              # bring up both clusters + deploy the mock model
-nix run .#e2e -- --verify  # same, then wait for readiness and assert a live 200
+nix run .#e2e -- --verify  # same, then wait for readiness and run the behavioral suite
 nix run .#e2e -- --clean   # tear both clusters down
 ```
 
@@ -117,10 +117,16 @@ kubectl run curl -n ml-team --rm -it --image=curlimages/curl@sha256:7c12af72ceb3
   -d '{"model":"mock","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
 ```
 
-`--verify` runs both of those (OpenAI then Anthropic) and exits non-zero on
-failure. It's the exact command the `E2E` CI workflow runs, so a green `--verify`
-locally and a green CI run mean the same thing; use the manual curls above to
-poke the endpoints interactively.
+`--verify` goes further than those curls: it runs [`verify/test_serving.py`](verify/test_serving.py)
+from a pod on the control plane and asserts what came back — the response shapes
+both surfaces promise, that the last user turn reaches the engine, that a
+streamed response arrives as `text/event-stream` frames rather than one buffered
+blob, and that malformed input and unrouted paths fail. The suite goes in as a
+ConfigMap and runs under a stock `python:3.12-alpine` pod; it imports only the
+stdlib, so nothing is built or installed. It exits non-zero on failure and is the
+exact command the `E2E` CI workflow runs, so a green `--verify` locally and a
+green CI run mean the same thing; use the manual curls above to poke the
+endpoints interactively.
 
 ## How it's structured
 

--- a/e2e/manifests/40-model-deployment.yaml
+++ b/e2e/manifests/40-model-deployment.yaml
@@ -37,6 +37,8 @@ spec:
                 - |
                   import json, http.server
                   class H(http.server.BaseHTTPRequestHandler):
+                      # HTTP/1.1 so the streaming path can chunk, the way a real engine does.
+                      protocol_version = "HTTP/1.1"
                       def _s(self, o, c=200):
                           b = json.dumps(o).encode()
                           self.send_response(c)
@@ -44,6 +46,24 @@ spec:
                           self.send_header("content-length", str(len(b)))
                           self.end_headers()
                           self.wfile.write(b)
+                      def _sse(self, frames):
+                          self.send_response(200)
+                          self.send_header("content-type", "text/event-stream")
+                          self.send_header("cache-control", "no-cache")
+                          self.send_header("transfer-encoding", "chunked")
+                          self.end_headers()
+                          for f in [*frames, "[DONE]"]:
+                              b = ("data: " + (f if isinstance(f, str) else json.dumps(f)) + "\n\n").encode()
+                              self.wfile.write(b"%X\r\n" % len(b) + b + b"\r\n")
+                              self.wfile.flush()
+                          self.wfile.write(b"0\r\n\r\n")
+                      def _read(self):
+                          n = int(self.headers.get("content-length") or 0)
+                          try:
+                              r = json.loads(self.rfile.read(n) or b"{}")
+                          except ValueError:
+                              return None
+                          return r if isinstance(r, dict) and r.get("messages") else None
                       def do_GET(self):
                           if self.path == "/health":
                               self._s({"status": "ok"})
@@ -52,27 +72,46 @@ spec:
                           else:
                               self._s({"error": "not found"}, 404)
                       def do_POST(self):
-                          n = int(self.headers.get("content-length") or 0)
-                          self.rfile.read(n)
-                          text = "Hello from the Modelplane local mock engine."
-                          if self.path.startswith("/v1/messages"):
+                          req = self._read()
+                          anthropic = self.path.startswith("/v1/messages")
+                          if not anthropic and not self.path.startswith("/v1/chat/completions"):
+                              self._s({"error": "not found"}, 404)
+                          elif req is None:
+                              self._s({"error": "messages is required"}, 400)
+                          else:
+                              self._answer(req, anthropic)
+                      def _answer(self, req, anthropic):
+                          model = req.get("model") or "mock"
+                          # Echo the last user turn back, so a caller can tell its request reached the engine.
+                          turns = [m.get("content") or "" for m in req["messages"] if m.get("role") == "user"]
+                          text = "Echo: " + (turns[-1] if turns else "")
+                          if anthropic:
                               # Anthropic Messages API; vLLM serves it alongside the OpenAI routes.
                               self._s({
                                   "id": "msg-mock", "type": "message", "role": "assistant",
-                                  "model": "mock", "stop_reason": "end_turn",
+                                  "model": model, "stop_reason": "end_turn",
                                   "content": [{"type": "text", "text": text}],
-                                  "usage": {"input_tokens": 1, "output_tokens": 1},
+                                  "usage": {"input_tokens": len(turns), "output_tokens": 1},
                               })
+                          elif req.get("stream"):
+                              head = {"id": "chatcmpl-mock", "object": "chat.completion.chunk", "model": model}
+                              frames = [dict(head, choices=[{"index": 0, "delta": {"role": "assistant"}}])]
+                              frames += [dict(head, choices=[{"index": 0, "delta": {"content": w + " "}}]) for w in text.split()]
+                              frames.append(dict(head, choices=[{"index": 0, "delta": {}, "finish_reason": "stop"}]))
+                              self._sse(frames)
                           else:
                               self._s({
-                                  "id": "chatcmpl-mock", "object": "chat.completion", "model": "mock",
+                                  "id": "chatcmpl-mock", "object": "chat.completion", "model": model,
                                   "choices": [{"index": 0, "finish_reason": "stop",
                                                "message": {"role": "assistant", "content": text}}],
-                                  "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                                  "usage": {"prompt_tokens": len(turns), "completion_tokens": 1,
+                                            "total_tokens": len(turns) + 1},
                               })
                       def log_message(self, *a):
                           pass
-                  http.server.HTTPServer(("0.0.0.0", 8000), H).serve_forever()
+                  # Threaded: HTTP/1.1 keeps connections alive, so a single-threaded server
+                  # would block the probes and the endpoint-picker behind one client.
+                  http.server.ThreadingHTTPServer(("0.0.0.0", 8000), H).serve_forever()
                 # The ModelDeployment container template is a curated subset
                 # (name/image/command/args/env); the composition wires the port,
                 # readiness, and any GPU resources itself (it assumes port 8000). So

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -19,9 +19,9 @@ WL=modelplane-e2e-workload
 # project run creates needs no DRA, so its image doesn't matter here.
 WL_NODE_IMAGE=kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
 METALLB_URL=https://raw.githubusercontent.com/metallb/metallb/v0.14.8/config/manifests/metallb-native.yaml
-# Pinned by digest (a multi-arch manifest list) so a moving :latest can't flake
-# the verify curl pod.
-CURL_IMAGE=curlimages/curl@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
+# The same python:3.12-alpine digest the mock engine runs, so the e2e pins one
+# image. The suite is stdlib-only, so the stock image needs no pip install.
+PYTHON_IMAGE=python@sha256:6d43704baacd1bfbe7c295d7f13079d5d8104ed33568873133f8fc69980419df
 ROOT="$(git rev-parse --show-toplevel)"
 
 log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
@@ -180,9 +180,9 @@ fi
 
 # --verify: project run returns once the config is healthy and the resources are
 # applied, so the serving-stack install and model rollout are still reconciling.
-# Wait for the ModelService to publish an address, then route a real request to
-# the engine and assert a 200. Any failure exits non-zero — that is what makes
-# this usable as a CI gate.
+# Wait for the ModelService to publish an address, then run the behavioral suite
+# in e2e/verify against it. Any failure exits non-zero — that is what makes this
+# usable as a CI gate.
 log "Verifying the model serves end to end"
 ns=ml-team
 svc=mock
@@ -200,52 +200,62 @@ done
 log "ModelService address: $addr"
 
 # The address is on the kind Docker subnet the host can't route to on macOS, so
-# curl from a pod on the control plane, reading the status from the pod's logs
-# (not `run -i`, whose attach drops output on a headless runner). curl_status
-# runs one throwaway pod per call and echoes the HTTP code; it polls the logs
-# (curl writes the code once, then exits) so a failed attempt costs seconds, and
-# a unique pod name per call keeps retries from reading a prior pod's output.
-curl_status() {
-	local pod="$1" url="$2"
-	shift 2
-	kubectl --context "$cpctx" -n "$ns" run "$pod" --restart=Never \
-		--labels=app.kubernetes.io/name=e2e-verify --image="$CURL_IMAGE" \
-		--command -- curl -sS --max-time 15 -o /dev/null -w '%{http_code}' "$url" "$@" \
-		>/dev/null 2>&1 || true
-	local c=""
-	for _ in $(seq 1 30); do
-		c="$(kubectl --context "$cpctx" -n "$ns" logs "$pod" 2>/dev/null | tr -dc '0-9' || true)"
-		[ -n "$c" ] && break
-		sleep 2
-	done
-	printf '%s' "$c"
-}
+# the suite runs from a pod on the control plane. It ships as a ConfigMap rather
+# than an image we'd have to build and push, and the stock python image runs it
+# as-is because it imports nothing outside the stdlib.
+log "Running the behavioral suite (e2e/verify) against $addr"
+kubectl --context "$cpctx" -n "$ns" create configmap e2e-verify-suite \
+	--from-file=test_serving.py="$ROOT/e2e/verify/test_serving.py" \
+	--dry-run=client -o yaml | kubectl --context "$cpctx" apply -f -
 
-# OpenAI /v1/chat/completions, retried: the address can publish a moment before
-# the cross-cluster route is serving, and a slower CI runner widens that gap.
-oai='{"model":"'"$svc"'","messages":[{"role":"user","content":"ping"}]}'
-code=""
-for attempt in $(seq 1 10); do
-	code="$(curl_status "e2e-verify-oai-$attempt" "$addr/v1/chat/completions" -H 'content-type: application/json' -d "$oai")"
-	log "verify attempt $attempt (OpenAI): HTTP ${code:-none}"
-	[ "$code" = "200" ] && break
+# A rerun against a live cluster would otherwise hit an immutable completed pod.
+kubectl --context "$cpctx" -n "$ns" delete pod e2e-verify --now >/dev/null 2>&1 || true
+kubectl --context "$cpctx" apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: e2e-verify
+  namespace: $ns
+  labels:
+    app.kubernetes.io/name: e2e-verify
+spec:
+  restartPolicy: Never
+  containers:
+    - name: verify
+      image: $PYTHON_IMAGE
+      command: [python, -u, /suite/test_serving.py, -v]
+      env:
+        - name: MODELPLANE_ADDRESS
+          value: "$addr"
+        - name: MODELPLANE_MODEL
+          value: "$svc"
+      volumeMounts:
+        - name: suite
+          mountPath: /suite
+  volumes:
+    - name: suite
+      configMap:
+        name: e2e-verify-suite
+EOF
+
+# The suite waits for the route itself, so the only wait here is for the pod to
+# finish. Poll the phase: kubectl wait has no single condition for "ran, either
+# way", and a Failed pod is a result to report, not an error to time out on.
+phase=""
+for _ in $(seq 1 90); do
+	phase="$(kubectl --context "$cpctx" -n "$ns" get pod e2e-verify -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+	case "$phase" in
+	Succeeded | Failed) break ;;
+	esac
 	sleep 10
 done
-[ "$code" = "200" ] || {
-	echo "verify: $addr/v1/chat/completions did not return 200 within retries (last: ${code:-none})" >&2
-	kubectl --context "$cpctx" -n "$ns" delete pod -l app.kubernetes.io/name=e2e-verify --now >/dev/null 2>&1 || true
-	exit 1
-}
 
-# Anthropic Messages API on the same address: vLLM serves /v1/messages alongside
-# the OpenAI routes (PR #360) and the route preserves the path. Serving is up by
-# now, so one attempt suffices.
-ant='{"model":"'"$svc"'","max_tokens":16,"messages":[{"role":"user","content":"ping"}]}'
-mcode="$(curl_status e2e-verify-anthropic "$addr/v1/messages" -H 'content-type: application/json' -H 'anthropic-version: 2023-06-01' -d "$ant")"
-log "verify (Anthropic /v1/messages): HTTP ${mcode:-none}"
-kubectl --context "$cpctx" -n "$ns" delete pod -l app.kubernetes.io/name=e2e-verify --now >/dev/null 2>&1 || true
-[ "$mcode" = "200" ] || {
-	echo "verify: $addr/v1/messages did not return 200 (last: ${mcode:-none})" >&2
+# unittest writes to stderr, and the logs are the failure report on a red run.
+kubectl --context "$cpctx" -n "$ns" logs e2e-verify 2>&1 || true
+kubectl --context "$cpctx" -n "$ns" delete pod e2e-verify --now >/dev/null 2>&1 || true
+kubectl --context "$cpctx" -n "$ns" delete configmap e2e-verify-suite >/dev/null 2>&1 || true
+[ "$phase" = "Succeeded" ] || {
+	echo "verify: the behavioral suite did not pass (pod phase: ${phase:-none})" >&2
 	exit 1
 }
-log "End to end OK: $addr serves OpenAI (/v1/chat/completions) and Anthropic (/v1/messages)"
+log "End to end OK: $addr passes the behavioral suite in e2e/verify"

--- a/e2e/verify/test_serving.py
+++ b/e2e/verify/test_serving.py
@@ -1,0 +1,166 @@
+# Copyright 2026 The Modelplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral checks against a running ModelService.
+
+A 200 only proves the path is wired. These assert what came back: the response
+shapes the OpenAI and Anthropic surfaces promise, that a request body reaches
+the engine intact, that a streamed response survives the two-hop route as
+event-stream frames, and that bad input fails instead of returning a 200 with
+an error in the body.
+
+MODELPLANE_ADDRESS is the ModelService's status.address. It's on the kind
+Docker subnet, so this runs from a pod on the control plane (see run.sh), not
+from the host.
+"""
+
+import json
+import os
+import time
+import unittest
+import urllib.error
+import urllib.request
+
+ADDRESS = os.environ.get("MODELPLANE_ADDRESS", "").rstrip("/")
+MODEL = os.environ.get("MODELPLANE_MODEL", "mock")
+READY_TIMEOUT = float(os.environ.get("MODELPLANE_READY_TIMEOUT", "300"))
+
+OK = 200
+BAD_REQUEST = 400
+ANTHROPIC_HEADERS = {"anthropic-version": "2023-06-01"}
+
+Response = tuple[int, dict[str, str], bytes]
+
+
+def call(
+    path: str, data: bytes | None = None, *, headers: dict[str, str] | None = None, timeout: float = 30.0
+) -> Response:
+    """POST data (GET when it's None) and return the status, headers and body, 4xx included."""
+    req = urllib.request.Request(f"{ADDRESS}{path}", data=data, method="GET" if data is None else "POST")
+    req.add_header("content-type", "application/json")
+    for name, value in (headers or {}).items():
+        req.add_header(name, value)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, dict(resp.headers), resp.read()
+    except urllib.error.HTTPError as err:
+        with err:
+            return err.code, dict(err.headers), err.read()
+
+
+def chat(*turns: str, stream: bool = False) -> bytes:
+    """An OpenAI chat request. Turns alternate user, assistant, user, so the last one is the user's."""
+    messages = [{"role": "user" if i % 2 == 0 else "assistant", "content": t} for i, t in enumerate(turns)]
+    payload: dict[str, object] = {"model": MODEL, "messages": messages}
+    if stream:
+        payload["stream"] = True
+    return json.dumps(payload).encode()
+
+
+def frames(body: bytes) -> list[str]:
+    return [line[len("data: ") :] for line in body.decode().splitlines() if line.startswith("data: ")]
+
+
+def setUpModule() -> None:
+    """Wait for the route to serve. The address publishes before the path carries traffic."""
+    if not ADDRESS:
+        raise RuntimeError("MODELPLANE_ADDRESS is not set")
+    deadline = time.monotonic() + READY_TIMEOUT
+    status = 0
+    while True:
+        try:
+            status, _, _ = call("/v1/chat/completions", chat("ready?"), timeout=15.0)
+        except OSError:
+            status = 0
+        if status == OK:
+            return
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"{ADDRESS} did not serve a chat completion within {READY_TIMEOUT:.0f}s (last status {status})"
+            )
+        time.sleep(5)
+
+
+class ChatCompletions(unittest.TestCase):
+    def test_response_shape(self) -> None:
+        status, _, body = call("/v1/chat/completions", chat("ping"))
+        self.assertEqual(status, OK)
+        got = json.loads(body)
+        self.assertEqual(got["object"], "chat.completion")
+        self.assertEqual(got["model"], MODEL)
+        self.assertEqual(len(got["choices"]), 1)
+        choice = got["choices"][0]
+        self.assertEqual(choice["message"]["role"], "assistant")
+        self.assertTrue(choice["message"]["content"], "empty assistant content")
+        self.assertEqual(choice["finish_reason"], "stop")
+        self.assertIn("usage", got)
+
+    def test_last_user_turn_reaches_the_engine(self) -> None:
+        marker = "marker-4d91"
+        status, _, body = call("/v1/chat/completions", chat("first", "an earlier answer", marker))
+        self.assertEqual(status, OK)
+        content = json.loads(body)["choices"][0]["message"]["content"]
+        self.assertIn(marker, content, "the engine did not see the last user turn")
+
+    def test_streaming_returns_event_stream_frames(self) -> None:
+        status, headers, body = call("/v1/chat/completions", chat("one two", stream=True))
+        self.assertEqual(status, OK)
+        self.assertIn("text/event-stream", headers.get("content-type", ""))
+        got = frames(body)
+        self.assertGreater(len(got), 1, "a stream collapsed to a single frame")
+        self.assertEqual(got[-1], "[DONE]")
+        self.assertEqual(json.loads(got[0])["object"], "chat.completion.chunk")
+        streamed = "".join(json.loads(f)["choices"][0]["delta"].get("content", "") for f in got[:-1])
+        self.assertIn("one two", streamed)
+
+    def test_malformed_body_is_rejected(self) -> None:
+        status, _, _ = call("/v1/chat/completions", b"not json")
+        self.assertGreaterEqual(status, BAD_REQUEST, "malformed JSON was accepted")
+
+    def test_request_without_messages_is_rejected(self) -> None:
+        status, _, _ = call("/v1/chat/completions", json.dumps({"model": MODEL}).encode())
+        self.assertGreaterEqual(status, BAD_REQUEST, "a request with no messages was accepted")
+
+
+class Messages(unittest.TestCase):
+    """The Anthropic surface, served on the same address."""
+
+    def test_response_shape(self) -> None:
+        payload = json.dumps({"model": MODEL, "max_tokens": 16, "messages": [{"role": "user", "content": "ping"}]})
+        status, _, body = call("/v1/messages", payload.encode(), headers=ANTHROPIC_HEADERS)
+        self.assertEqual(status, OK)
+        got = json.loads(body)
+        self.assertEqual(got["type"], "message")
+        self.assertEqual(got["role"], "assistant")
+        self.assertEqual(got["model"], MODEL)
+        self.assertEqual(got["content"][0]["type"], "text")
+        self.assertTrue(got["content"][0]["text"], "empty text block")
+        self.assertEqual(got["stop_reason"], "end_turn")
+        self.assertIn("input_tokens", got["usage"])
+        self.assertIn("output_tokens", got["usage"])
+
+
+class Routing(unittest.TestCase):
+    def test_models_lists_the_served_model(self) -> None:
+        status, _, body = call("/v1/models")
+        self.assertEqual(status, OK)
+        self.assertIn(MODEL, [m["id"] for m in json.loads(body)["data"]])
+
+    def test_unknown_path_does_not_serve(self) -> None:
+        status, _, _ = call("/v1/nonexistent", chat("ping"))
+        self.assertGreaterEqual(status, BAD_REQUEST, "an unrouted path returned a success")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -46,8 +46,8 @@
           find . -name '*.sh' -type f -exec shellcheck {} +
 
           echo "Formatting and linting Python..."
-          ruff format functions/
-          ruff check --fix functions/
+          ruff format functions/ e2e/verify/
+          ruff check --fix functions/ e2e/verify/
 
           echo "Refreshing uv.lock..."
           uv lock

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -111,18 +111,19 @@ in
         cp -r ${self} src
         chmod -R u+w src
         cd src
-        ruff format --check functions/ docs/utils/validate/
-        ruff check functions/ docs/utils/validate/
+        ruff format --check functions/ docs/utils/validate/ e2e/verify/
+        ruff check functions/ docs/utils/validate/ e2e/verify/
         mkdir -p $out
         touch $out/.python-checks-passed
       '';
 
   # Fail if any hand-written source file is missing its Apache 2.0 license
-  # header. Scoped to the files we author: the composition functions and the
-  # docs manifest validator. Generated models under schemas/python carry their
-  # own codegen banner, and config (*.toml) and vendored upstream CRDs (*.yaml)
-  # are excluded. addlicense -check only reads, so it runs against the store
-  # path directly. Run 'nix run .#fix' to add any missing headers.
+  # header. Scoped to the files we author: the composition functions, the docs
+  # manifest validator, and the e2e verify suite. Generated models under
+  # schemas/python carry their own codegen banner, and config (*.toml) and
+  # vendored upstream CRDs (*.yaml) are excluded. addlicense -check only reads,
+  # so it runs against the store path directly. Run 'nix run .#fix' to add any
+  # missing headers.
   license =
     pkgs.runCommand "modelplane-license-check"
       {
@@ -134,7 +135,7 @@ in
           -ignore '**/*.toml' \
           -ignore '**/*.yaml' \
           -ignore '**/*.yml' \
-          functions/ docs/utils/validate/ nix.sh docs/vercel-build.sh
+          functions/ docs/utils/validate/ e2e/verify/ nix.sh docs/vercel-build.sh
         mkdir -p $out
         touch $out/.license-check-passed
       '';


### PR DESCRIPTION
Fixes #368.

The local e2e brings the whole path up and then checks one thing about it: that `/v1/chat/completions` and `/v1/messages` return 200. A regression that answers with the wrong shape, loses the request body between the gateway and the engine, or buffers a stream into a single blob passes that check.

The mock engine is what limited it: one canned response to any POST, body ignored, so there was nothing else to assert. It now echoes the last user turn and the requested model, streams `chat.completion.chunk` frames terminated by `[DONE]` when a request sets `stream`, and returns 400 for an unparseable body or one with no `messages` and 404 for an unknown path. On top of that, the two curl pods become a stdlib `unittest` suite in `e2e/verify`, run from a pod on the control plane because the address is on the kind Docker subnet. It ships as a ConfigMap and runs under the same python image the mock uses, so nothing is built or installed.

The suite fails 5 of its 8 cases against the pre-change mock, which is what says it tests behaviour rather than reachability. I verified the pod wiring on a throwaway kind cluster: green against the new mock with the pod reaching `Succeeded`, and a deliberately wrong `MODELPLANE_MODEL` putting it in `Failed`, which is what makes `run.sh` exit non-zero. I have not run the full two-cluster e2e, so this needs the `test-e2e` label to be proven end to end.

The mock is about twice as long and still inline in `args`, since the ModelDeployment container template is a curated subset with no volume to load a file from. `env.valueFrom` from a ConfigMap is the way out if it grows further.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~ This PR touches no composition functions; the tests it adds are the e2e serving suite in `e2e/verify`.
- [x] Signed off every commit with `git commit -s`.
