### PR TITLE
Document the per-cluster serving stack choice

### DIFF
--- a/docs/content/architecture/_index.md
+++ b/docs/content/architecture/_index.md
@@ -129,9 +129,9 @@ provider resources and plain Kubernetes objects. A `ModelDeployment` is the
 clearest example. Its function schedules the replicas, then composes a
 `ModelReplica` for each, and a `ModelEndpoint` for each replica that's ready to
 serve. Each `ModelReplica` function composes the serving workload onto its target
-workload cluster through provider-kubernetes: a Deployment for single-node, or a
-LeaderWorkerSet for multi-node (a Grove PodCliqueSet on clusters that opt into
-the Dynamo stack via `InferenceCluster.spec.stack: Dynamo`).
+workload cluster through provider-kubernetes: a Deployment for single-node, or,
+for multi-node, a LeaderWorkerSet or a Grove PodCliqueSet depending on the
+cluster's [serving stack]({{< ref "/platform/inference-cluster.md#serving-stack" >}}).
 
 ```mermaid
 flowchart TD

--- a/docs/content/models/model-cache.md
+++ b/docs/content/models/model-cache.md
@@ -105,8 +105,9 @@ end.
 ## Accelerating with ModelExpress
 
 A cache's weights always live on its own PVC, portable across every cluster. On a
-Dynamo cluster (`InferenceCluster.spec.stack: Dynamo`) the serving stack also
-runs a [ModelExpress](https://github.com/ai-dynamo/modelexpress) server, and
+[Dynamo cluster]({{< ref "/platform/inference-cluster.md#serving-stack" >}}) the
+serving stack also runs a
+[ModelExpress](https://github.com/ai-dynamo/modelexpress) server, and
 Modelplane injects ModelExpress env into every engine pod that references a
 cache. An engine opts in with `--load-format modelexpress`: the first replica
 loads from its PVC seed and publishes itself as a source, and later replicas pull

--- a/docs/content/models/model-deployment.md
+++ b/docs/content/models/model-deployment.md
@@ -68,6 +68,16 @@ engines:
       nodes: 1              # one worker pod per node
 ```
 
+Modelplane injects the gang's coordination env, so a worker's command can find
+the leader and its own rank. `$(MODELPLANE_LEADER_ADDRESS)` is the leader's
+address on either [serving stack]({{< ref "/platform/inference-cluster.md#serving-stack" >}}).
+`$(MODELPLANE_RANK)` is the pod's node rank (0 on the leader, `1..N` on the
+workers) on Standard, but isn't injected on Dynamo yet
+([#418](https://github.com/modelplaneai/modelplane/issues/418)). A gang on Dynamo
+derives its rank from Grove's `GROVE_PCLQ_POD_INDEX` instead,
+`$$((GROVE_PCLQ_POD_INDEX + 1))` on the workers (`$$` escapes Kubernetes' own
+expansion, leaving `$((...))` for the shell).
+
 A member's `env` can read pod fields through `valueFrom.fieldRef`, like setting
 vLLM's `VLLM_HOST_IP` from `status.podIP`, which multi-NIC RDMA nodes need so the
 engine binds the right interface instead of guessing it.

--- a/docs/content/overview/faq.md
+++ b/docs/content/overview/faq.md
@@ -27,10 +27,12 @@ Modelplane.
 
 {{< qa "How is Modelplane different from KServe or NVIDIA Dynamo?" >}}
 Scope. KServe and Dynamo are cluster orchestrators: they schedule, scale, route,
-and cache within a single Kubernetes cluster. Modelplane runs its operations across a
-fleet of clusters, clouds, and regions. Modelplane uses llm-d for multi-node serving, 
-and KV-cache management, as do KServe and Dynamo. Modelplane is planning deeper integrations
-with NVIDIA Dynamo in future releases.
+and cache within a single Kubernetes cluster. Modelplane runs those operations
+across a fleet of clusters, clouds, and regions. It uses llm-d for
+inference-aware routing, and installs a per-cluster
+[serving stack]({{< ref "/platform/inference-cluster.md#serving-stack" >}}) that's
+Standard by default or Dynamo, which brings in NVIDIA's Grove, KAI Scheduler, and
+ModelExpress.
 {{< /qa >}}
 
 {{< qa "How is Modelplane different from a managed provider like Baseten or Fireworks?" >}}
@@ -56,7 +58,8 @@ attributes such as GPU memory and architecture with CEL selectors.
 The software stack rides on the engine-agnostic API. NVIDIA NIM microservices and
 the TensorRT-LLM engine run as engine containers like any other, Modelplane stages
 weights and NIM-style artifacts from NVIDIA NGC alongside Hugging Face and other
-registries, and the inference stack it installs includes NVIDIA Dynamo and llm-d,
+registries, and a cluster can run NVIDIA's
+[Dynamo serving stack]({{< ref "/platform/inference-cluster.md#serving-stack" >}}),
 with deeper Dynamo integration on the roadmap.
 {{< /qa >}}
 
@@ -125,14 +128,12 @@ replicas, and load-balances across all of them.
 
 {{< qa "How do large or multi-node models work?" >}}
 An engine can be a gang: a leader and one or more workers serving across nodes.
-By default Modelplane composes the gang into a LeaderWorkerSet; a cluster can opt
-into Grove + KAI Scheduler for gang scheduling via
-`InferenceCluster.spec.stack: Dynamo`. You write the coordination (like
-Ray or vLLM's data-parallel coordinator) in the engine flags, referencing the
-leader's address through `MODELPLANE_LEADER_ADDRESS`, which resolves on either
-stack. The pod's rank is `MODELPLANE_RANK` under Standard; under Dynamo the
-command derives it from Grove's own `GROVE_PCLQ_POD_INDEX`. Multi-node
-deployments stage weights through a `ModelCache`.
+How Modelplane composes and schedules the gang depends on the cluster's
+[serving stack]({{< ref "/platform/inference-cluster.md#serving-stack" >}}), a
+LeaderWorkerSet on Standard or a gang-scheduled Grove PodCliqueSet on Dynamo. You
+write the coordination (like Ray or vLLM's data-parallel coordinator) in the
+engine flags; `MODELPLANE_LEADER_ADDRESS` resolves on either stack.
+Multi-node deployments stage weights through a `ModelCache`.
 {{< /qa >}}
 
 {{< qa "What about disaggregated prefill/decode?" >}}

--- a/docs/content/overview/glossary.md
+++ b/docs/content/overview/glossary.md
@@ -26,6 +26,13 @@ you can bring your own through an `InferenceCluster` with `source: Existing`.
 
 All inference clusters managed by a single Modelplane control cluster.
 
+## Serving stack
+
+The per-cluster software layer that turns a stock engine into a routable serving
+instance: `Standard` (the default, Modelplane-composed Deployments and
+LeaderWorkerSets) or `Dynamo` (NVIDIA's Grove, KAI Scheduler, and ModelExpress).
+Set by `InferenceCluster.spec.stack`.
+
 ## Platform
 
 The inference infrastructure the platform team

--- a/docs/content/overview/how-it-works.md
+++ b/docs/content/overview/how-it-works.md
@@ -141,11 +141,10 @@ re-converges.
 A single-node deployment composes to a Kubernetes Deployment fronted by a
 service. When a model is too large for one node, an engine becomes a gang: a
 `Leader` member and one or more `Worker` members serving the model together
-across nodes. By default Modelplane composes the gang into a LeaderWorkerSet;
-a cluster can opt into Grove + KAI Scheduler for gang scheduling by setting
-`InferenceCluster.spec.stack: Dynamo`. Gang deployments
-should stage their weights through a `ModelCache`, so the pods share one copy
-instead of each pulling the same model.
+across nodes. How Modelplane composes and schedules the gang depends on the
+cluster's [serving stack]({{< ref "/platform/inference-cluster.md#serving-stack" >}}),
+Standard or Dynamo. Gang deployments should stage their weights through a
+`ModelCache`, so the pods share one copy instead of each pulling the same model.
 
 Disaggregated serving splits prefill and decode into separate engines
 (`serving.mode: PrefillDecode`) that run on the same cluster and hand off the KV

--- a/docs/content/platform/inference-cluster.md
+++ b/docs/content/platform/inference-cluster.md
@@ -20,8 +20,8 @@ Each cluster has:
 - **Labels** for organizational metadata: tier, region, provider. These are the
   matching surface for `ModelDeployment.clusterSelector`.
 
-Modelplane installs the serving stack it needs on every cluster it manages,
-including existing clusters, which it assumes are solely for its use.
+Modelplane installs a serving stack on every cluster it manages, including
+existing clusters, which it assumes are solely for its use.
 
 ## Ownership and requirements
 
@@ -51,6 +51,45 @@ The `cluster.source` discriminator picks one of two models:
   Modelplane's requirements, including labeling each pool's nodes
   `modelplane.ai/pool=<pool-name>` (see
   [how scheduling pins placement]({{< ref "/architecture/scheduling.md#pinning-placement-to-a-pool" >}})).
+
+## Serving stack
+
+`spec.stack` selects the serving layer the cluster runs: `Standard` (the default)
+or `Dynamo`. The field is immutable, so recreate the cluster to change it.
+
+Both stacks compose a single-node engine the same way, as a Deployment, and front
+it the same way, with Gateway API and an endpoint picker. They differ in how they
+run a multi-node gang and distribute its weights:
+
+- **Standard** composes a gang as a LeaderWorkerSet. It has no gang scheduler, so
+  the pods schedule independently.
+- **Dynamo** installs NVIDIA's [Grove](https://github.com/ai-dynamo/grove) and the
+  [KAI Scheduler](https://github.com/NVIDIA/KAI-Scheduler) in place of the
+  LeaderWorkerSet controller, and composes a gang as a Grove `PodCliqueSet` that
+  they gang-schedule all-or-nothing and topology-aware. It also runs a
+  [ModelExpress](https://github.com/ai-dynamo/modelexpress) server that moves
+  weights between replicas over the fabric, so a later replica pulls a model from
+  a peer's GPU rather than reading storage again.
+
+A `ModelDeployment` looks the same on either stack. On `Dynamo` an engine can
+opt into peer-to-peer weight loading with `--load-format modelexpress`. An
+engine that does this will work on `Standard` too, but won't load weights
+peer-to-peer. See
+[model caching]({{< ref "/models/model-cache.md#accelerating-with-modelexpress" >}})
+for more details.
+
+{{< hint "note" >}}
+A multi-node gang on `Dynamo` derives its node rank from Grove's
+`GROVE_PCLQ_POD_INDEX`, because Modelplane doesn't inject `$(MODELPLANE_RANK)`
+there yet. This is a temporary gap, not by design:
+[#418](https://github.com/modelplaneai/modelplane/issues/418) tracks closing it,
+so a gang command reads the same on both stacks.
+[Multi-node deployments]({{< ref "/models/model-deployment.md#multi-node" >}}) show
+the rank a gang computes until then.
+{{< /hint >}}
+
+Composing a full Dynamo graph deployment, for its frontend and request routing,
+is planned.
 
 ## Examples
 

--- a/docs/utils/vale/styles/config/vocabularies/Modelplane/accept.txt
+++ b/docs/utils/vale/styles/config/vocabularies/Modelplane/accept.txt
@@ -525,6 +525,11 @@ GROVE_HEADLESS_SERVICE
 MODELPLANE_LEADER_ADDRESS
 MODELPLANE_RANK
 ModelExpress
+topology-aware
+all-or-nothing
+[Pp]eer-to-peer
+[Gg]ang-schedules?
+routable
 
 agent
 requirement


### PR DESCRIPTION
### Description of your changes

#406 added the Standard and Dynamo serving stacks but documented them only in passing: a scattering of asides that each restated the `spec.stack: Dynamo` opt-in, and nothing on the platform page where you actually register a cluster. This gives the per-cluster choice a home and points the asides at it.

A new Serving stack section on the cluster page explains Standard versus Dynamo and what each installs. The multi-node deployment docs gain a note on the two things that differ under Dynamo: a gang derives its rank from Grove's pod index because `MODELPLANE_RANK` isn't injected there yet (#418), and an engine opts into ModelExpress peer-to-peer loading. The glossary gains an entry, and the how-it-works, architecture, model-cache, and FAQ mentions now link the section instead of re-deriving the opt-in.

It also corrects the FAQ, which claimed Modelplane uses llm-d for multi-node serving. The stacks own multi-node now, a LeaderWorkerSet on Standard or a Grove PodCliqueSet on Dynamo; llm-d is the inference-aware routing layer.

A Dynamo how-to guide is deliberately left out, to follow up once it's validated end to end on real hardware.

Towards #111.

I have:

- [x] Read and followed Modelplane's [contribution process](https://github.com/modelplaneai/modelplane/blob/main/CONTRIBUTING.md).
- [x] Run `nix flake check` (or `./nix.sh flake check`) and made sure it passes.
- [ ] ~Added or updated tests covering any composition function changes.~
- [x] Signed off every commit with `git commit -s`.