### PR TITLE
Point the docs dropdown and apex at v0.4

### DIFF
--- a/docs/data/versions.yaml
+++ b/docs/data/versions.yaml
@@ -14,3 +14,5 @@ versions:
     url: "https://v0-2.docs.modelplane.ai"
   - version: "0.3"
     url: "https://v0-3.docs.modelplane.ai"
+  - version: "0.4"
+    url: "https://v0-4.docs.modelplane.ai"

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -127,7 +127,7 @@ ignoreFiles = ["themes/geekboot/content/.*", "README.md"]
   version = "main"
   # Latest stable release. Drives the version dropdown and the "not the latest
   # release" banners; the apex (docs.modelplane.ai) is this release's own build.
-  latest = "0.3"
+  latest = "0.4"
   [params.anchors]
     min = 2
     max = 5


### PR DESCRIPTION
### Description of your changes

The `main` half of publishing the v0.4 docs, per RELEASING.md § Versioning the docs. Until `latest` moves, the version dropdown and "not the latest release" banners on every build still point at 0.3.

- Bump `latest = "0.4"` in `docs/hugo.toml` so the dropdown and banners point at v0.4.
- Add v0.4 to `docs/data/versions.yaml` so every build offers it.

`version` stays `"main"` here; the release-branch changes are in #441. The two `versions.yaml` files stay identical across branches.

I appended v0.4 at the end of `versions.yaml` to match how 0.2 and 0.3 were added, rather than the file's stale "newest first" comment.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.