### PR TITLE
Pin the getting-started package to v0.4.0

### DIFF
--- a/docs/manifests/getting-started/configuration.yaml
+++ b/docs/manifests/getting-started/configuration.yaml
@@ -6,4 +6,4 @@ kind: Configuration
 metadata:
   name: modelplane
 spec:
-  package: xpkg.upbound.io/modelplane/modelplane:v0.3.1
+  package: xpkg.upbound.io/modelplane/modelplane:v0.4.0


### PR DESCRIPTION
### Description of your changes

The getting-started guide on the v0.4 docs still installs the Modelplane `Configuration` at `modelplane:v0.3.1`. Bump it to `v0.4.0` so readers on the v0.4 docs install the matching release.

This was meant to ride along with #441 but landed after that PR merged, so it needs its own PR.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [ ] ~Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.~
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.