### PR TITLE
Bump the e2e workload node image past the DRA idle deadlock

### DIFF
--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -17,7 +17,8 @@ WL=modelplane-e2e-workload
 # Pinned so the workload cluster has the DRA APIs the serving stack's NVIDIA DRA
 # driver needs (resource.k8s.io, GA in k8s 1.34). The control-plane cluster that
 # project run creates needs no DRA, so its image doesn't matter here.
-WL_NODE_IMAGE=kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
+# v1.34.2 or newer: older kubelets deadlock on an idle DRA connection (k/k#133934).
+WL_NODE_IMAGE=kindest/node:v1.34.8@sha256:02722c2dedddcfc00febf5d27fbeb9b7b2c14294c82109ff4a85d89ac9ba3256
 METALLB_URL=https://raw.githubusercontent.com/metallb/metallb/v0.14.8/config/manifests/metallb-native.yaml
 # Pinned by digest (a multi-arch manifest list) so a moving :latest can't flake
 # the verify curl pod.
@@ -50,6 +51,10 @@ if kind get clusters 2>/dev/null | grep -qx "$WL"; then
 	# older one lacks the DRA APIs and would fail the run confusingly later.
 	ver="$(kubectl --context "$WLCTX" get nodes -o jsonpath='{.items[0].status.nodeInfo.kubeletVersion}' 2>/dev/null || true)"
 	case "$ver" in
+	v1.34.0 | v1.34.1)
+		echo "workload cluster $WL is $ver, whose kubelet deadlocks on an idle DRA connection (fixed in v1.34.2); recreate it with: nix run .#e2e -- --clean" >&2
+		exit 1
+		;;
 	v1.34.*) log "Reusing workload cluster $WL ($ver)" ;;
 	*)
 		echo "workload cluster $WL is ${ver:-unreachable}, but v1.34 is required for the DRA APIs; recreate it with: nix run .#e2e -- --clean" >&2


### PR DESCRIPTION
Fixes #419.

The e2e workload cluster runs `kindest/node:v1.34.0`, whose kubelet deadlocks once its connection to a DRA driver has been idle for 30 minutes: the next pod referencing a ResourceClaim sits in `ContainerCreating` with one `Scheduled` event and nothing else, and `NodePrepareResources` never reaches the driver. The goroutine dump and the reproduction are in the issue. Fixed upstream by kubernetes/kubernetes#133934, which `CHANGELOG-1.34.md` lists under `v1.34.2`.

The pin's stated reason is the DRA APIs, GA in 1.34, so any 1.34 image satisfies it. The containerd constraint you may remember is a different pin: #315 changed only `docs/content/getting-started/installation.md`, where the comment says kind v0.31+ ships containerd 2.2.0. `e2e/run.sh` got its pin from the e2e PR instead and never carried that constraint. containerd 2.2.0 was also one release: v1.34.3 has 2.2.0, v1.34.8 has 2.3.1, v1.34.11 has 2.3.4, each checked with `docker run --rm --entrypoint containerd <image> --version`.

So this takes v1.34.8, the oldest published image clearing both the deadlock and 2.2.0. v1.34.11 is there if you would rather track kind's latest. I have not run the full e2e locally, so whether Modelplane is happy on containerd 2.3.x is what the `test-e2e` label would settle. The docs pin is untouched: that cluster runs no DRA driver, so the deadlock doesn't reach it.

The reuse guard rejects a v1.34.0 or v1.34.1 cluster now instead of reusing it, since long-lived dev clusters are the population that hits this and bumping only the image would leave them deadlocking.

Touches `e2e/run.sh` like #420 does, on different lines.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~ This PR changes only `e2e/run.sh`, no composition functions.
- [x] Signed off every commit with `git commit -s`.

