### PR TITLE
Docs: Derive API reference grouping from XRD categories

### DIFF
--- a/apis/aksclusters/definition.yaml
+++ b/apis/aksclusters/definition.yaml
@@ -8,6 +8,7 @@ spec:
     categories:
     - crossplane
     - modelplane
+    - infrastructure
     kind: AKSCluster
     plural: aksclusters
     shortNames:

--- a/apis/eksclusters/definition.yaml
+++ b/apis/eksclusters/definition.yaml
@@ -8,6 +8,7 @@ spec:
     categories:
     - crossplane
     - modelplane
+    - infrastructure
     kind: EKSCluster
     plural: eksclusters
     shortNames:

--- a/apis/gkeclusters/definition.yaml
+++ b/apis/gkeclusters/definition.yaml
@@ -8,6 +8,7 @@ spec:
     categories:
     - crossplane
     - modelplane
+    - infrastructure
     kind: GKECluster
     plural: gkeclusters
     shortNames:

--- a/apis/inferenceclasses/definition.yaml
+++ b/apis/inferenceclasses/definition.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   group: modelplane.ai
   names:
-    categories: [crossplane, modelplane]
+    categories: [crossplane, modelplane, platform]
     kind: InferenceClass
     plural: inferenceclasses
     shortNames: [icl]

--- a/apis/inferenceclusters/definition.yaml
+++ b/apis/inferenceclusters/definition.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   group: modelplane.ai
   names:
-    categories: [crossplane, modelplane]
+    categories: [crossplane, modelplane, platform]
     kind: InferenceCluster
     plural: inferenceclusters
     shortNames: [ic]

--- a/apis/inferencegateways/definition.yaml
+++ b/apis/inferencegateways/definition.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   group: modelplane.ai
   names:
-    categories: [crossplane, modelplane]
+    categories: [crossplane, modelplane, platform]
     kind: InferenceGateway
     plural: inferencegateways
     shortNames: [ig]

--- a/apis/modelcaches/definition.yaml
+++ b/apis/modelcaches/definition.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   group: modelplane.ai
   names:
-    categories: [crossplane, modelplane]
+    categories: [crossplane, modelplane, models]
     kind: ModelCache
     plural: modelcaches
     shortNames: [mc]

--- a/apis/modeldeployments/definition.yaml
+++ b/apis/modeldeployments/definition.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   group: modelplane.ai
   names:
-    categories: [crossplane, modelplane]
+    categories: [crossplane, modelplane, models]
     kind: ModelDeployment
     plural: modeldeployments
     shortNames: [md]

--- a/apis/modelendpoints/definition.yaml
+++ b/apis/modelendpoints/definition.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   group: modelplane.ai
   names:
-    categories: [crossplane, modelplane]
+    categories: [crossplane, modelplane, models]
     kind: ModelEndpoint
     plural: modelendpoints
     shortNames: [me]

--- a/apis/modelreplicas/definition.yaml
+++ b/apis/modelreplicas/definition.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   group: modelplane.ai
   names:
-    categories: [crossplane, modelplane]
+    categories: [crossplane, modelplane, models]
     kind: ModelReplica
     plural: modelreplicas
     shortNames: [mr]

--- a/apis/modelservices/definition.yaml
+++ b/apis/modelservices/definition.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   group: modelplane.ai
   names:
-    categories: [crossplane, modelplane]
+    categories: [crossplane, modelplane, models]
     kind: ModelService
     plural: modelservices
     shortNames: [ms]

--- a/apis/nebiusclusters/definition.yaml
+++ b/apis/nebiusclusters/definition.yaml
@@ -8,6 +8,7 @@ spec:
     categories:
     - crossplane
     - modelplane
+    - infrastructure
     kind: NebiusCluster
     plural: nebiusclusters
     shortNames:

--- a/apis/servingstacks/definition.yaml
+++ b/apis/servingstacks/definition.yaml
@@ -8,6 +8,7 @@ spec:
     categories:
     - crossplane
     - modelplane
+    - infrastructure
     kind: ServingStack
     plural: servingstacks
     shortNames:

--- a/apis/vultrclusters/definition.yaml
+++ b/apis/vultrclusters/definition.yaml
@@ -8,6 +8,7 @@ spec:
     categories:
     - crossplane
     - modelplane
+    - infrastructure
     kind: VultrCluster
     plural: vultrclusters
     shortNames:

--- a/docs/content/reference/_content.gotmpl
+++ b/docs/content/reference/_content.gotmpl
@@ -1,14 +1,17 @@
 {{/*
   Generates one reference page per CRD from the definition.yaml files mounted at
-  site.Data.apis.crds.<plural>.definition. Grouping and order come from
-  site.Data.apigroups (see docs/data/apigroups.yaml); a kind not listed in any
-  group still gets a page, sorted last under "Other".
+  site.Data.apis.crds.<plural>.definition. Each CRD's group is read from its own
+  spec.names.categories: the category matching a group id in
+  site.Data.apigroups (docs/data/apigroups.yaml) picks the section, which only
+  supplies titles, descriptions, and section order. A CRD whose categories
+  match no group still gets a page, sorted last under "Other".
 
   Each page carries product=crd plus the plural/kind/group it needs; the
   crd-single partial (via single-list.html) renders the schema. Weight encodes
-  group order (×100) then position within the group, so the section lists pages
-  Platform → Models → Infrastructure in the order authored.
+  group order (×100) plus arrival order — the crds map ranges in key order, so
+  pages within a group list alphabetically.
 */}}
+{{ $seen := 0 }}
 {{ range $plural, $dir := site.Data.apis.crds }}
   {{ $crd := $dir.definition }}
   {{ if $crd }}
@@ -24,18 +27,20 @@
       {{ end }}
     {{ end }}
 
-    {{/* Find this kind's group and order. Weights start at 1: Hugo treats a 0
-         weight as "unset" and sorts it last, which would wrap the first page. */}}
+    {{/* Match a group id against the XRD's own categories. Weights start at 1:
+         Hugo treats a 0 weight as "unset" and sorts it last, which would wrap
+         the first page. The shared $seen counter is safe because it stays
+         below the ×100 gap between group bases. */}}
+    {{ $seen = add $seen 1 }}
     {{ $groupId := "other" }}
     {{ $groupTitle := "Other" }}
-    {{ $weight := 9999 }}
+    {{ $weight := add 9900 $seen }}
+    {{ $categories := $crd.spec.names.categories | default slice }}
     {{ range $gi, $group := site.Data.apigroups.groups }}
-      {{ range $ki, $k := $group.kinds }}
-        {{ if eq $k $kind }}
-          {{ $groupId = $group.id }}
-          {{ $groupTitle = $group.title }}
-          {{ $weight = add (mul (add $gi 1) 100) (add $ki 1) }}
-        {{ end }}
+      {{ if in $categories $group.id }}
+        {{ $groupId = $group.id }}
+        {{ $groupTitle = $group.title }}
+        {{ $weight = add (mul (add $gi 1) 100) $seen }}
       {{ end }}
     {{ end }}
 

--- a/docs/content/reference/_index.md
+++ b/docs/content/reference/_index.md
@@ -1,7 +1,7 @@
 ---
 title: API Reference
 weight: 50
-description: Every Modelplane API type, grouped by Platform, Models, and Composed.
+description: Every Modelplane API type, grouped by Platform, Models, and Infrastructure.
 product: reference
 ---
 

--- a/docs/data/apigroups.yaml
+++ b/docs/data/apigroups.yaml
@@ -1,42 +1,30 @@
-# Groups the API reference into sections, in display order. Each kind listed
-# here gets its own generated page under /reference/<plural>/ (see
-# content/reference/_content.gotmpl), and the order here drives the sidebar,
-# the landing-page cards, and prev/next pagination. A kind absent from every
-# group still gets a page, but falls under "Other" at the end.
+# Styles and orders the API reference sections. Every CRD under apis/ gets its
+# own generated page under /reference/<plural>/, and its section comes from the
+# XRD itself: content/reference/_content.gotmpl matches a group's id against
+# the XRD's spec.names.categories (each XRD declares platform, models, or
+# infrastructure alongside crossplane and modelplane). Nothing to update here
+# when adding an API — types list alphabetically within their group. A CRD
+# whose categories match no group still gets a page, under "Other" at the end.
 groups:
   - id: platform
     title: Platform
     description: >-
       Types platform engineers author to provision GPU clusters and define the
       hardware classes models run on.
-    kinds:
-      - InferenceGateway
-      - InferenceClass
-      - InferenceCluster
 
   - id: models
     title: Models
     description: >-
       Types ML teams author to deploy models, register endpoints, and expose
-      them behind a unified, OpenAI-compatible URL.
-    kinds:
-      - ModelDeployment
-      - ModelService
-      - ModelEndpoint
-      - ModelCache
+      them behind one unified URL speaking the OpenAI and Anthropic Messages
+      APIs.
 
-  - id: composed
-    title: Composed
+  - id: infrastructure
+    title: Infrastructure
     description: >-
-      Resources Modelplane composes and manages for you. You don't author these
-      directly; they're created when you deploy models and register clusters.
-    kinds:
-      - ModelReplica
-      - AKSCluster
-      - EKSCluster
-      - GKECluster
-      - NebiusCluster
-      - ServingStack
+      Infrastructure Modelplane composes and manages for you, the clusters it
+      provisions and the serving stack it installs on them. You don't author
+      these directly; they're created when you register clusters.
 
 # Link each kind back to its concept doc in the Documentation tab (by content
 # path). Kinds without an entry (machine-generated / infra) just omit the link.

--- a/docs/themes/geekboot/assets/scss/_components.scss
+++ b/docs/themes/geekboot/assets/scss/_components.scss
@@ -461,6 +461,23 @@ a.mp-chip:hover {
   .mp-row-ctx { display: none; }
 }
 
+// ── API reference rows (reference landing) ────────────────────
+// Reuses the recipe-row shell. The id column stretches so a one-line
+// description fits under the kind name, and the chips shrink to content.
+.mp-crd-row .mp-row-id { flex: 1 1 24rem; }
+.mp-crd-row .mp-row-chips { flex: 0 0 auto; }
+.mp-row-desc {
+  font-size: 0.78rem;
+  color: var(--mp-card-muted);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+}
+@media (max-width: 800px) {
+  .mp-crd-row .mp-row-id { flex-basis: 100%; }
+}
+
 // ── Browse-all recipe table (/recipes/all/) ───────────────────
 .mp-table-wrap {
   background: var(--mp-card-bg);

--- a/docs/themes/geekboot/layouts/partials/crd-index.html
+++ b/docs/themes/geekboot/layouts/partials/crd-index.html
@@ -1,34 +1,45 @@
 {{/*
-  Reference landing (product: reference). Renders the page body, then a card per
-  CRD grouped by hugo.Data.apigroups. Cards link to the generated per-type pages
-  and pull their summary from the page Description, so new CRDs appear here once
-  they're added to a group.
+  Reference landing (product: reference). Renders the page body, then one row
+  per CRD grouped by the apiGroup param each generated page carries (assigned
+  in content/reference/_content.gotmpl from hugo.Data.apigroups). Rows reuse
+  the recipe-row look: kind and a one-line description on the left, then
+  scope and apiVersion chips read from the CRD's definition. Kinds
+  that fall into no group render under "Other" at the end rather than
+  disappearing.
 */}}
 {{ .Content }}
 
-{{ range hugo.Data.apigroups.groups }}
-  <section class="api-index-group">
-    <h2 id="{{ .id }}">{{ .title }}</h2>
-    {{ with .description }}<p>{{ . }}</p>{{ end }}
-    <div class="mp-cards mp-cards--2">
-      {{ $group := . }}
-      {{ range $group.kinds }}
-        {{ $k := . }}
-        {{ range $plural, $dir := hugo.Data.apis.crds }}
-          {{ $crd := $dir.definition }}
-          {{ if and $crd (eq $crd.spec.names.kind $k) }}
-            {{ $page := site.GetPage (printf "/reference/%s" $plural) }}
-            {{ with $page }}
-              <a class="mp-card mp-card--link" href="{{ .Permalink }}">
-                <span class="mp-card-head"><span class="mp-card-title">{{ $k }}</span></span>
-                {{ with .Description }}<span class="mp-card-note">{{ . }}</span>{{ end }}
-                <span class="mp-card-link">&rarr;</span>
-              </a>
-            {{ end }}
-          {{ end }}
-        {{ end }}
-      {{ end }}
-    </div>
-  </section>
+{{ $refPages := .RegularPages.ByWeight }}
+{{ $ungrouped := where $refPages "Params.apiGroup" "other" }}
+{{ $groups := hugo.Data.apigroups.groups }}
+{{ if $ungrouped }}
+  {{ $groups = $groups | append (dict "id" "other" "title" "Other") }}
 {{ end }}
 
+{{ range $groups }}
+  {{ $groupPages := where $refPages "Params.apiGroup" .id }}
+  {{ if $groupPages }}
+    <section class="api-index-group">
+      <h2 id="{{ .id }}">{{ .title }}</h2>
+      {{ with .description }}<p>{{ . }}</p>{{ end }}
+      <div class="mp-recipe-rows">
+        {{ range $groupPages }}
+          {{ $def := (index hugo.Data.apis.crds .Params.plural).definition }}
+          {{ $ver := "" }}
+          {{ range $def.spec.versions }}{{ if or .served (not $ver) }}{{ $ver = .name }}{{ end }}{{ end }}
+          <a class="mp-recipe-row mp-crd-row" href="{{ .Permalink }}">
+            <span class="mp-row-id">
+              <span class="mp-row-name">{{ .Title }}</span>
+              {{ with .Description }}<span class="mp-row-desc">{{ . }}</span>{{ end }}
+            </span>
+            <span class="mp-row-chips">
+              <span class="mp-vchip">{{ $def.spec.scope }}</span>
+              <span class="mp-vchip">{{ $def.spec.group }}/{{ $ver }}</span>
+            </span>
+            <span class="mp-row-meta"><span class="mp-row-arrow">&rarr;</span></span>
+          </a>
+        {{ end }}
+      </div>
+    </section>
+  {{ end }}
+{{ end }}

--- a/docs/themes/geekboot/layouts/partials/docs-sidebar.html
+++ b/docs/themes/geekboot/layouts/partials/docs-sidebar.html
@@ -16,29 +16,33 @@
 <nav class="bd-links-nav w-100" aria-label="Docs navigation">
 
   {{ if $isRef }}
-    {{/* ── Reference tab: landing, then one page per type grouped by apigroups ── */}}
+    {{/* ── Reference tab: landing, then one page per type grouped by the
+         apiGroup param each generated page carries (assigned in
+         content/reference/_content.gotmpl from hugo.Data.apigroups). Ungrouped
+         kinds render under "Other" rather than disappearing. ── */}}
     {{ with $ref }}
       <div class="nav-group">
         <a class="nav-section-link nav-top-link{{ if eq . $current }} active{{ end }}" href="{{ .Permalink }}">{{ .Title }}</a>
       </div>
     {{ end }}
-    {{ range hugo.Data.apigroups.groups }}
-      <div class="nav-group">
-        <div class="nav-group-label">{{ .title }}</div>
-        <div class="nav-children">
-          {{ range .kinds }}
-            {{ $k := . }}
-            {{ range $plural, $dir := hugo.Data.apis.crds }}
-              {{ $crd := $dir.definition }}
-              {{ if and $crd (eq $crd.spec.names.kind $k) }}
-                {{ with site.GetPage (printf "/reference/%s" $plural) }}
-                  <a class="bd-links d-flex{{ if eq . $current }} active{{ end }}" href="{{ .Permalink }}">{{ $k }}</a>
-                {{ end }}
-              {{ end }}
+    {{ $refPages := $ref.RegularPages.ByWeight }}
+    {{ $ungrouped := where $refPages "Params.apiGroup" "other" }}
+    {{ $groups := hugo.Data.apigroups.groups }}
+    {{ if $ungrouped }}
+      {{ $groups = $groups | append (dict "id" "other" "title" "Other") }}
+    {{ end }}
+    {{ range $groups }}
+      {{ $groupPages := where $refPages "Params.apiGroup" .id }}
+      {{ if $groupPages }}
+        <div class="nav-group">
+          <div class="nav-group-label">{{ .title }}</div>
+          <div class="nav-children">
+            {{ range $groupPages }}
+              <a class="bd-links d-flex{{ if eq . $current }} active{{ end }}" href="{{ .Permalink }}">{{ .Title }}</a>
             {{ end }}
-          {{ end }}
+          </div>
         </div>
-      </div>
+      {{ end }}
     {{ end }}
   {{ else if $isRecipes }}
     {{/* ── Recipes tab: the catalog landing, then recipes grouped by vendor.

--- a/schemas/.lock.json
+++ b/schemas/.lock.json
@@ -1,6 +1,6 @@
 {
   "packages": {
-    "fs://apis": "b64f43119c18c7d6cb8a1bce9e67e57f37a915a48cafebdf253260ad01a23473",
+    "fs://apis": "b293c47a8ef8bc8d56f3e1bfa9aaebd3de80e867e5ac1d6b0d660ae6cdf65c33",
     "git://https://github.com/crossplane/crossplane/cluster/crds": "90d8b72ad8b829f0bcd7d7d5a98eaa0d579f244a",
     "xpkg://xpkg.upbound.io/upbound/provider-aws-ec2:v2.6.0": "sha256:acc26c8d2710e0306185b6c626a2f8c8fe0fdf89874e85efe7944a3668322865",
     "xpkg://xpkg.upbound.io/upbound/provider-aws-efs:v2.6.0": "sha256:00f1bbbb3c0f1948b6dd45c841a083d63e41850f5a559a15580915311f404911",


### PR DESCRIPTION
<!--
Thanks for contributing to Modelplane! Read CONTRIBUTING.md before opening a PR
and follow it, especially the commit, pull request, and writing style
conventions: https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md
PRs that don't follow it will be closed.
-->

### Description of your changes

`VultrCluster` never showed up on the API reference page. The reference sections were driven by a hand-written kinds list in docs/data/apigroups.yaml, and a kind missing from that list, as happened when vultrclusters was added, fell into an "Other" bucket that neither the sidebar nor the landing page rendered, so the page was generated but unreachable.

Each XRD now declares its section itself: a `platform`, `models`, or `infrastructure` entry in `spec.names.categories`, alongside the crossplane and modelplane categories it already carried. The docs match a section id against those categories to place the page, and apigroups.yaml shrinks to section titles, descriptions, and display order, there is nothing to update there when adding an API. A kind whose categories match no section renders in a visible "Other" section at the end instead of disappearing. Because categories are real Kubernetes API surface, `kubectl get platform`, `kubectl get models`, and `kubectl get infrastructure` now also work as category queries on a live cluster.

Two grouping changes ride along: the "Composed" section is renamed Infrastructure to match what it holds (the clusters Modelplane provisions and the serving stack it installs on them), and ModelReplica moves to Models, next to the ModelDeployment that composes it. Types list alphabetically within their section, the curated ordering was only achievable with the hand-written list, and it wasn't worth the failure mode.

The reference landing also swaps its description cards for the recipe-row listing used on the vendor pages: one row per type with a one-line clamped description and chips for scope and apiVersion, both read from the CRD definition the site already mounts.

<img width="1288" height="681" alt="image" src="https://github.com/user-attachments/assets/5d81b841-4c86-4548-b765-a360d361f2a8" />



<!--
Lead with the problem, then the change and why it's right. Direct reviewers to
the parts that need judgment. Don't pad or invent rationale. See the Pull
requests and Writing style sections of CONTRIBUTING.md for what a good
description looks like.

If this PR fixes an open issue, reference it below, e.g. "Fixes #95".
-->

Fixes #

I have: <!-- You MUST either [x] check or [ ] ~strike through~ every item. -->

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
