### PR TITLE
Skip the default ManagedResourceActivationPolicy in the dev control plane

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,116 +1,6 @@
 {
   "nodes": {
-    "crossplane-cli": {
-      "inputs": {
-        "gomod2nix": "gomod2nix",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable"
-      },
-      "locked": {
-        "lastModified": 1787290757,
-        "narHash": "sha256-ksym0FzurF2fkpKtIiTJ184Wzj4Xz48uCUPSBUeSgbg=",
-        "owner": "crossplane",
-        "repo": "cli",
-        "rev": "1acb525095a4e43c9a765954efa66a47667a432b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "crossplane",
-        "ref": "v2.5.0",
-        "repo": "cli",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "gomod2nix": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "crossplane-cli",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1770585520,
-        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
-        "owner": "nix-community",
-        "repo": "gomod2nix",
-        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "gomod2nix",
-        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1787101114,
-        "narHash": "sha256-gwrPcFf/rDjHPaVflbDZ040ZDmBTRj/7+s8ZmE2SaIM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b18a4b905f8d028dc4476412e6d6891728695379",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-26.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1787172299,
-        "narHash": "sha256-PShzS87awOlE5XWkxUGBd/58/F+AtE2ZMgFffKj4r8s=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "07e1d92cdc0ed416cfa11ff3ca40d17e61cfba7a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable_2": {
-      "locked": {
-        "lastModified": 1786247143,
-        "narHash": "sha256-8S3Kcxs7D4UtxJxSJZz0m14CGhuW0MxfrIwJxeGWGnQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "279b4a8275f032c566576b3f181fa0f27197f588",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1786313170,
         "narHash": "sha256-9BG7OgUWdu0ONDO5X2q6+K4bsuBITkX/3W4nNJu1Ito=",
@@ -122,6 +12,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1786247143,
+        "narHash": "sha256-8S3Kcxs7D4UtxJxSJZz0m14CGhuW0MxfrIwJxeGWGnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "279b4a8275f032c566576b3f181fa0f27197f588",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -174,27 +80,11 @@
     },
     "root": {
       "inputs": {
-        "crossplane-cli": "crossplane-cli",
-        "nixpkgs": "nixpkgs_2",
-        "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "pyproject-build-systems": "pyproject-build-systems",
         "pyproject-nix": "pyproject-nix",
         "uv2nix": "uv2nix"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     },
     "uv2nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,8 +12,6 @@
     # tracking the latest uv_build releases.
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    crossplane-cli.url = "github:crossplane/cli/v2.5.0";
-
     # uv2nix reads a uv workspace's uv.lock and generates Nix derivations
     # for each Python package, using pyproject.nix's build infrastructure.
     pyproject-nix = {
@@ -42,7 +40,6 @@
       self,
       nixpkgs,
       nixpkgs-unstable,
-      crossplane-cli,
       pyproject-nix,
       uv2nix,
       pyproject-build-systems,
@@ -159,7 +156,7 @@
       apps = forAllSystems (
         { pkgs, system, ... }:
         let
-          deps = import ./nix/deps.nix { inherit pkgs crossplane-cli; };
+          deps = import ./nix/deps.nix { inherit pkgs; };
           apps = import ./nix/apps.nix { inherit pkgs; };
           crossplane = deps.crossplane { inherit system; };
           functionsPkg = self.packages.${system}.functions or null;
@@ -189,7 +186,7 @@
       devShells = forAllSystems (
         { pkgs, system, ... }:
         let
-          deps = import ./nix/deps.nix { inherit pkgs crossplane-cli; };
+          deps = import ./nix/deps.nix { inherit pkgs; };
           crossplane = deps.crossplane { inherit system; };
         in
         {

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -158,10 +158,15 @@
               esac
             done
 
+            # Skip the default ManagedResourceActivationPolicy: it activates
+            # every MRD each installed provider ships, and this project pulls
+            # in the full AWS/GCP/Azure provider families. The compositions
+            # activate exactly the MRs they compose.
+            #
             # On failure, dump the package revision state: installs time out
             # with only "context deadline exceeded", and under nix.sh the
             # cluster is gone by the time anyone can look at it.
-            if ! crossplane project run "''${timeout_args[@]}" "''${version_args[@]}" "$@"; then
+            if ! crossplane project run --no-default-mrap "''${timeout_args[@]}" "''${version_args[@]}" "$@"; then
               echo ""
               echo "crossplane project run failed; package revision state:"
               for cluster in $(kind get clusters 2>/dev/null); do

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -1,7 +1,58 @@
 # External dependencies not available in nixpkgs.
-{ crossplane-cli, ... }:
+#
+# The Crossplane CLI comes from the master channel of the release CDN, not
+# the crossplane/cli flake: we need `crossplane project run --no-default-mrap`,
+# which no tagged release ships yet. To bump: pick a version from
+# https://cli.crossplane.io/master/current/version and refresh the hashes:
+#
+#   for p in linux_amd64 linux_arm64 darwin_arm64; do
+#     curl -sL "https://cli.crossplane.io/master/<version>/bin/$p/crossplane" | sha256sum
+#   done
+{ pkgs, ... }:
+let
+  version = "v2.6.0-rc.0.73.ga588ce6";
+  channel = "master";
+
+  hashes = {
+    linux_amd64 = "8184e02bbb419652f475fe8f3dd9681d2c62549563209c27c41e169437f2fb8f";
+    linux_arm64 = "6c4d38e9a903beb72d2f45feffa0f9f1b5e95be986165ecfa1bd8426b98137ed";
+    darwin_arm64 = "180ee3796aca6e8ae98ddf339c5b23e8220434064b867970dd67b6a2c05b2970";
+  };
+
+  platforms = {
+    x86_64-linux = "linux_amd64";
+    aarch64-linux = "linux_arm64";
+    aarch64-darwin = "darwin_arm64";
+  };
+in
 {
-  # The Crossplane CLI. The upstream flake's default package is the host-native
-  # binary for the current system, so we can use it as-is.
-  crossplane = { system }: crossplane-cli.packages.${system}.default;
+  crossplane =
+    { system }:
+    let
+      platform = platforms.${system};
+    in
+    pkgs.stdenvNoCC.mkDerivation {
+      pname = "crossplane-cli";
+      inherit version;
+
+      src = pkgs.fetchurl {
+        url = "https://cli.crossplane.io/${channel}/${version}/bin/${platform}/crossplane";
+        sha256 = hashes.${platform};
+      };
+
+      dontUnpack = true;
+
+      installPhase = ''
+        runHook preInstall
+        install -Dm755 $src $out/bin/crossplane
+        runHook postInstall
+      '';
+
+      meta = {
+        description = "CLI for interacting with Crossplane";
+        homepage = "https://docs.crossplane.io/latest/cli/";
+        license = pkgs.lib.licenses.asl20;
+        mainProgram = "crossplane";
+      };
+    };
 }

--- a/schemas/.lock.json
+++ b/schemas/.lock.json
@@ -1,6 +1,6 @@
 {
   "packages": {
-    "fs://apis": "f0cff8a93ff8ea443b4004428e557a5e9a04107d149aae4bb64779402ddcffda",
+    "fs://apis": "57f4af86cf3ab9f80745c8e359da03e25c806734156e7029883f3b306419038f",
     "git://https://github.com/crossplane/crossplane/cluster/crds": "90d8b72ad8b829f0bcd7d7d5a98eaa0d579f244a",
     "xpkg://xpkg.upbound.io/upbound/provider-aws-ec2:v2.6.0": "sha256:acc26c8d2710e0306185b6c626a2f8c8fe0fdf89874e85efe7944a3668322865",
     "xpkg://xpkg.upbound.io/upbound/provider-aws-efs:v2.6.0": "sha256:00f1bbbb3c0f1948b6dd45c841a083d63e41850f5a559a15580915311f404911",


### PR DESCRIPTION
### Description of your changes

#429 moved cloud managed resource activation into `compose-inference-cluster`, so a control plane runs a cloud's providers only once it has an InferenceCluster on that cloud. The local dev control plane never got that benefit: `crossplane project run` installs a **default** `ManagedResourceActivationPolicy` that activates every managed resource kind of every installed provider, so `nix run .#run` still spins up the full AWS/GCP/Azure/Nebius/Vultr provider fleet on every dev cluster.

`nix run .#run` now passes `--no-default-mrap`, leaving activation to the base policy the Configuration ships (provider-helm and provider-kubernetes) plus the per-cloud policies `compose-inference-cluster` composes on demand.

No tagged CLI release ships https://github.com/crossplane/cli/pull/302 `--no-default-mrap` yet, so the Crossplane CLI moves from the `crossplane/cli` v2.5.0 flake input to a master-channel binary (`v2.6.0-rc.0.73.ga588ce6`) fetched from cli.crossplane.io, mirroring how `nix/upbound.nix` fetches the up CLI. `nix/deps.nix` documents the bump procedure; the now-unused flake input is removed and the lock pruned.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [x] Added or updated tests covering any composition function changes.
- [x] Signed off every commit with `git commit -s`.
