### PR TITLE
Publish the v0.4 docs

### DIFF
--- a/docs/data/versions.yaml
+++ b/docs/data/versions.yaml
@@ -14,3 +14,5 @@ versions:
     url: "https://v0-2.docs.modelplane.ai"
   - version: "0.3"
     url: "https://v0-3.docs.modelplane.ai"
+  - version: "0.4"
+    url: "https://v0-4.docs.modelplane.ai"

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -124,10 +124,10 @@ ignoreFiles = ["themes/geekboot/content/.*", "README.md"]
   docs = true
   description = "Modelplane documentation."
   # "main" on the dev branch; "X.Y" (e.g. "0.1") on release branches.
-  version = "main"
+  version = "0.4"
   # Latest stable release. Drives the version dropdown and the "not the latest
   # release" banners; the apex (docs.modelplane.ai) is this release's own build.
-  latest = "0.3"
+  latest = "0.4"
   [params.anchors]
     min = 2
     max = 5


### PR DESCRIPTION
### Description of your changes

Cuts the docs over to v0.4 on the release branch, per RELEASING.md § Versioning the docs. On the `release-0.4` branch the docs still build as `main` and the apex banner treats 0.3 as latest.

- Set `version = "0.4"` in `docs/hugo.toml` so this branch builds the 0.4 docs.
- Set `latest = "0.4"` so the "not the latest release" banner stays off this release's own build.
- Add v0.4 to `docs/data/versions.yaml` so the version dropdown offers it.
- Bump the getting-started `Configuration` package from `modelplane:v0.3.1` to `v0.4.0`, so readers on the v0.4 docs install the matching release.

The matching `main` change (bump `latest`, add v0.4 to the dropdown) is #442. The two `versions.yaml` files stay identical across branches. The Vercel steps (assign the `release-0.4` project domains, move the apex) are manual and not part of this PR.

I appended v0.4 at the end of `versions.yaml` to match how 0.2 and 0.3 were added, rather than the file's stale "newest first" comment.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.